### PR TITLE
Add an undef op to undefine a symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Middleware        | Op(s)      | Description
 `wrap-stacktrace` | `stacktrace` | Cause and stacktrace analysis for exceptions.
 `wrap-test`       | `test/retest/test-stacktrace` | Test execution, reporting, and inspection.
 `wrap-trace`      | `toggle-trace` | Toggle tracing of a given var.
+`wrap-undef`      | `undef`    | Undefine a var.
 
 ## Contributing
 

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -9,7 +9,8 @@
             [cider.nrepl.middleware.resource]
             [cider.nrepl.middleware.stacktrace]
             [cider.nrepl.middleware.test]
-            [cider.nrepl.middleware.trace]))
+            [cider.nrepl.middleware.trace]
+            [cider.nrepl.middleware.undef]))
 
 (def cider-middleware
   "A vector containing all CIDER middleware."
@@ -22,7 +23,8 @@
     cider.nrepl.middleware.resource/wrap-resource
     cider.nrepl.middleware.stacktrace/wrap-stacktrace
     cider.nrepl.middleware.test/wrap-test
-    cider.nrepl.middleware.trace/wrap-trace])
+    cider.nrepl.middleware.trace/wrap-trace
+    cider.nrepl.middleware.undef/wrap-undef])
 
 (def cider-nrepl-handler
   "CIDER's nREPL handler."

--- a/src/cider/nrepl/middleware/undef.clj
+++ b/src/cider/nrepl/middleware/undef.clj
@@ -1,0 +1,39 @@
+(ns cider.nrepl.middleware.undef
+  "Undefine a symbol"
+  (:require
+   [cider.nrepl.middleware.util.misc :as u]
+   [clojure.tools.nrepl.transport :as transport]
+   [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
+   [clojure.tools.nrepl.misc :refer [response-for]]))
+
+(defn undef
+  [{:keys [ns symbol] :as msg}]
+  (let [[ns symbol] (map u/as-sym [ns symbol])]
+    (ns-unalias ns symbol)
+    (ns-unmap ns symbol)))
+
+(defn undef-reply
+  [{:keys [transport] :as msg}]
+  (try
+    (undef msg)
+    (catch Exception e
+      (transport/send
+       transport (response-for msg :exception (.getMessage e)))))
+  (transport/send transport (response-for msg :status :done)))
+
+(defn wrap-undef
+  "Middleware to undefine a symbol in a namespace."
+  [handler]
+  (fn [{:keys [op] :as msg}]
+    (if (= "undef" op)
+      (undef-reply msg)
+      (handler msg))))
+
+(set-descriptor!
+ #'wrap-undef
+ {:handles
+  {"undef"
+   {:doc "Undefine a symbol"
+    :requires {"symbol" "The symbol to undefine"
+               "ns" "The current namespace"}
+    :returns {"status" "done"}}}})

--- a/test/cider/nrepl/middleware/undef_test.clj
+++ b/test/cider/nrepl/middleware/undef_test.clj
@@ -1,0 +1,14 @@
+(ns cider.nrepl.middleware.undef-test
+  (:require
+   [clojure.test :refer :all]
+   [cider.nrepl.middleware.test-transport :refer [messages test-transport]]
+   [cider.nrepl.middleware.undef :refer [undef-reply]]))
+
+(def x 1)
+
+(deftest test-toogle-undef-op
+  (let [transport (test-transport)]
+    (is (ns-resolve 'cider.nrepl.middleware.undef-test 'x))
+    (undef-reply {:transport transport :ns "cider.nrepl.middleware.undef-test" :symbol "x"})
+    (is (= [{:status #{:done}}] (messages transport)))
+    (is (nil? (ns-resolve 'cider.nrepl.middleware.undef-test 'x)))))


### PR DESCRIPTION
Adds a middleware with an "undef" op to be used to undefine a symbol in the
current namespace.
