### PR TITLE
Move Java info support from ASM to source parsing.

### DIFF
--- a/src/cider/nrepl/middleware/info.clj
+++ b/src/cider/nrepl/middleware/info.clj
@@ -81,7 +81,7 @@
    (resolve-special sym) (resolve-special sym)
    ;; it's a var
    (var-meta (resolve-var ns sym)) (var-meta (resolve-var ns sym))
-   ;; it's a Java class/method symbol...or nil
+   ;; it's a Java class/member symbol...or nil
    :else (java/resolve-symbol ns sym)))
 
 (defn info-cljs
@@ -91,7 +91,7 @@
 
 (defn info-java
   [class member]
-  (apply java/method-info (map str [class member])))
+  (java/member-info class member))
 
 (defn info
   [{:keys [ns symbol class member] :as msg}]

--- a/src/cider/nrepl/middleware/util/java.clj
+++ b/src/cider/nrepl/middleware/util/java.clj
@@ -1,20 +1,31 @@
 (ns cider.nrepl.middleware.util.java
-  "Source info for Java classes and members"
+  "Info for Java classes and members"
   {:author "Jeff Valk"}
-  (:require [clojure.java.io :as io]
+  (:require [cider.nrepl.middleware.util.misc :as util]
+            [clojure.java.io :as io]
+            [clojure.reflect :as r]
             [clojure.string :as str]
             [dynapath.util :as dp])
-  (:import (clojure.asm ClassReader ClassVisitor MethodVisitor Opcodes)
-           (clojure.asm.commons Method)))
+  (:import (clojure.lang IPersistentMap)
+           (clojure.reflect Constructor Field Method)))
 
-;;; ## Source Files
+;;; ## Java Class/Member Info
+;; Getting class and member info (i.e. type hierarchy, method names,
+;; argument/return types, etc) is straightforward using reflection; this
+;; provides the basis of Java metadata support. When the source is available
+;; (and `tools.jar` is too), we supplement reflection with source analysis to
+;; get file, line, and column info, as well as docstrings and argument names.
+
+;;; ## Classpath
 ;; Java source files are resolved from the classpath. For library dependencies,
 ;; this simply entails having the corresponding source artifacts in the
 ;; project's dev dependencies. The core Java API classes are the exception to
 ;; this, since these are external to lein/maven dependency management. For
 ;; these, we look at the JDK itself and add the source classpath entry manually.
+;; Parsing these also requires having `tools.jar` on the classpath, which we'll
+;; have to add as well.
 
-;; This is used only to add text resources to the classpath. Issues of class
+;; This is used only to add JDK resources to the classpath. Issues of class
 ;; dependency are not in play.
 (defn add-classpath!
   "Similar to the deprecated `clojure.core/add-classpath`, adds the URL to the
@@ -28,172 +39,252 @@
     (when (dp/add-classpath-url classloader url)
       url)))
 
+(def jdk-root
+  "The JDK root directory (parent of the `java.home` JRE directory)"
+  (-> (io/file (System/getProperty "java.home"))
+      (.getParentFile)))
+
 (def jdk-sources
   "The JDK sources path. If available, this is added to the classpath. By
-  convention, this is the file `src.zip` in the root of the JDK directory
-  (parent of the `java.home` JRE directory)."
-  (let [zip (-> (io/file (System/getProperty "java.home"))
-                (.getParentFile)
-                (io/file "src.zip"))]
+  convention, this is the file `src.zip` in the root of the JDK directory."
+  (let [zip (io/file jdk-root "src.zip")]
     (when (.canRead zip)
       (add-classpath! (io/as-url zip)))))
 
-(defn java-source
-  "Return the relative .java source path for the top-level class name."
-  [class]
-  (-> (str/replace class #"\$.*" "")
-      (str/replace "." "/")
-      (str ".java")))
-
-(defn java-doc
-  "Return the relative .html javadoc path for the class name."
-  [class]
-  (-> (str/replace class "." "/")
-      (str/replace "$" ".")
-      (str ".html")))
+(def jdk-tools
+  "The JDK `tools.jar` path. If available, this is added to the classpath."
+  (let [jar (io/file jdk-root "lib" "tools.jar")]
+    (when (.canRead jar)
+      (add-classpath! (io/as-url jar)))))
 
 
-;;; ## Class/Method Info
-
-;; Getting class member info (i.e. method names, argument/return types, etc) is
-;; straightforward using reflection...but this leaves us without source
-;; location. For line numbers, we either have to parse bytecode, or the .java
-;; source itself. For present purposes, we'll take the former approach.
-
-;; N.b. Java class LineNumberTables map source lines to bytecode instructions.
-;; This means that the line numbers returned for methods are generally the first
-;; executable line of the method, rather than its declaration. (Constructors are
-;; an exception to this.)
-
-;; ASM Workaround: Clojure <=1.5 bundles ASM 3.3; Clojure 1.6 upgraded to ASM
-;; 4.1, which had breaking API changes. Declaring our own ASM dependency causes
-;; headaches (see issue #44), so we'll work around the API changes.
-(def asm
-  "The ASM API version"
-  (try (import (clojure.asm.commons EmptyVisitor)) 3
-       (catch Exception _ 4)))
-
-;; In the ASM4 API, visitors are abstract classes with stub methods whose
-;; constructrors require the API version as an argument. In ASM3, visitor were
-;; interfaces, and stubs were provided by the `EmptyVisitor` class, which has
-;; only a nullary constructor.
-(defmacro proxy-asm
-  "Like `proxy`, but provides a shim to support both ASM3 and ASM4 visitors."
-  [supers args & fs]
-  (let [[supers args] (if (< asm 4)
-                        [`[EmptyVisitor] []]
-                        [supers `[Opcodes/ASM4]])]
-    `(proxy ~supers ~args ~@fs)))
-
-(defn class-info
-  "For the named class, return Java source and member info, including line
-  numbers. Methods are indexed first by name, and then by argument types to
-  list all overloads. Parent (super) class info is appended recursively."
-  [class]
-  (let [methods (atom {})
-        parent  (atom nil)
-        typesym #(-> % .getClassName symbol)
-        visitor (proxy-asm [ClassVisitor] []
-                  (visit [version access name signature super interfaces]
-                    (when super
-                      (let [super (str/replace super "/" ".")]
-                        (reset! parent (class-info super)))))
-                  (visitMethod [access name desc signature exceptions]
-                    (let [m (Method. name desc)
-                          ret (typesym (.getReturnType m))
-                          args (mapv typesym (.getArgumentTypes m))]
-                      (proxy-asm [MethodVisitor] []
-                        (visitLineNumber [line label]
-                          (when-not (get-in @methods [name args])
-                            (swap! methods assoc-in [name args]
-                                   {:ret ret :args args :line line})))))))]
-    (try (-> (ClassReader. class)
-             (.accept visitor 0))
-         {:class class
-          :super @parent
-          :methods @methods
-          :file (java-source class)
-          :javadoc (java-doc class)}
-         (catch Exception _))))
-
+;;; ## Javadoc URLs
+;; Relative Javadoc URLs can be constructed from class/member signatures.
+;;
 ;; N.b. Where a method's bytecode signature differs from its declared signature
 ;; (other than collection generics), the javadoc method URL can't be inferred as
 ;; done below. (Specifically, this applies to varargs and non-collection
-;; generics, e.g. `java/util/Arrays.html#asList(T...)`.) Since the method is
+;; generics, e.g. `java/util/Arrays.html#asList(T...)`.) Since the member is
 ;; just a URL fragment, the javadoc link will simply navigate to the parent
 ;; class in these cases.
-(defn method-info
-  "Return Java member info, including argument (type) lists, javadoc, and source
-  file/line. If the member is an overloaded method, line number and javadoc
-  signature are that of the first overload. If the method's implementation is in
-  a superclass, source file/line and javadoc are that of the implemention."
-  [class method]
-  (let [c (->> (class-info class)
-               (iterate :super)
-               (take-while identity)
-               (filter #(get-in % [:methods method]))
-               (first))]
-    (when-let [m (get-in c [:methods method])]
-      (let [m* (first (sort-by :line (vals m)))]
-        (-> (dissoc c :methods :super)
-            (assoc :class class
-                   :method method
-                   :line (:line m*)
-                   :arglists (keys m)
-                   :javadoc (format "%s#%s(%s)" (:javadoc c) method
-                                    (str/join ", " (:args m*)))
-                   :doc nil))))))
+(defn javadoc-url
+  "Return the relative `.html` javadoc path and member fragment."
+  ([class]
+     (-> (str/replace (str class) "." "/")
+         (str/replace "$" ".")
+         (str ".html")))
+  ([class member argtypes]
+     (str (javadoc-url class) "#" member
+          (when argtypes
+            (str "(" (str/join ", " argtypes) ")")))))
 
-(defn constructor-info
-  "Return contructor method info for the named class."
+
+;;; ## Class Metadata Assembly
+;; We construct metadata at the class level, first using `reflect-info` to
+;; transform the metadata returned by `clojure.reflect/reflect`. This is then
+;; merged with a source analysis pass (when available) from `source-info`. The
+;; nested map structure and keys returned by these two functions is identical
+;; for the same class. Class members are indexed first by name, then argument
+;; types.
+
+(defn typesym
+  [o]
+  (when o (symbol (r/typename o))))
+
+(defprotocol Reflected
+  (reflect-info [o]))
+
+(extend-protocol Reflected
+  Constructor
+  (reflect-info [c]
+    {:argtypes (mapv typesym (:parameter-types c))
+     :throws (map typesym (:exception-types c))})
+
+  Method
+  (reflect-info [m]
+    {:argtypes (mapv typesym (:parameter-types m))
+     :throws (map typesym (:exception-types m))
+     :returns (typesym (:return-type m))})
+
+  Field
+  (reflect-info [f]
+    {:type (typesym (:type f))})
+
+  IPersistentMap ; => Class
+  (reflect-info [c]
+    {:name (:name c)
+     :modifiers (:flags c)
+     :members (->> (:members c)
+                   ;; Merge type-specific attributes with common ones.
+                   (map (fn [m]
+                          (merge {:name (:name m)
+                                  :modifiers (:flags m)}
+                                 (reflect-info m))))
+                   ;; Index by name, argtypes. Args for fields are nil.
+                   (group-by :name)
+                   (reduce (fn [ret [n ms]]
+                             (assoc ret n (zipmap (map :argtypes ms) ms)))
+                           {}))}))
+
+(def source-info
+  "When `tools.jar` is available, return class info from its parsed source;
+  otherwise return nil."
+  (if jdk-tools
+    (do (require '[cider.nrepl.middleware.util.java.parser :as src])
+        (resolve 'src/source-info))
+    (constantly nil)))
+
+(defn class-info*
+  "For the class symbol, return Java class and member info. Members are indexed
+  first by name, and then by argument types to list all overloads."
   [class]
-  (method-info class "<init>"))
+  (when-let [c (try (Class/forName (str class))
+                    (catch Exception _))]
+    (util/deep-merge (reflect-info (r/reflect c))
+                     (source-info class)
+                     {:name       (-> c .getSimpleName symbol)
+                      :class      (-> c .getName symbol)
+                      :package    (-> c .getPackage .getName symbol)
+                      :super      (-> c .getSuperclass typesym)
+                      :interfaces (map typesym (.getInterfaces c))
+                      :javadoc    (javadoc-url class)})))
 
 
-;;; ## Class/Method Resolution
+;;; ## Class Metadata Caching
+;; When it won't change, cache the class info. Otherwise when we analyze
+;; hundreds or more classes at once (as with a naive symbol resolution call),
+;; duplicated reflection and source parsing becomes a wasteful performance hit.
+;;
+;; To support mixed Clojure/Java projects where `.java` files are being updated
+;; and recompiled, we cache classes for which the Java source is in a jar/zip or
+;; is not present, but don't cache when the `.java` file is on the classpath.
+
+(def cache (atom {}))
+(defn cache?
+  "Whether to cache the class info; this will be true if the source file is
+  effectively immutable, and false otherwise. Specifically, this returns true if
+  no source file is available, or if the source file is in a jar/zip archive."
+  [info]
+  (let [path (:file info)
+        src  (when path (io/resource path))]
+    (or (not src)
+        (re-find #"\.(jar|zip)!" (str src)))))
+
+(defn class-info
+  "For the class symbol, return (possibly cached) Java class and member info.
+  Members are indexed first by name, and then by argument types to list all
+  overloads."
+  [class]
+  (or (@cache class)
+      (let [info (class-info* class)]
+        (when (cache? info)
+          (swap! cache assoc class info))
+        info)))
+
+
+;;; ## Class/Member Info
+;; These functions filter the class info assembled above to respond to a more
+;; specific query: type information for a class name, and member information for
+;; a class/member combination.
+
+(defn type-info
+  "For the class or interface symbol, return Java type info. If the type has
+  defined contructors, the line and column returned will be for the first of
+  these for more convenient `jump` navigation."
+  [class]
+  (let [info (class-info class)
+        ctor (->> (get-in info [:members class])
+                  (vals)
+                  (sort-by :line)
+                  (filter :line)
+                  (first))]
+    (merge (dissoc info :members)
+           (select-keys ctor [:line :column]))))
+
+(defn member-info
+  "For the class and member symbols, return Java member info. If the member is
+  overloaded, line number and javadoc signature are that of the first overload.
+  If the member's definition is in a superclass, info returned will be for the
+  implemention. If the member is an instance member, `this` is prepended to its
+  arglists."
+  [class member]
+  (let [c (->> (class-info class)
+               (iterate (comp class-info :super))
+               (take-while identity)
+               (filter #(get-in % [:members member]))
+               (first))]
+    (when-let [m (get-in c [:members member])]
+      (let [m* (first (sort-by :line (vals m)))
+            static? (or (:static (:modifiers m*)) (= class member))
+            +this   (comp vec (partial cons 'this))]
+        (-> (dissoc m* :name :argnames)
+            (assoc :class class
+                   :member member
+                   :file (:file c)
+                   :arglists (map #((if static? identity +this)
+                                    (or (:argnames %) (:argtypes %)))
+                                  (vals m))
+                   :javadoc (javadoc-url class member
+                                         (:argtypes m*))))))))
+
+
+;;; ## Class/Member Resolution
 ;; A namespace provides a search context for resolving a symbol to a Java class
 ;; or member. Classes, constructors, and static members can be resolved
-;; unambiguously. With instance methods, more than one imported class may have
+;; unambiguously. With instance members, more than one imported class may have
 ;; a member that matches the searched symbol. In such cases, the result will be
-;; a list of resolved candidate methods. (Note that this list could be narrowed
+;; a list of resolved candidate members. (Note that this list could be narrowed
 ;; by considering arity, and narrowed further *if* we could consider argument
 ;; types...)
 
 (defn resolve-class
-  "Given a namespace name and class, search the imported classes and return
-  class info."
+  "Given namespace and class symbols, search the imported classes and return
+  class info. If not found, search all classes on the classpath (requires a
+  qualified name)."
   [ns sym]
-  (when-let [ns (find-ns (symbol ns))]
-    (let [c (try (ns-resolve ns (symbol sym))
+  (when-let [ns (find-ns ns)]
+    (let [c (try (ns-resolve ns sym)
                  (catch Exception _))]
-      (when (class? c)
-        (class-info (.getName c))))))
+      (if (class? c)
+        (class-info (-> c .getName symbol))
+        (class-info sym)))))
 
-(defn resolve-method
-  "Given a namespace name and method, search the imported classes and return
-  a list of each matching method's info."
+(defn resolve-member
+  "Given namespace and member symbols, search the imported classes and return
+  a list of each matching member's info."
   [ns sym]
-  (when-let [ns (find-ns (symbol ns))]
+  (when-let [ns (find-ns ns)]
     (->> (vals (ns-imports ns))
-         (map #(method-info (.getName %) (str sym)))
+         (map #(member-info (-> % .getName symbol) sym))
          (filter identity)
          (distinct))))
 
 (defn resolve-symbol
-  "Given a namespace name and a class or method, resolve the class/method from
-  the imported classes. For a class symbol, constructor info is returned. Class,
-  constructor, and static calls are resolved unambiguously. Instance methods are
-  resolved unambiguously if defined by only one imported class. If multiple
-  imported classes have a method by that name, a map of class names to method
-  info is returned as `:candidates`."
+  "Given a namespace and a class or member symbol, resolve the class/member.
+  Class symbols, constructors, and static calls are resolved to the class
+  unambiguously. Instance members are resolved unambiguously if defined by only
+  one imported class. If multiple imported classes have a member by that name, a
+  map of class names to member info is returned as `:candidates`."
   [ns sym]
-  (let [sym (str/replace sym #"^\.|\.$" "") ; strip leading/trailing dot
-        [class static-member] (str/split sym #"/" 2)]
+  {:pre [(every? symbol? [ns sym])]}
+  (let [name (-> (str sym)
+                 (str/replace #"^\.|\.$" "")) ; strip leading/trailing dot
+        sym* (symbol name)
+        [class static-member] (->> (str/split name #"/" 2)
+                                   (map #(when % (symbol %))))]
     (if-let [c (resolve-class ns class)]
       (if static-member
-        (method-info (:class c) static-member)
-        (constructor-info (:class c)))
-      (when-let [ms (seq (resolve-method ns sym))]
+        (member-info (:class c) static-member)      ; SomeClass/methodCall
+        (type-info (:class c)))                     ; SomeClass
+      (when-let [ms (seq (resolve-member ns sym*))] ; methodCall
         (if (= 1 (count ms))
           (first ms)
           {:candidates (zipmap (map :class ms) ms)})))))
+
+
+;;; ## Initialization
+;; On startup, cache info for the most commonly referenced classes.
+(future
+  (doseq [class (->> (ns-imports 'clojure.core)
+                     (map #(-> % val .getName symbol)))]
+    (class-info class)))

--- a/src/cider/nrepl/middleware/util/java/parser.clj
+++ b/src/cider/nrepl/middleware/util/java/parser.clj
@@ -1,0 +1,253 @@
+(ns cider.nrepl.middleware.util.java.parser
+  "Source and docstring info for Java classes and members"
+  {:author "Jeff Valk"}
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str])
+  (:import (com.sun.javadoc ClassDoc ConstructorDoc FieldDoc MethodDoc)
+           (com.sun.tools.javac.tree JCTree)
+           (com.sun.tools.javac.util Context List Options)
+           (com.sun.tools.javadoc DocEnv JavadocEnter JavadocTool
+                                  Messager ModifierFilter RootDocImpl)
+           (java.io StringReader)
+           (java.net URI)
+           (javax.swing.text.html HTMLEditorKit$ParserCallback HTML$Tag)
+           (javax.swing.text.html.parser ParserDelegator)
+           (javax.tools JavaFileObject$Kind SimpleJavaFileObject)))
+
+;;; ## Java Source Analysis
+;; Any metadata not available via reflection can be had from the source code; we
+;; just need to parse it. In the case of docstrings, we actually need to parse
+;; it twice -- first from Java source, and then from Javadoc HTML.
+
+;;; ## Java Parsing
+;; The Java Compiler API provides in-process access to the Javadoc compiler.
+;; Unlike the standard Java compiler which it extends, the Javadoc compiler
+;; preserves docstrings (obviously), as well as source position and argument
+;; names in its parse tree -- pieces we're after to augment reflection info.
+;; The net effect is as advertised, but the API has some rough edges:
+;;
+;; 1. The default `JavadocTool` entry point needlessly expects that all sources
+;; will be `.java` file paths. To examine sources inside `.jar` files too, we
+;; need to roll our own, which is mostly a matter of environment setup.
+;;
+;; 2. This setup requires manipulating a `DocEnv` instance; however prior to
+;; JDK8, a required field in this class is declared with default (package) level
+;; access, and no accessor methods. In JDK8, this field's visibility has been
+;; [promoted][1] precisely for this sort of tool usage; however to support
+;; pre-JDK8 use, we have to reflect into the field in question to set it.
+;;
+;; 3. By default, whenever the compiler touches an internal Java API, it emits
+;; warnings that can't be suppressed. To work around this behavior, we link
+;; against the symbol file `lib/ct.sym` instead of `rt.jar` by setting the
+;; option `ignore.symbol.file`. [This][2] is how `javac` compiles `rt.jar`
+;; itself.
+;;
+;; [1]: http://hg.openjdk.java.net/jdk8/tl/langtools/rev/b0909f992710
+;; [2]: http://stackoverflow.com/questions/4065401/using-internal-sun-classes-with-javac
+
+(defn set-field!
+  [obj field val]
+  (let [f (.getDeclaredField (class obj) field)]
+    (.setAccessible f true)
+    (.set f obj val)))
+
+(defn parse-java
+  "Load and parse the resource path, returning a `RootDoc` object."
+  [path]
+  (when-let [res (io/resource path)]
+    (let [access   (ModifierFilter. ModifierFilter/ALL_ACCESS)
+          context  (doto (Context.) (Messager/preRegister "cider-nrepl-javadoc"))
+          options  (doto (Options/instance context) (.put "ignore.symbol.file" "y"))
+          compiler (JavadocTool/make0 context)
+          enter    (JavadocEnter/instance0 context)
+          docenv   (doto (DocEnv/instance context)
+                     (.setLocale "en")
+                     (.setEncoding "utf-8")
+                     (.setSilent true)
+                     (set-field! "showAccess" access))
+          source   (proxy [SimpleJavaFileObject]
+                       [(URI. path) JavaFileObject$Kind/SOURCE]
+                     (getCharContent [_] (slurp res)))
+          tree     (.parse compiler source)
+          classes  (->> (.defs tree)
+                        (filter #(= (.getTag %) JCTree/CLASSDEF))
+                        (into-array)
+                        (List/from))]
+      (.main enter (List/of tree))
+      (RootDocImpl. docenv classes (List/nil) (List/nil)))))
+
+
+;;; ## Docstring Parsing
+;; Unlike source metadata (line, position, etc) that's available directly from
+;; the compiler parse tree, docstrings are "some assembly required." Javadoc
+;; comments use both `@tags` and HTML <tags> for semantics and formatting. The
+;; latter could be passed through intact if our presentation layer could read
+;; it, but we want a pure text representation, so we'll parse html to markdown.
+;; This way it can either be rendered or displayed as text.
+
+;; Use GFM extensions for multiline code blocks and tables.
+(def markdown
+  "Syntax map from html tag to a tuple of tag type key, start, and end chars"
+  (let [chars {:p     ["\n\n"]     :code  ["`" "`"]
+               :br    ["\n"]       :code* ["\n\n```\n" "```\n\n"]
+               :em    ["*" "*"]    :table ["\n|--" "\n|--"]
+               :str   ["**" "**"]  :thead ["" "|--\n"]
+               :list  ["\n"]       :tr    ["\n" "|"]
+               :li    ["- "]       :td    ["|"]
+               :dd    [": "]       :th    ["|"]}
+        tags  {HTML$Tag/P  :p           HTML$Tag/TT    :code
+               HTML$Tag/BR :br          HTML$Tag/CODE  :code
+               HTML$Tag/I  :em          HTML$Tag/VAR   :code
+               HTML$Tag/EM :em          HTML$Tag/KBD   :code
+               HTML$Tag/B  :str         HTML$Tag/PRE   :code*
+               HTML$Tag/STRONG :str     HTML$Tag/BLOCKQUOTE :code*
+               HTML$Tag/UL :list        HTML$Tag/TABLE :table
+               HTML$Tag/OL :list        HTML$Tag/TR    :tr
+               HTML$Tag/DL :list        HTML$Tag/TD    :td
+               HTML$Tag/LI :li          HTML$Tag/TH    :th
+               HTML$Tag/DT :li
+               HTML$Tag/DD :dd}]
+    (-> (reduce (fn [tags [tag k]]
+                  (assoc tags tag (cons k (chars k))))
+                {} tags)
+        (with-meta chars))))
+
+;; We parse html and emit text in a single pass -- there's no need to build a
+;; tree. The syntax map defines most of the output format, but a few stateful
+;; rules are applied:
+;;
+;; 1. List items are indented to their nested depth.
+;; 2. Nested elements with the same tag type key are coalesced (`<pre>` inside
+;;    of `<blockquote>` is common, for instance).
+;; 3. A border row is inserted between `<th>` and `<td>` table rows. Since
+;;    `<thead>` and `<tbody>` are optional, we look for the th/td transition.
+(defn parse-html
+  "Parse html to markdown text."
+  [html]
+  (let [sb (StringBuilder.)
+        sr (StringReader. html)
+        parser (ParserDelegator.)
+        stack (atom nil)
+        flags (atom #{})
+        handler (proxy [HTMLEditorKit$ParserCallback] []
+                  (handleText [chars _]
+                    (.append sb (String. chars)))
+
+                  (handleStartTag [tag _ _]
+                    (let [[k start] (markdown tag)]
+                      (when (and k (not= k (peek @stack)))
+                        (swap! stack conj k)
+
+                        ;; Indent list items at the current depth.
+                        (when (#{:li} k)
+                          (let [depth (count (filter #{:list} @stack))]
+                            (.append sb "\n")
+                            (dotimes [_ (dec depth)]
+                              (.append sb "  "))))
+
+                        ;; Keep th/td state; emit border between th and td rows.
+                        (when (#{:th} k) (swap! flags conj :th))
+                        (when (and (#{:td} k) (@flags :th))
+                          (.append sb (-> markdown meta :thead last)))
+
+                        (when start (.append sb start)))))
+
+                  (handleEndTag [tag _]
+                    (let [[k _ end] (markdown tag)]
+                      (when (and k (= k (peek @stack)))
+                        (swap! stack pop)
+                        (when (#{:table :td} k) (swap! flags disj :th))
+                        (when end (.append sb end))))))]
+
+    (.parse parser sr handler false)
+    (-> (str sb)
+        (str/replace #"\n{3,}" "\n\n") ; normalize whitespace
+        (str/replace #" +```" "```"))))
+
+;; Note that @link and @linkplain are also of 'kind' @see.
+(defn docstring
+  "Given a Java parse tree `Doc` instance, return its parsed docstring text."
+  [doc]
+  (->> (.inlineTags doc)
+       (map (fn [t]
+              (case (.kind t)
+                "@see"     (format " `%s` " (.text t)) ; TODO use .referencedClassName ...?
+                "@code"    (format " `%s` " (-> t .inlineTags first .text))
+                "@literal" (format " `%s` " (-> t .inlineTags first .text))
+                (parse-html (.text t)))))
+       (apply str)))
+
+
+;;; ## Java Parse Tree Traversal
+;; From the parse tree returned by the compiler, create a nested map structure
+;; as produced by `cider.nrepl.middleware.util.java/reflect-info`: class members
+;; are indexed first by name, then argument types.
+
+(defn typesym
+  "Using parse tree info, return the type's name equivalently to the `typesym`
+  function in `cider.nrepl.middleware.util.java`."
+  [t]
+  (symbol
+   (str (when-let [c (.asClassDoc t)] ; when not a primitive
+          (str (-> c .containingPackage .name) "."))
+        (-> t .typeName (str/replace "." "$"))
+        (.dimension t))))
+
+(defprotocol Parsed
+  (parse-info [o]))
+
+(extend-protocol Parsed
+  ConstructorDoc
+  (parse-info [c]
+    {:name (-> c .qualifiedName symbol)
+     :argtypes (mapv #(-> % .type typesym) (.parameters c))
+     :argnames (mapv #(-> % .name symbol) (.parameters c))})
+
+  MethodDoc
+  (parse-info [m]
+    {:argtypes (mapv #(-> % .type typesym) (.parameters m))
+     :argnames (mapv #(-> % .name symbol) (.parameters m))})
+
+  FieldDoc
+  (parse-info [f])
+
+  ClassDoc
+  (parse-info [c]
+    {:class   (typesym c)
+     :doc     (docstring c)
+     :line    (-> c .position .line)
+     :column  (-> c .position .column)
+     :members (->> (concat (.constructors c) (.methods c) (.fields c))
+                   ;; Merge type-specific attributes with common ones.
+                   (map (fn [m]
+                          (merge {:name   (-> m .name symbol)
+                                  :line   (-> m .position .line)
+                                  :column (-> m .position .column)
+                                  :doc    (docstring m)}
+                                 (parse-info m))))
+                   ;; Index by name, argtypes. Args for fields are nil.
+                   (group-by :name)
+                   (reduce (fn [ret [n ms]]
+                             (assoc ret n (zipmap (map :argtypes ms) ms)))
+                           {}))}))
+
+(defn source-path
+  "Return the relative `.java` source path for the top-level class."
+  [class]
+  (-> (str/replace (str class) #"\$.*" "")
+      (str/replace "." "/")
+      (str ".java")))
+
+(defn source-info
+  "If the source for the Java class is available on the classparh, parse it
+  and return info to supplement reflection. Specifically this includes source
+  file and position, docstring, and argument name info. Info returned has the
+  same structure as that of `cider.nrepl.middleware.util.java/reflect-info`."
+  [class]
+  {:pre [(symbol? class)]}
+  (let [path (source-path class)]
+    (when-let [root (parse-java path)]
+      (assoc (->> (map parse-info (.classes root))
+                  (filter #(= class (:class %)))
+                  (first))
+        :file path))))

--- a/src/cider/nrepl/middleware/util/misc.clj
+++ b/src/cider/nrepl/middleware/util/misc.clj
@@ -5,6 +5,15 @@
   (try (-> (System/getProperty "java.version") (str/split #"\.") second)
        (catch Exception _ "7")))
 
+(defn deep-merge
+  "Merge maps recursively. When vals are not maps, last value wins."
+  [& xs]
+  (let [f (fn f [& xs]
+            (if (every? map? xs)
+              (apply merge-with f xs)
+              (last xs)))]
+    (apply f (filter identity xs))))
+
 (defn as-sym
   [x]
   (if x (symbol x)))

--- a/test/cider/nrepl/middleware/info_test.clj
+++ b/test/cider/nrepl/middleware/info_test.clj
@@ -43,10 +43,10 @@
                            (map :name)
                            (set)))))
 
-  (is (info/info-java "clojure.lang.Atom" "swap"))
+  (is (info/info-java 'clojure.lang.Atom 'swap))
 
   (is (re-find #"^(http|file|jar|zip):" ; resolved either locally or online
-               (-> (info/info-java "java.lang.Object" "toString")
+               (-> (info/info-java 'java.lang.Object 'toString)
                    (info/format-response)
                    (get "javadoc"))))
 


### PR DESCRIPTION
This moves Java `info` support essentially on par with Clojure. Specifically, we now have:
- `doc` and `jump` to source support for everything that has `.java` source code -- all classes, nested classes, interfaces, methods, and fields,
- actual `doc` text (not just URLs) for Java symbols,
- argument names (not just types) for Java arglists, and
- proper arglist arity for Clojure host interop (prepends `this` to instance method and field arglists).

It also removes the dependency on ASM in favor of the Java Compiler API. This does require `tools.jar`, but when that's not available, Java `info` falls back to simple reflection for basic symbol lookup.

I should note that Java symbol lookup can be "tuned" however we think makes sense. Right now qualified classes and static members are resolved universally, while unqualified classes and members are resolved in the current scope of `ns-imports`.

This requires `cider` PR [#584](https://github.com/clojure-emacs/cider/pull/584).
