### PR TITLE
[Fix #88] Invoke html parser directly.

### DIFF
--- a/src/cider/nrepl/middleware/util/java/parser.clj
+++ b/src/cider/nrepl/middleware/util/java/parser.clj
@@ -11,7 +11,7 @@
            (java.io StringReader)
            (java.net URI)
            (javax.swing.text.html HTMLEditorKit$ParserCallback HTML$Tag)
-           (javax.swing.text.html.parser ParserDelegator)
+           (javax.swing.text.html.parser DTD DocumentParser)
            (javax.tools JavaFileObject$Kind SimpleJavaFileObject)))
 
 ;;; ## Java Source Analysis
@@ -126,7 +126,7 @@
   [html]
   (let [sb (StringBuilder.)
         sr (StringReader. html)
-        parser (ParserDelegator.)
+        parser (DocumentParser. (DTD/getDTD "html32"))
         stack (atom nil)
         flags (atom #{})
         handler (proxy [HTMLEditorKit$ParserCallback] []


### PR DESCRIPTION
The documented way to do this using `ParserDelegator` triggers an apparent platform bug on Apple hosts: the internal `sun.awt.AppContext` reference causes an unwanted GUI window to pop up.
