### PR TITLE
Provide classpath operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ middleware to to `:nrepl-middleware` under `:repl-options`.
 ```clojure
 :dependencies [[cider/cider-nrepl "0.1.0-SNAPSHOT"]]
 :repl-options {:nrepl-middleware
-                 [cider.nrepl.middleware.complete/wrap-complete
+                 [cider.nrepl.middleware.classpath/wrap-classpath
+                  cider.nrepl.middleware.complete/wrap-complete
                   cider.nrepl.middleware.info/wrap-info
                   cider.nrepl.middleware.inspect/wrap-inspect
                   cider.nrepl.middleware.stacktrace/wrap-stacktrace]}
@@ -30,6 +31,7 @@ middleware to to `:nrepl-middleware` under `:repl-options`.
 
 Middleware        | Op(s)      | Description
 ------------------|------------|---------------------------------------------------------
+`wrap-classpath`  | `classpath` | Java classpath.
 `wrap-complete`   | `complete` | Simple completion. Supports both Clojure & ClojureScript.
 `wrap-info`       | `info`     | File/line, arglists, docstrings and other metadata for vars.
 `wrap-inspect`    |`inspect-(start/refresh/pop/push/reset)` | Inspect a Clojure expression.

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,8 @@
                  [org.clojure/java.classpath "0.2.0"]
                  [org.clojure/tools.namespace "0.2.3"]]
 
-  :profiles {:dev {:repl-options {:nrepl-middleware [cider.nrepl.middleware.complete/wrap-complete
+  :profiles {:dev {:repl-options {:nrepl-middleware [cider.nrepl.middleware.classpath/wrap-classpath
+                                                     cider.nrepl.middleware.complete/wrap-complete
                                                      cider.nrepl.middleware.info/wrap-info
                                                      cider.nrepl.middleware.inspect/wrap-inspect
                                                      ]}

--- a/src/cider/nrepl/middleware/classpath.clj
+++ b/src/cider/nrepl/middleware/classpath.clj
@@ -1,0 +1,28 @@
+(ns cider.nrepl.middleware.classpath
+  (:require [clojure.java.classpath :as cp]
+            [clojure.tools.nrepl.transport :as transport]
+            [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
+            [clojure.tools.nrepl.misc :refer [response-for]]))
+
+(defn classpath []
+  (map str (cp/classpath)))
+
+(defn classpath-reply
+  [{:keys [transport] :as msg}]
+  (transport/send transport (response-for msg :value (classpath)))
+  (transport/send transport (response-for msg :status :done)))
+
+(defn wrap-classpath
+  "Middleware that provides the java classpath."
+  [handler]
+  (fn [{:keys [op] :as msg}]
+    (if (= "classpath" op)
+      (classpath-reply msg)
+      (handler msg))))
+
+(set-descriptor!
+  #'wrap-classpath
+  {:handles
+   {"classpath"
+    {:doc "Return a list of entries in the java classpath"
+     :returns {"status" "done"}}}})

--- a/src/cider_nrepl/plugin.clj
+++ b/src/cider_nrepl/plugin.clj
@@ -19,7 +19,8 @@
                  [['cider/cider-nrepl version]])
       (update-in [:repl-options :nrepl-middleware]
                  (fnil into [])
-                 '[cider.nrepl.middleware.complete/wrap-complete
+                 '[cider.nrepl.middleware.info/wrap-classpath
+                   cider.nrepl.middleware.complete/wrap-complete
                    cider.nrepl.middleware.info/wrap-info
                    cider.nrepl.middleware.inspect/wrap-inspect
                    cider.nrepl.middleware.stacktrace/wrap-stacktrace])))

--- a/test/cider/nrepl/middleware/test_classpath.clj
+++ b/test/cider/nrepl/middleware/test_classpath.clj
@@ -1,0 +1,9 @@
+(ns cider.nrepl.middleware.test-classpath
+  (:use clojure.test
+        cider.nrepl.middleware.test-transport
+        cider.nrepl.middleware.classpath))
+
+(deftest test-classpath-op
+  (let [transport (test-transport)]
+    (classpath-reply {:transport transport})
+    (is (= (messages transport) [{:value (classpath)} {:status #{:done}}]))))


### PR DESCRIPTION
This fell out of a discussion with @gtrak. It's my most significant remaining eval in [fireplace.vim](/tpope/vim-fireplace), and @gtrak thought it might find use on the Emacs side of the fence as well.
