### PR TITLE
Remove explicit ASM dependency in favor of bundled clojure.asm.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: clojure
-script: lein2 with-profile dev test
+script:
+  - lein2 with-profile dev test
+  - lein2 with-profile dev,1.5 test
+  - lein2 with-profile dev,1.6 test
+  - lein2 with-profile dev,1.7 test
 jdk:
   - openjdk6
   - openjdk7

--- a/project.clj
+++ b/project.clj
@@ -6,14 +6,15 @@
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [compliment "0.0.3"]
                  [cljs-tooling "0.1.2"]
-                 [org.ow2.asm/asm "5.0.2"]
-                 [org.ow2.asm/asm-commons "5.0.2"]
                  [org.tcrawley/dynapath "0.2.3"]
                  [org.clojure/tools.nrepl "0.2.3"]
                  [org.clojure/java.classpath "0.2.0"]
                  [org.clojure/tools.namespace "0.2.3"]]
 
-  :profiles {:dev {:repl-options {:nrepl-middleware [cider.nrepl.middleware.classpath/wrap-classpath
+  :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
+             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0-master-SNAPSHOT"]]}
+             :dev {:repl-options {:nrepl-middleware [cider.nrepl.middleware.classpath/wrap-classpath
                                                      cider.nrepl.middleware.complete/wrap-complete
                                                      cider.nrepl.middleware.info/wrap-info
                                                      cider.nrepl.middleware.inspect/wrap-inspect


### PR DESCRIPTION
Fixes #44. As behavior is now different for different Clojure versions, I added test profiles.
