### PR TITLE
Use test file names compatible with clojure-mode.

### DIFF
--- a/test/cider/nrepl/middleware/classpath_test.clj
+++ b/test/cider/nrepl/middleware/classpath_test.clj
@@ -1,4 +1,4 @@
-(ns cider.nrepl.middleware.test-classpath
+(ns cider.nrepl.middleware.classpath-test
   (:use clojure.test
         cider.nrepl.middleware.test-transport
         cider.nrepl.middleware.classpath))

--- a/test/cider/nrepl/middleware/info_test.clj
+++ b/test/cider/nrepl/middleware/info_test.clj
@@ -1,4 +1,4 @@
-(ns cider.nrepl.middleware.test-info
+(ns cider.nrepl.middleware.info-test
   (:require [clojure.test :refer :all]
             [clojure.java.io :as io]
             [cider.nrepl.middleware.info :as info]))
@@ -18,7 +18,7 @@
          java.net.URL))
   (is (= (class (file "clojure-1.5.1.jar:clojure/core.clj"))
          java.net.URL))
-  (is (= (class (file "test/cider/nrepl/middleware/test_info.clj"))
+  (is (= (class (file "test/cider/nrepl/middleware/info_test.clj"))
          java.io.File))
   (is (relative "clojure/core.clj"))
   (is (nil? (relative "notclojure/core.clj"))))
@@ -39,13 +39,13 @@
   (is (-> (info/info-clj 'cider.nrepl.middleware.info 'clojure.core)
           (dissoc :file)
           (info/format-response)))
-  
+
   (is (info/format-response (info/info-clj 'cider.nrepl.middleware.info 'clojure.core/+)))
   ;; used to crash, sym is parsed as a class name
   (is (nil? (info/format-response (info/info-clj 'cider.nrepl.middleware.info 'notincanter.core))))
   ;; unfound nses should fall through
   (is (nil? (info/format-response (info/info-clj 'cider.nrepl.middleware.nonexistent-namespace 'a-var))))
-)
+  )
 
 (deftest test-response
   (is (= (dissoc (info/format-response (info/info-clj 'cider.nrepl.middleware.info 'assoc)) "file")
@@ -60,4 +60,3 @@
            "line" 177,
            "resource" "clojure/core.clj"
            })))
-

--- a/test/cider/nrepl/middleware/stacktrace_test.clj
+++ b/test/cider/nrepl/middleware/stacktrace_test.clj
@@ -1,4 +1,4 @@
-(ns cider.nrepl.middleware.test-stacktrace
+(ns cider.nrepl.middleware.stacktrace-test
   (:require [cider.nrepl.middleware.stacktrace :refer :all]
             [clojure.test :refer :all]))
 

--- a/test/cider/nrepl/middleware/util/misc_test.clj
+++ b/test/cider/nrepl/middleware/util/misc_test.clj
@@ -1,4 +1,4 @@
-(ns cider.nrepl.middleware.util.test-misc
+(ns cider.nrepl.middleware.util.misc-test
   (:require [clojure.test :refer :all]
             [cider.nrepl.middleware.util.misc :as misc]))
 
@@ -19,4 +19,3 @@
 (deftest test-as-sym
   (is (= nil (misc/as-sym nil)))
   (is (= 'WAT (misc/as-sym "WAT"))))
-


### PR DESCRIPTION
Use the naming convention `clojure-mode` expects so `clojure-jump-between-tests-and-code` works and `clojure-test-run-tests` can be run from the namespace/file being tested.
