### PR TITLE
Add cljs support to ns-list and ns-vars ops

### DIFF
--- a/src/cider/nrepl/middleware/ns.clj
+++ b/src/cider/nrepl/middleware/ns.clj
@@ -1,29 +1,54 @@
 (ns cider.nrepl.middleware.ns
   (:require [clojure.tools.nrepl.transport :as transport]
             [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
-            [clojure.tools.nrepl.misc :refer [response-for]]))
+            [clojure.tools.nrepl.misc :refer [response-for]]
+            [cider.nrepl.middleware.util.cljs :as cljs]
+            [cljs-tooling.util.analysis :as cljs-analysis]))
 
-(defn ns-list []
+(defn ns-list-clj []
   (->> (all-ns)
        (map ns-name)
        (map name)
        (sort)))
 
-(defn ns-vars [ns]
+(defn ns-vars-clj [ns]
   (->> (symbol ns)
        ns-publics
        keys
        (map name)
        sort))
 
+(defn ns-list-cljs [env]
+  (->> (cljs-analysis/all-ns env)
+       keys
+       (map name)
+       sort))
+
+(defn ns-vars-cljs [env ns]
+  (->> (symbol ns)
+       (cljs-analysis/public-vars env)
+       keys
+       (map name)
+       sort))
+
+(defn ns-list [msg]
+  (if-let [cljs-env (cljs/grab-cljs-env msg)]
+    (ns-list-cljs cljs-env)
+    (ns-list-clj)))
+
+(defn ns-vars [{:keys [ns] :as msg}]
+  (if-let [cljs-env (cljs/grab-cljs-env msg)]
+    (ns-vars-cljs cljs-env ns)
+    (ns-vars-clj ns)))
+
 (defn ns-list-reply
   [{:keys [transport] :as msg}]
-  (transport/send transport (response-for msg :value (ns-list)))
+  (transport/send transport (response-for msg :value (ns-list msg)))
   (transport/send transport (response-for msg :status :done)))
 
 (defn ns-vars-reply
-  [{:keys [transport ns] :as msg}]
-  (transport/send transport (response-for msg :value (ns-vars ns)))
+  [{:keys [transport] :as msg}]
+  (transport/send transport (response-for msg :value (ns-vars msg)))
   (transport/send transport (response-for msg :status :done)))
 
 (defn wrap-ns
@@ -37,10 +62,12 @@
 
 (set-descriptor!
  #'wrap-ns
- {:handles
-  {"ns-list"
-   {:doc "Return a sorted list of all namespaces."
-    :returns {"status" "done"}}
-   "ns-vars"
-   {:doc "Return a sorted list of all vars in a namespace."
-    :returns {"status" "done"}}}})
+ (cljs/maybe-piggieback
+  {:handles
+   {"ns-list"
+    {:doc "Return a sorted list of all namespaces."
+     :returns {"status" "done"}}
+    "ns-vars"
+    {:doc "Returns a sorted list of all vars in a namespace."
+     :requires {"ns" "The namespace to browse"}
+     :returns {"status" "done"}}}}))

--- a/test/cider/nrepl/middleware/ns_test.clj
+++ b/test/cider/nrepl/middleware/ns_test.clj
@@ -2,11 +2,11 @@
   (:require
    [clojure.test :refer :all]
    [cider.nrepl.middleware.test-transport :refer [messages test-transport]]
-   [cider.nrepl.middleware.ns :refer [ns-list ns-vars]]))
+   [cider.nrepl.middleware.ns :refer [ns-list-clj ns-vars-clj]]))
 
 (deftest test-toogle-ns-list
-  (is (= (count (all-ns)) (count (ns-list)))))
+  (is (= (count (all-ns)) (count (ns-list-clj)))))
 
 (deftest test-toogle-ns-vars
   (let [ns "clojure.core"]
-    (is (= (count (ns-publics (symbol ns))) (count (ns-vars ns))))))
+    (is (= (count (ns-publics (symbol ns))) (count (ns-vars-clj ns))))))


### PR DESCRIPTION
This adds support for cljs namespaces and vars (i.e. no macro namespaces or macros yet) to these middleware ops. I also updated the descriptor to include `:requires` for `ns-vars` - let me know if that should be in a separate commit or PR.
