### PR TITLE
Fix :forms metadata not appearing in 'info' response

### DIFF
--- a/src/cider/nrepl/middleware/info.clj
+++ b/src/cider/nrepl/middleware/info.clj
@@ -18,7 +18,7 @@
     info))
 
 (def var-meta-whitelist
-  [:ns :name :doc :file :arglists :macro :protocol :line :column :static :added :deprecated :resource])
+  [:ns :name :doc :file :arglists :forms :macro :protocol :line :column :static :added :deprecated :resource])
 
 (defn- map-seq [x]
   (if (seq x)


### PR DESCRIPTION
In standard Clojure's `doc` function `:forms` metadata has a priority over `:arglists` metadata when displaying the documentation. CIDER's Elisp side also has capabilities for that, but for some reason `cider.nrepl.middleware.info/var-meta-whitelist` is missing `:forms`, so Elisp side never receives `:forms` metadata for a symbol.

Example:

``` clojure
(defn foobar
  {:forms '([foo])}
  ([foo] foo)
  ([foo bar] (+ foo bar)))
```

`C-c C-d d` before patch:

```
test.core/foobar
([foo] [foo bar])
```

`C-c C-d d` after patch:

```
test.core/foobar
  [foo]

```
