### PR TITLE
Don't invoke `info-clj` on missing symbol

### DIFF
--- a/src/cider/nrepl/middleware/info.clj
+++ b/src/cider/nrepl/middleware/info.clj
@@ -128,9 +128,10 @@
   (let [[ns symbol class member] (map u/as-sym [ns symbol class member])]
     (if-let [cljs-env (cljs/grab-cljs-env msg)]
       (handle-cljx-sources (info-cljs cljs-env symbol ns))
-      (if ns
-        (handle-cljx-sources (info-clj ns symbol))
-        (info-java class member)))))
+      (cond (and ns symbol) (handle-cljx-sources (info-clj ns symbol))
+            (and class member) (info-java class member)
+            :else (throw (Exception.
+                          "Either \"symbol\", or (\"class\", \"member\") must be supplied"))))))
 
 (defn resource-path
   "If it's a resource, return a tuple of the relative path and the full resource path."

--- a/test/cider/nrepl/middleware/info_test.clj
+++ b/test/cider/nrepl/middleware/info_test.clj
@@ -79,6 +79,14 @@
          (-> (info/info-clj 'cider.nrepl.middleware.info-test 'test-info)
              info/handle-cljx-sources
              :file)))
+
+  ;; either symbol or (class method) should be passed
+  (is (thrown? Exception
+               (info/info {:ns "cider.nrepl.middleware.info-test"
+                           :class "Thread"})))
+
+  ;; this is a replacement for (is (not (thrown? ..)))
+  (is (nil? (info/info {:class "Thread" :member "UncaughtExceptionHandler"})))
   )
 
 (deftest test-response


### PR DESCRIPTION
Try the following 

```clojure
(defn tt []
  (/ 1 0))

(tt)
```
In the stacktrace go to the line for anonymous method ending in /evalNNN and jump to source. You should get a stacktrace in the message buffer similar to the following:

```

edebug-signal: Source has changed - reevaluate definition of cider--jump-to-loc-from-info
java.lang.NullPointerException: null
 at java.util.concurrent.ConcurrentHashMap.hash (ConcurrentHashMap.java:333)
    java.util.concurrent.ConcurrentHashMap.get (ConcurrentHashMap.java:988)
    clojure.lang.Namespace.find (Namespace.java:188)
    clojure.core$find_ns.invoke (core.clj:3728)
    cider.nrepl.middleware.info$info_clj.invoke (info.clj:113)
    cider.nrepl.middleware.info$info.invoke (info.clj:132)
    cider.nrepl.middleware.info$info_reply.invoke (info.clj:217)
    cider.nrepl.middleware.info$wrap_info$fn__2658.invoke (info.clj:260)
    clojure.tools.nrepl.middleware$wrap_conj_descriptor$fn__406.invoke (middleware.clj:17)
    cider.nrepl.middleware.classpath$wrap_classpath$fn__1245.invoke (classpath.clj:25)
    clojure.tools.nrepl.middleware$wrap_conj_descriptor$fn__406.invoke (middleware.clj:17)
    cider.nrepl.middleware.undef$wrap_undef$fn__3383.invoke (undef.clj:30)
    clojure.tools.nrepl.middleware$wrap_conj_descriptor$fn__406.invoke (middleware.clj:17)
    cider.nrepl.middleware.trace$wrap_trace$fn__3355.invoke (trace.clj:65)
    clojure.tools.nrepl.middleware$wrap_conj_descriptor$fn__406.invoke (middleware.clj:17)
    cider.nrepl.middleware.apropos$wrap_apropos$fn__1178.invoke (apropos.clj:102)
    clojure.tools.nrepl.middleware$wrap_conj_descriptor$fn__406.invoke (middleware.clj:17)
    cider.nrepl.middleware.complete$wrap_complete$fn__2155.invoke (complete.clj:47)
    clojure.tools.nrepl.middleware$wrap_conj_descriptor$fn__406.invoke (middleware.clj:17)
    clojure.tools.nrepl.server$handle_STAR_.invoke (server.clj:19)
    clojure.tools.nrepl.server$handle$fn__760.invoke (server.clj:28)
    clojure.core$binding_conveyor_fn$fn__4107.invoke (core.clj:1836)
    clojure.lang.AFn.call (AFn.java:18)
    java.util.concurrent.FutureTask.run (FutureTask.java:262)
    java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1145)
    java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:615)
    java.lang.Thread.run (Thread.java:745)
```

The problem is that the request for info on class/method also contains `ns`, and `info-clj` has wrong conditional on `ns`. You can reproce the problem directly from info namespace along the following lines:

```
(info {:ns "cider.nrepl.middleware.info", :class "cider.nrepl.middleware.info$eval3995", :member "invoke",})
```
