### PR TITLE
Don't discard wrapping CompilerException. Fixes CIDER #541.

### DIFF
--- a/src/cider/nrepl/middleware/stacktrace.clj
+++ b/src/cider/nrepl/middleware/stacktrace.clj
@@ -101,19 +101,14 @@
   thrown exception is a wrapping compiler exception, its immediate cause.
   If `ex-data` exists for any item, a `:data` key is appended."
   [e]
-  (loop [e (if (and (instance? Compiler$CompilerException e) (.getCause e))
-             (.getCause e)
-             e)
-         chain []]
-    (if e
-      (recur (.getCause e)
-             (conj chain
-                   (let [m {:class (.getName (class e))
-                            :message (.getMessage e)}]
-                     (if-let [data (ex-data e)]
-                       (assoc m :data (with-out-str (pp/pprint data)))
-                       m))))
-      chain)))
+  (->> e
+       (iterate #(.getCause %))
+       (take-while identity)
+       (map #(let [m {:class (.getName (class %))
+                      :message (.getMessage %)}]
+               (if-let [data (ex-data %)]
+                 (assoc m :data (with-out-str (pp/pprint data)))
+                 m)))))
 
 
 ;;; ## Middleware

--- a/test/cider/nrepl/middleware/stacktrace_test.clj
+++ b/test/cider/nrepl/middleware/stacktrace_test.clj
@@ -21,7 +21,7 @@
 
 ;; ## Test fixtures
 
-(def form1 '(throw (ex-info "oops" {:x 1})))
+(def form1 '(throw (ex-info "oops" {:x 1} (ex-info "cause" {:y 2}))))
 (def form2 '(do (defn oops [] (+ 1 "2"))
                 (oops)))
 
@@ -85,10 +85,9 @@
                 (filter (comp :dup :flags val) ixd2))))))
 
 (deftest test-exception-causes
-  (testing "Exception unwrapping"
-    ;; The outermost compiler exception just wraps the useful ones.
-    (is (not (instance? clojure.lang.Compiler$CompilerException (first causes1))))
-    (is (not (instance? clojure.lang.Compiler$CompilerException (first causes2)))))
+  (testing "Exception cause unrolling"
+    (is (= 2 (count causes1)))
+    (is (= 1 (count causes2))))
   (testing "Exception data"
     ;; If ex-data is present, the cause should have a :data attribute.
     (is (:data (first causes1)))


### PR DESCRIPTION
Fixes CIDER [#541](https://github.com/clojure-emacs/cider/issues/541)
