### PR TITLE
use https to when accessing sonatype maven repository

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -39,7 +39,7 @@
                    ;; "snapshot" builds to run tests.
                    ;; See http://dev.clojure.org/jira/browse/CLJ-1161.
                    :repositories [["snapshots"
-                                   "http://oss.sonatype.org/content/repositories/snapshots"]]
+                                   "https://oss.sonatype.org/content/repositories/snapshots"]]
                    :dependencies [[org.clojure/clojure "1.5.2-SNAPSHOT"
                                    :classifier "sources"]
                                   [org.clojure/clojure "1.5.1"


### PR DESCRIPTION
I'm not sure how closely this is related to the change to `https` for maven repositories in [Leiningen 2.3.4](https://github.com/technomancy/leiningen/commit/e0ad0db0d66dc73e6a04d951791579c5ea4bb75f) but it seems that `https` is available so we should use it I guess. 
