### PR TITLE
Add javadoc to Java class/method info.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,9 @@
                    :repositories [["snapshots"
                                    "http://oss.sonatype.org/content/repositories/snapshots"]]
                    :dependencies [[org.clojure/clojure "1.5.2-SNAPSHOT"
-                                   :classifier "sources"]]
+                                   :classifier "sources"]
+                                  [org.clojure/clojure "1.5.1"
+                                   :classifier "javadoc"]]
 
                    ;; Wait til 1.5 comes out for a fix to cljs dep
                    ;; :plugins [[com.cemerick/austin "0.1.5"]]

--- a/src/cider/nrepl/middleware/util/misc.clj
+++ b/src/cider/nrepl/middleware/util/misc.clj
@@ -1,4 +1,9 @@
-(ns cider.nrepl.middleware.util.misc)
+(ns cider.nrepl.middleware.util.misc
+  (:require [clojure.string :as str]))
+
+(def java-api-version
+  (try (-> (System/getProperty "java.version") (str/split #"\.") second)
+       (catch Exception _ "7")))
 
 (defn as-sym
   [x]
@@ -38,4 +43,3 @@
 
 ;; handles vectors
 (prefer-method transform-value clojure.lang.Sequential clojure.lang.Associative)
-

--- a/test/cider/nrepl/middleware/info_test.clj
+++ b/test/cider/nrepl/middleware/info_test.clj
@@ -34,6 +34,11 @@
 
   (is (info/info-java "clojure.lang.Atom" "swap"))
 
+  (is (re-find #"^(http|file|jar|zip):" ; resolved either locally or online
+               (-> (info/info-java "java.lang.Object" "toString")
+                   (info/format-response)
+                   (get "javadoc"))))
+
   (is (info/format-response (info/info-clj 'cider.nrepl.middleware.info 'clojure.core)))
 
   (is (-> (info/info-clj 'cider.nrepl.middleware.info 'clojure.core)

--- a/test/cider/nrepl/middleware/util/java_test.clj
+++ b/test/cider/nrepl/middleware/util/java_test.clj
@@ -64,6 +64,40 @@
       (testing "that is static"
         (is m6)))))
 
+(deftest test-javadoc-urls
+  (testing "Javadoc URL"
+    (testing "for a class"
+      (is (= (:javadoc (class-info "java.lang.String"))
+             "java/lang/String.html")))
+
+    (testing "for a nested class"
+      (is (= (:javadoc (class-info "java.util.AbstractMap$SimpleEntry"))
+             "java/util/AbstractMap.SimpleEntry.html")))
+
+    (testing "for an interface"
+      (is (= (:javadoc (class-info "java.io.Closeable"))
+             "java/io/Closeable.html")))
+
+    (testing "for a method"
+      (testing "with no args"
+        (is (= (:javadoc (method-info "java.util.Random" "nextInt"))
+               "java/util/Random.html#nextInt()")))
+      (testing "with primitive args"
+        (is (= (:javadoc (method-info "java.util.Random" "setSeed"))
+               "java/util/Random.html#setSeed(long)")))
+      (testing "with object args"
+        (is (= (:javadoc (method-info "java.lang.String" "contains"))
+               "java/lang/String.html#contains(java.lang.CharSequence)")))
+      (testing "with array args"
+        (is (= (:javadoc (method-info "java.lang.Thread" "enumerate"))
+               "java/lang/Thread.html#enumerate(java.lang.Thread[])")))
+      (testing "with multiple args"
+        (is (= (:javadoc (method-info "java.util.ArrayList" "subList"))
+               "java/util/ArrayList.html#subList(int, int)")))
+      (testing "with generic type erasure"
+        (is (= (:javadoc (method-info "java.util.Hashtable" "putAll"))
+               "java/util/Hashtable.html#putAll(java.util.Map)"))))))
+
 (deftest test-class-resolution
   (let [ns (ns-name *ns*)]
     (testing "Class resolution"


### PR DESCRIPTION
This was a pretty straightforward addition. We nearly get Javadoc for free using the Java class/method info support. And `cider-javadoc` now works just like `cider-var-info` for Java symbols, so you can browse directly to class members.

It looks for docs on the classpath first, and then uses docs.oracle.com for core API classes.

Counterpart PR for `cider` is [#545](https://github.com/clojure-emacs/cider/pull/545).
