### PR TITLE
Add a whitelist for info keys on var metadata

### DIFF
--- a/src/cider/nrepl/middleware/info.clj
+++ b/src/cider/nrepl/middleware/info.clj
@@ -17,9 +17,17 @@
                  :line (:line prot-meta)})
     info))
 
+(def var-meta-whitelist
+  [:ns :name :doc :file :arglists :macro :protocol :line :column :static :added :resource])
+
+(defn- map-seq [x]
+  (if (seq x)
+    x
+    nil))
+
 (defn var-meta
   [v]
-  (-> v meta maybe-protocol))
+  (-> v meta maybe-protocol (select-keys var-meta-whitelist) map-seq))
 
 (defn ns-meta
   [ns]


### PR DESCRIPTION
When generating a map for info on a var, whitelist the keys that may appear.

Address cider #588
