### PR TITLE
Add pprint middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ middleware to to `:nrepl-middleware` under `:repl-options`.
                   cider.nrepl.middleware.inspect/wrap-inspect
                   cider.nrepl.middleware.macroexpand/wrap-macroexpand
                   cider.nrepl.middleware.ns/wrap-ns
+                  cider.nrepl.middleware.pprint/wrap-pprint
                   cider.nrepl.middleware.resource/wrap-resource
                   cider.nrepl.middleware.stacktrace/wrap-stacktrace
                   cider.nrepl.middleware.test/wrap-test
@@ -94,6 +95,7 @@ Middleware        | Op(s)      | Description
 `wrap-inspect`    |`inspect-(start/refresh/pop/push/reset)` | Inspect a Clojure expression.
 `wrap-macroexpand`| `macroexpand/macroexpand-1/macroexpand-all` | Macroexpand a Clojure form.
 `wrap-ns`         | `ns-list/ns-vars` | Namespace browsing.
+`wrap-pprint`     | | Adds pretty-printing support to code evaluation.
 `wrap-resource`   | `resource` | Return resource path.
 `wrap-stacktrace` | `stacktrace` | Cause and stacktrace analysis for exceptions.
 `wrap-test`       | `test/retest/test-stacktrace` | Test execution, reporting, and inspection.

--- a/project.clj
+++ b/project.clj
@@ -29,6 +29,7 @@
                                                      cider.nrepl.middleware.inspect/wrap-inspect
                                                      cider.nrepl.middleware.macroexpand/wrap-macroexpand
                                                      cider.nrepl.middleware.ns/wrap-ns
+                                                     cider.nrepl.middleware.pprint/wrap-pprint
                                                      cider.nrepl.middleware.resource/wrap-resource
                                                      cider.nrepl.middleware.stacktrace/wrap-stacktrace
                                                      cider.nrepl.middleware.test/wrap-test

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -8,6 +8,7 @@
             [cider.nrepl.middleware.inspect]
             [cider.nrepl.middleware.macroexpand]
             [cider.nrepl.middleware.ns]
+            [cider.nrepl.middleware.pprint]
             [cider.nrepl.middleware.resource]
             [cider.nrepl.middleware.stacktrace]
             [cider.nrepl.middleware.test]
@@ -24,6 +25,7 @@
     cider.nrepl.middleware.inspect/wrap-inspect
     cider.nrepl.middleware.macroexpand/wrap-macroexpand
     cider.nrepl.middleware.ns/wrap-ns
+    cider.nrepl.middleware.pprint/wrap-pprint
     cider.nrepl.middleware.resource/wrap-resource
     cider.nrepl.middleware.stacktrace/wrap-stacktrace
     cider.nrepl.middleware.test/wrap-test

--- a/src/cider/nrepl/middleware/pprint.clj
+++ b/src/cider/nrepl/middleware/pprint.clj
@@ -1,0 +1,33 @@
+(ns cider.nrepl.middleware.pprint
+  (:require [clojure.pprint :refer [pprint *print-right-margin*]]
+            [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
+            [cider.nrepl.middleware.util.cljs :as cljs]))
+
+(defn pprint-eval
+  [form]
+  (let [result (eval form)]
+    (pprint result)
+    result))
+
+(defn wrap-pprint-reply
+  [handler {:keys [right-margin session] :as msg}]
+  (when right-margin
+    (swap! session assoc #'*print-right-margin* right-margin))
+  (handler (assoc msg :eval 'cider.nrepl.middleware.pprint/pprint-eval)))
+
+(defn wrap-pprint
+  [handler]
+  "Middleware that adds a pretty printing option to the eval op.
+  Passing a non-nil value in the `:pprint` slot will cause eval to call
+  clojure.pprint/pprint on its result. The `:right-margin` slot can be used to
+  bind `*clojure.pprint/*print-right-margin*` during the evaluation."
+  (fn [{:keys [op pprint right-margin] :as msg}]
+    (if (and pprint (= op "eval"))
+      (wrap-pprint-reply handler msg)
+      (handler msg))))
+
+(set-descriptor!
+ #'wrap-pprint
+ (cljs/maybe-piggieback
+  {:requires #{"clone"}
+   :expects #{"eval"}}))

--- a/test/cider/nrepl/middleware/pprint_test.clj
+++ b/test/cider/nrepl/middleware/pprint_test.clj
@@ -1,0 +1,41 @@
+(ns cider.nrepl.middleware.pprint-test
+  (:require [cider.nrepl.middleware.pprint :refer [wrap-pprint]]
+            [clojure.test :refer :all]
+            [clojure.tools.nrepl :as nrepl]
+            [clojure.tools.nrepl.server :as server]
+            [clojure.tools.nrepl.transport :as transport]))
+
+(defn send-message
+  [message]
+  (with-open [server (server/start-server :handler (server/default-handler #'wrap-pprint))
+              transport (nrepl/connect :port (:port server))]
+    (let [client (nrepl/client transport 1000)
+          session (nrepl/client-session client)
+          response (nrepl/message session message)]
+      (nrepl/combine-responses response))))
+
+(deftest test-wrap-pprint
+  (let [code "[1 2 3 4 5 6 7 8 9 0]"]
+    (testing "wrap-pprint does not interfere with normal :eval requests"
+      (is (= [code]
+             (:value (send-message {:op :eval
+                                    :code code}))))
+      (is (= nil
+             (:out (send-message {:op :eval
+                                  :code code})))))
+    (testing "wrap-pprint does not clobber the :value slot"
+      (is (= [code]
+             (:value (send-message {:op :eval
+                                    :code code
+                                    :pprint "true"})))))
+    (testing "wrap-pprint ensures that :eval requests are pretty-printed"
+      (is (= "[1 2 3 4 5 6 7 8 9 0]\n"
+             (:out (send-message {:op :eval
+                                  :code code
+                                  :pprint "true"})))))
+    (testing "wrap-pprint respects the :right-margin slot"
+      (is (= "[1\n 2\n 3\n 4\n 5\n 6\n 7\n 8\n 9\n 0]\n"
+             (:out (send-message {:op :eval
+                                  :code code
+                                  :pprint "true"
+                                  :right-margin 10})))))))


### PR DESCRIPTION
This adds a `wrap-pprint` middleware so that CIDER's pprinting functionality will also be ClojureScript-compatible. By using `interruptible-eval`'s optional `:eval` slot we can ensure that `clojure.core/pprint` is not evaluated in a CLJS context, and also keep the evaluation inside `interruptible-eval`'s machinery, so the user can interrupt the printing of the result at the REPL.

See also clojure-emacs/cider#972.