### PR TITLE
Favor functions over namespaces in ns op

### DIFF
--- a/src/cider/nrepl/middleware/info.clj
+++ b/src/cider/nrepl/middleware/info.clj
@@ -1,5 +1,5 @@
 (ns cider.nrepl.middleware.info
-  (:require [clojure.string :as s]
+  (:require [clojure.string :as str]
             [clojure.java.io :as io]
             [cider.nrepl.middleware.util.cljs :as cljs]
             [cider.nrepl.middleware.util.java :as java]
@@ -81,14 +81,14 @@
 (defn info-clj
   [ns sym]
   (cond
-   ;; sym is an alias for another ns
-   (get (resolve-aliases ns) sym) (ns-meta (get (resolve-aliases ns) sym))
-   ;; it's simply a full ns
-   (find-ns sym) (ns-meta (find-ns sym))
    ;; it's a special (special-symbol? or :special-form)
    (resolve-special sym) (resolve-special sym)
    ;; it's a var
    (var-meta (resolve-var ns sym)) (var-meta (resolve-var ns sym))
+   ;; sym is an alias for another ns
+   (get (resolve-aliases ns) sym) (ns-meta (get (resolve-aliases ns) sym))
+   ;; it's simply a full ns
+   (find-ns sym) (ns-meta (find-ns sym))
    ;; it's a Java class/member symbol...or nil
    :else (java/resolve-symbol ns sym)))
 
@@ -177,7 +177,7 @@
                  {:arglists-str (pr-str args)})
                (when-let [forms (:forms info)]
                  {:forms-str (->> (map #(str "  " (pr-str %)) forms)
-                                  (s/join \newline))})
+                                  (str/join \newline))})
                (when-let [file (:file info)]
                  (file-info file))
                (when-let [path (:javadoc info)]

--- a/test/cider/nrepl/middleware/info_test.clj
+++ b/test/cider/nrepl/middleware/info_test.clj
@@ -33,6 +33,8 @@
   (is (info/info-clj 'cider.nrepl.middleware.info 'Class/forName))
   (is (info/info-clj 'cider.nrepl.middleware.info '.toString))
 
+  (is (= (the-ns 'clojure.core) (:ns (info/info-clj 'cider.nrepl.middleware.info 'str))))
+
   ;; special forms are marked as such and nothing else is (for all syms in ns)
   (let [ns 'cider.nrepl.middleware.info
         spec-forms (into '#{letfn fn let loop} (keys @#'repl/special-doc-map))


### PR DESCRIPTION
This is of course subjective, but I'd call the current behavior broken. If a `str` namespace alias exists and I call `(doc str)` in the REPL, I get the docs for the `str` function. If I call `(source str)`, I get the source. The current implementation is incompatible with both.

From the perspective of a lookup symbol under cursor operation, aliases generally only appear as bare symbols after `:as` in a require, and in that particular case, it's easy enough to just lookup the original namespace (two words to the left) instead.
