### PR TITLE
Limit the levels printed for exception data

### DIFF
--- a/test/cider/nrepl/middleware/stacktrace_test.clj
+++ b/test/cider/nrepl/middleware/stacktrace_test.clj
@@ -9,7 +9,8 @@
   (analyze-causes
    (try (eval form)
         (catch Exception e
-          e))))
+          e))
+   nil))
 
 (defn stack-frames
   [form]


### PR DESCRIPTION
When pprint'ing the exception data for an exception cause, limit the depth of
data printed to avoid errors on circular data structures.
