### PR TITLE
Handle classpath-related errors in info middleware

### DIFF
--- a/src/cider/nrepl/middleware/info.clj
+++ b/src/cider/nrepl/middleware/info.clj
@@ -77,6 +77,7 @@
                  (when (:url m)
                    (str "http://clojure.org/" (:url m)))
                  (str "http://clojure.org/special_forms#" (:name m))))))
+    (catch NoClassDefFoundError _)
     (catch Exception _)))
 
 (defn find-cljx-source

--- a/src/cider/nrepl/middleware/util/java/parser.clj
+++ b/src/cider/nrepl/middleware/util/java/parser.clj
@@ -6,7 +6,7 @@
   (:import (com.sun.javadoc ClassDoc ConstructorDoc Doc FieldDoc MethodDoc
                             Parameter Tag Type)
            (com.sun.source.tree ClassTree)
-           (com.sun.tools.javac.util Context List Options)
+           (com.sun.tools.javac.util Abort Context List Options)
            (com.sun.tools.javadoc DocEnv JavadocEnter JavadocTool Messager
                                   ModifierFilter RootDocImpl)
            (java.io StringReader)
@@ -252,9 +252,11 @@
   same structure as that of `cider.nrepl.middleware.util.java/reflect-info`."
   [class]
   {:pre [(symbol? class)]}
-  (let [path (source-path class)]
-    (when-let [root (parse-java path)]
-      (assoc (->> (map parse-info (.classes root))
-                  (filter #(= class (:class %)))
-                  (first))
-        :file path))))
+  (try
+    (let [path (source-path class)]
+      (when-let [root (parse-java path)]
+        (assoc (->> (map parse-info (.classes root))
+                    (filter #(= class (:class %)))
+                    (first))
+               :file path)))
+    (catch Abort _)))

--- a/src/cider/nrepl/middleware/util/java/parser.clj
+++ b/src/cider/nrepl/middleware/util/java/parser.clj
@@ -246,8 +246,8 @@
       (str ".java")))
 
 (defn source-info
-  "If the source for the Java class is available on the classparh, parse it
-  and return info to supplement reflection. Specifically this includes source
+  "If the source for the Java class is available on the classpath, parse it
+  and return info to supplement reflection. Specifically, this includes source
   file and position, docstring, and argument name info. Info returned has the
   same structure as that of `cider.nrepl.middleware.util.java/reflect-info`."
   [class]


### PR DESCRIPTION
Not sure the best way to add tests for these without adding `funnyqt` to the test profile deps (since I'm not sure what it's doing to the classpath, and how else to replicate it). Will go ahead with that if you think it's needed.