### PR TITLE
Add resource to the list of middleware in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ middleware to to `:nrepl-middleware` under `:repl-options`.
                   cider.nrepl.middleware.info/wrap-info
                   cider.nrepl.middleware.inspect/wrap-inspect
                   cider.nrepl.middleware.macroexpand/wrap-macroexpand
+                  cider.nrepl.middleware.resource/wrap-resource
                   cider.nrepl.middleware.stacktrace/wrap-stacktrace
                   cider.nrepl.middleware.test/wrap-test
                   cider.nrepl.middleware.trace/wrap-trace


### PR DESCRIPTION
Add the resource middleware to the list of middleware in the :repl-options
example in the README.
