### PR TITLE
Add stacktrace filtering/navigation middleware.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ middleware to to `:nrepl-middleware` under `:repl-options`.
 :repl-options {:nrepl-middleware
                  [cider.nrepl.middleware.complete/wrap-complete
                   cider.nrepl.middleware.info/wrap-info
-                  cider.nrepl.middleware.inspect/wrap-inspect]}
+                  cider.nrepl.middleware.inspect/wrap-inspect
+                  cider.nrepl.middleware.stacktrace/wrap-stacktrace]}
 ```
 
 ## Supplied nREPL middleware
@@ -32,6 +33,7 @@ Middleware        | Op(s)      | Description
 `wrap-complete`   | `complete` | Simple completion. Supports both Clojure & ClojureScript.
 `wrap-info`       | `info`     | File/line, arglists, docstrings and other metadata for vars.
 `wrap-inspect`    |`inspect-(start/refresh/pop/push/reset)` | Inspect a Clojure expression.
+`wrap-stacktrace` | `stacktrace` | Cause and stacktrace analysis for exceptions.
 
 ## License
 

--- a/src/cider/nrepl/middleware/stacktrace.clj
+++ b/src/cider/nrepl/middleware/stacktrace.clj
@@ -1,0 +1,144 @@
+(ns cider.nrepl.middleware.stacktrace
+  "Cause and stacktrace analysis for exceptions"
+  {:author "Jeff Valk"}
+  (:require [clojure.pprint :as pp]
+            [clojure.repl :as repl]
+            [clojure.string :as str]
+            [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
+            [clojure.tools.nrepl.middleware.pr-values :refer [pr-values]]
+            [clojure.tools.nrepl.middleware.session :refer [session]]
+            [clojure.tools.nrepl.misc :refer [response-for]]
+            [clojure.tools.nrepl.transport :as t])
+  (:import (clojure.lang Compiler$CompilerException)))
+
+;;; ## Stacktraces
+
+;; Java stacktraces don't expose column number.
+(defn stack-frame
+  "Return a map describing the stack frame."
+  [^StackTraceElement frame]
+  {:name   (str (.getClassName frame) "/" (.getMethodName frame))
+   :file   (.getFileName frame)
+   :line   (.getLineNumber frame)
+   :class  (.getClassName frame)
+   :method (.getMethodName frame)})
+
+(defn analyze-fn
+  "Add namespace, fn, and var to the frame map when the source is a Clojure
+  function."
+  [{:keys [file type class] :as frame}]
+  (if (= :clj type)
+    (let [[ns fn & anons] (-> (repl/demunge class) (str/split #"/"))
+          anons (map #(str/replace % #"--\d{4,}" "") anons)]
+      (assoc frame
+        :ns  ns
+        :fn  (str/join "/" (cons fn anons))
+        :var (str ns "/" fn)))
+    frame))
+
+(defn analyze-file
+  "Associate the file type (extension) of the source file to the frame map, and
+  add it as a flag. If the name is `NO_SOURCE_FILE`, type `clj` is assumed."
+  [{:keys [file] :as frame}]
+  (let [type (keyword
+              (cond (nil? file)                "unknown"
+                    (= file "NO_SOURCE_FILE")  "clj"
+                    (neg? (.indexOf file ".")) "unknown"
+                    :else (last (.split file "\\."))))]
+    (-> frame
+        (assoc :type type)
+        (update-in [:flags] (comp set conj) type))))
+
+(defn flag-repl
+  "Flag the frame if its source is a REPL eval."
+  [{:keys [file] :as frame}]
+  (if (and file
+           (or (= file "NO_SOURCE_FILE")
+               (.startsWith file "form-init")))
+    (update-in frame [:flags] (comp set conj) :repl)
+    frame))
+
+(defn flag-tooling
+  "Walk the call stack from bottom to top, flagging frames below the *lowest*
+  call to `clojure.lang.Compiler/eval` as `:tooling` to distinguish compilation
+  and nREPL middleware frames from user code."
+  [frames]
+  (let [eval? #(= (:name %) "clojure.lang.Compiler/eval")
+        flag  #(update-in % [:flags] (comp set conj) :tooling)
+        [tools evals & user] (partition-by eval? (reverse frames))]
+    (reverse (apply concat
+                    (map flag tools)
+                    (map flag evals)
+                    user))))
+
+(defn flag-duplicates
+  "Where a parent and child frame represent substantially the same source
+  location, flag the parent as a duplicate."
+  [frames]
+  (cons (first frames)
+        (map (fn [frame child]
+               (if (or (= (:name frame) (:name child))
+                       (and (= (:file frame) (:file child))
+                            (= (:line frame) (:line child))))
+                 (update-in frame [:flags] (comp set conj) :dup)
+                 frame))
+             (rest frames)
+             frames)))
+
+(defn analyze-stacktrace
+  "Return the stacktrace as a sequence of maps, each describing a stack frame."
+  [e]
+  (-> (map (comp flag-repl analyze-fn analyze-file stack-frame)
+           (.getStackTrace e))
+      (flag-duplicates)
+      (flag-tooling)))
+
+
+;;; ## Causes
+
+(defn analyze-causes
+  "Return the cause chain, beginning with the thrown exception, or, if the
+  thrown exception is a wrapping compiler exception, its immediate cause.
+  If `ex-data` exists for any item, a `:data` key is appended."
+  [e]
+  (loop [e (if (and (instance? Compiler$CompilerException e) (.getCause e))
+             (.getCause e)
+             e)
+         chain []]
+    (if e
+      (recur (.getCause e)
+             (conj chain
+                   (let [m {:class (.getName (class e))
+                            :message (.getMessage e)}]
+                     (if-let [data (ex-data e)]
+                       (assoc m :data (with-out-str (pp/pprint data)))
+                       m))))
+      chain)))
+
+
+;;; ## Middleware
+
+(defn wrap-stacktrace
+  "Middleware that handles stacktrace requests, sending cause and stack frame
+  info for the most recent exception."
+  [handler]
+  (fn [{:keys [op session transport] :as msg}]
+    (if (= "stacktrace" op)
+      (do (if-let [e (@session #'*e)]
+            (do (doseq [cause (analyze-causes e)]
+                  (t/send transport (response-for msg cause)))
+                (doseq [frame (analyze-stacktrace e)]
+                  (t/send transport (response-for msg frame)))
+                (t/send transport (response-for msg :status :done)))
+            (t/send transport (response-for msg :status :no-error))))
+      (handler msg))))
+
+;; nREPL middleware descriptor info
+(set-descriptor!
+ #'wrap-stacktrace
+ {:requires #{#'session}
+  :expects #{#'pr-values}
+  :handles {"stacktrace"
+            {:doc (str "Return messages describing each cause and stack frame "
+                       "of the most recent exception.")
+             :returns {"status" "\"done\", or \"no-error\" if `*e` is nil"}}}})

--- a/src/cider_nrepl/plugin.clj
+++ b/src/cider_nrepl/plugin.clj
@@ -21,4 +21,5 @@
                  (fnil into [])
                  '[cider.nrepl.middleware.complete/wrap-complete
                    cider.nrepl.middleware.info/wrap-info
-                   cider.nrepl.middleware.inspect/wrap-inspect])))
+                   cider.nrepl.middleware.inspect/wrap-inspect
+                   cider.nrepl.middleware.stacktrace/wrap-stacktrace])))

--- a/test/cider/nrepl/middleware/test_stacktrace.clj
+++ b/test/cider/nrepl/middleware/test_stacktrace.clj
@@ -1,0 +1,95 @@
+(ns cider.nrepl.middleware.test-stacktrace
+  (:require [cider.nrepl.middleware.stacktrace :refer :all]
+            [clojure.test :refer :all]))
+
+;; # Utils
+
+(defn causes
+  [form]
+  (analyze-causes
+   (try (eval form)
+        (catch Exception e
+          e))))
+
+(defn stack-frames
+  [form]
+  (analyze-stacktrace
+   (try (eval form)
+        (catch Exception e
+          e))))
+
+
+;; ## Test fixtures
+
+(def form1 '(throw (ex-info "oops" {:x 1})))
+(def form2 '(do (defn oops [] (+ 1 "2"))
+                (oops)))
+
+(def frames1 (stack-frames form1))
+(def frames2 (stack-frames form2))
+(def causes1 (causes form1))
+(def causes2 (causes form2))
+
+
+;; ## Tests
+
+(deftest test-stacktrace-frames
+  (testing "File types"
+    ;; Should be clj and java only.
+    (let [ts1 (group-by :type frames1)
+          ts2 (group-by :type frames2)]
+      (is (= #{:clj :java} (set (keys ts1))))
+      (is (= #{:clj :java} (set (keys ts2))))))
+  (testing "Clojure ns, fn, and var"
+    ;; All Clojure frames should have non-nil :ns :fn and :var attributes.
+    (is (every? #(every? identity ((juxt :ns :fn :var) %))
+                (filter #(= :clj (:type %)) frames1)))
+    (is (every? #(every? identity ((juxt :ns :fn :var) %))
+                (filter #(= :clj (:type %)) frames2))))
+  (testing "Clojure name demunging"
+    ;; Clojure fn names should be free of munging characters.
+    (is (not-any? #(re-find #"[_$]|(--\d+)" (:fn %))
+                  (filter :fn frames1)))
+    (is (not-any? #(re-find #"[_$]|(--\d+)" (:fn %))
+                  (filter :fn frames2)))))
+
+(deftest test-stacktrace-frame-flags
+  (testing "Flags"
+    (testing "for file type"
+      ;; Every frame should have its file type added as a flag.
+      (is (every? #(contains? (:flags %) (:type %)) frames1))
+      (is (every? #(contains? (:flags %) (:type %)) frames2)))
+    (testing "for REPL frames"
+      ;; Frames defined in the test should be flagged as from the REPL.
+      ;; Here, this is only eval call.
+      (is (= 1 (count (filter (comp :repl :flags) frames1))))
+      (is (= 1 (count (filter (comp :repl :flags) frames2)))))
+    (testing "for tooling"
+      ;; Tooling frames are in classes named with 'clojure' or 'nrepl',
+      ;; or are java thread runners.
+      (is (every? #(re-find #"(clojure|nrepl|run)" (:name %))
+                  (filter (comp :tooling :flags) frames1)))
+      (is (every? #(re-find #"(clojure|nrepl|run)" (:name %))
+                  (filter (comp :tooling :flags) frames2))))
+    (testing "for duplicate frames"
+      ;; Index frames. For all frames flagged as :dup, the frame above it in
+      ;; the stack (index i - 1) should be substantially the same source info.
+      (let [ixd1 (zipmap (iterate inc 0) frames1)
+            ixd2 (zipmap (iterate inc 0) frames2)
+            dup? #(or (= (:name %1) (:name %2))
+                      (and (= (:file %1) (:file %2))
+                           (= (:line %1) (:line %2))))]
+        (every? (fn [[i v]] (dup? v (get ixd1 (dec i))))
+                (filter (comp :dup :flags val) ixd1))
+        (every? (fn [[i v]] (dup? v (get ixd2 (dec i))))
+                (filter (comp :dup :flags val) ixd2))))))
+
+(deftest test-exception-causes
+  (testing "Exception unwrapping"
+    ;; The outermost compiler exception just wraps the useful ones.
+    (is (not (instance? clojure.lang.Compiler$CompilerException (first causes1))))
+    (is (not (instance? clojure.lang.Compiler$CompilerException (first causes2)))))
+  (testing "Exception data"
+    ;; If ex-data is present, the cause should have a :data attribute.
+    (is (:data (first causes1)))
+    (is (not (:data (first causes2))))))


### PR DESCRIPTION
This is the nREPL stacktrace middleware that accompanies CIDER pull request [#521](https://github.com/clojure-emacs/cider/pull/521).
