### PR TITLE
Add context and doc op to complete middleware

### DIFF
--- a/src/cider/nrepl/middleware/complete.clj
+++ b/src/cider/nrepl/middleware/complete.clj
@@ -16,9 +16,20 @@
       (cljs-complete/completions cljs-env prefix ns)
       (jvm-complete/completions prefix ns context))))
 
+(defn completion-doc
+  [{:keys [symbol ns] :as msg}]
+  (when-not (cljs/grab-cljs-env msg)
+    (jvm-complete/documentation (str symbol) (u/as-sym ns))))
+
 (defn complete-reply
   [{:keys [transport] :as msg}]
   (let [results (complete msg)]
+    (transport/send transport (response-for msg :value results))
+    (transport/send transport (response-for msg :status :done))))
+
+(defn doc-reply
+  [{:keys [transport] :as msg}]
+  (let [results (completion-doc msg)]
     (transport/send transport (response-for msg :value results))
     (transport/send transport (response-for msg :status :done))))
 
@@ -26,9 +37,10 @@
   "Middleware that looks up possible functions for the given (partial) symbol."
   [handler]
   (fn [{:keys [op] :as msg}]
-    (if (= "complete" op)
-      (complete-reply msg)
-      (handler msg))))
+    (cond
+     (= "complete" op) (complete-reply msg)
+     (= "complete-doc" op) (doc-reply msg)
+     :else (handler msg))))
 
 (set-descriptor!
  #'wrap-complete


### PR DESCRIPTION
I have modified Compliment and ac-cider-compliment to work exclusively over middleware (no direct calls) and removed map-literal code from the client. The suggested changes to cider-nrepl add support for passing context to Compliment, and add another operation for retrieving popup-docs.

After you accept this patch and maybe after running on snapshots for a while, I'll be ready to cut `0.1.0`.
