### PR TITLE
Ensure map keys are bencoded as strings.

### DIFF
--- a/src/cider/nrepl/middleware/info.clj
+++ b/src/cider/nrepl/middleware/info.clj
@@ -18,7 +18,7 @@
     info))
 
 (def var-meta-whitelist
-  [:ns :name :doc :file :arglists :macro :protocol :line :column :static :added :resource])
+  [:ns :name :doc :file :arglists :macro :protocol :line :column :static :added :deprecated :resource])
 
 (defn- map-seq [x]
   (if (seq x)

--- a/src/cider/nrepl/middleware/util/misc.clj
+++ b/src/cider/nrepl/middleware/util/misc.clj
@@ -46,8 +46,8 @@
 
 (defmethod transform-value clojure.lang.Associative
   [m]
-  (->> (for [[k v] m]
-         [(transform-value k) (transform-value v)])
+  (->> (for [[k v] m] ; bencode keys must be strings
+         [(str (transform-value k)) (transform-value v)])
        (into {})))
 
 ;; handles vectors


### PR DESCRIPTION
Also, add `:deprecated` to var metadata whitelist.
