### PR TITLE
Add option for custom cljs compiler env

### DIFF
--- a/src/cider/nrepl/middleware/util/cljs.clj
+++ b/src/cider/nrepl/middleware/util/cljs.clj
@@ -14,9 +14,16 @@
     (update-in descriptor [:requires] #(set (conj % piggieback)))
     descriptor))
 
-(defn grab-cljs-env
+(defn grab-cljs-env-from-piggieback
   [msg]
   (when-let [piggieback-key (resolve 'cemerick.piggieback/*cljs-repl-env*)]
     (let [session (:session msg)
           env (get @session piggieback-key)]
       (if env @(:cljs.env/compiler env)))))
+
+(def ^:dynamic *compiler-env* nil)
+
+(defn grab-cljs-env
+  [msg]
+  (or (grab-cljs-env-from-piggieback msg)
+      (when *compiler-env* @*compiler-env*)))


### PR DESCRIPTION
See bhauman/lein-figwheel#59 for a bit more context on what this would enable. Basically, there are several new tools (figwheel, shadow-build, boot-reload, that I know of...) for cljs that fulfil a similar role - automatically compiling cljs on any file change, and reloading just the relevant changes in a connected web browser. This somewhat obviates the need for an actual REPL, and makes relying on Piggieback as the source of the cljs compiler environment somewhat troublesome from CIDER's perspective (as its compiler state does not update automatically to reflect what's been compiled by the build tool). I think in these situations, it would be okay to forgo the eval/load-file support from Piggieback but still have access to completion/doc lookup/the ns browser etc.

One alternative solution would be to get the compiler environment from the current session by looking it up using some known key (e.g. `:cider.nrepl/cljs-compiler-env`), and create a separate middleware that allows injecting the compiler-env atom into the current session with this key. This is essentially what Piggieback does using the key `#'cemerick.piggieback/*cljs-repl-env*`. A user could then integrate the compiler state from the build tool of their choosing by configuring this middleware accordingly. I like how general this would be - it would be compatible with any build tool that exposed its cljs compiler state atom.

Another idea I'm toying with is creating a specialised `figwheel-nrepl` middleware (and some supporting elisp) that would integrate figwheel with CIDER, allowing for starting/stopping of the figwheel server, reporting of compiler errors/warnings in emacs itself, and ensuring middleware ops automatically use the compiler state from figwheel (presumably by injecting it into the session as suggested above).

Thoughts?
