### PR TITLE
Fix inspector bug rendering sets of size < 5

### DIFF
--- a/src/cider/nrepl/middleware/util/inspect.clj
+++ b/src/cider/nrepl/middleware/util/inspect.clj
@@ -98,9 +98,9 @@
            (safe-pr-seq (take 5 value) "( %s ... )")
 
            (and (set? value) (< (count value) 5))
-           (safe-pr-seq "#{ %s }")
+           (safe-pr-seq value "#{ %s }")
 
-           (and (set? value))
+           (set? value)
            (safe-pr-seq (take 5 value) "#{ %s ... }")
 
            :default


### PR DESCRIPTION
Trivial fix for a bug that keeps me from extending the inspector to walk Datomic trees (Datomic's multiple value fields are returned as sets).
