### PR TITLE
Missing bracket in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ middleware to to `:nrepl-middleware` under `:repl-options`.
 ```clojure
 :dependencies [[cider/cider-nrepl "0.1.0-SNAPSHOT"]]
 :repl-options {:nrepl-middleware
-                 cider.nrepl.middleware.complete/wrap-complete
-                 cider.nrepl.middleware.info/wrap-info
-                 cider.nrepl.middleware.inspector/wrap-inspect]}
+                 [cider.nrepl.middleware.complete/wrap-complete
+                  cider.nrepl.middleware.info/wrap-info
+                  cider.nrepl.middleware.inspector/wrap-inspect]}
 ```
 
 ## Supplied nREPL middleware


### PR DESCRIPTION
The code in the README cannot be copy and pasted as is. 

(PS I don't mind if you junk this PR and apply the fix manually, not sure what your policy for typos is)
