### PR TITLE
Fix as-sym to not throw

### DIFF
--- a/src/cider/nrepl/middleware/util/misc.clj
+++ b/src/cider/nrepl/middleware/util/misc.clj
@@ -17,7 +17,8 @@
 
 (defn as-sym
   [x]
-  (if x (symbol x)))
+  (when (or (symbol? x) (string? x))
+    (symbol x)))
 
 (defmulti transform-value "Transform a value for output" type)
 

--- a/test/cider/nrepl/middleware/util/misc_test.clj
+++ b/test/cider/nrepl/middleware/util/misc_test.clj
@@ -18,4 +18,10 @@
 
 (deftest test-as-sym
   (is (= nil (misc/as-sym nil)))
-  (is (= 'WAT (misc/as-sym "WAT"))))
+  (is (= nil (misc/as-sym 1)))
+  (is (= nil (misc/as-sym '())))
+  (is (= nil (misc/as-sym [])))
+  (is (= nil (misc/as-sym {})))
+  (is (= nil (misc/as-sym :WAT)))
+  (is (= 'WAT (misc/as-sym "WAT")))
+  (is (= 'WAT (misc/as-sym 'WAT))))


### PR DESCRIPTION
It seems like `[]` was being passed in the `:ns` slot from the backtrace posted in clojure-emacs/cider#879. No idea why the client was doing that, but we shouldn't throw in that case.

The only valid types to pass to `symbol` are strings and symbols - since it either returns the symbol you passed, or calls `clojure.lang.Symbol/intern`, which takes a string.