### PR TITLE
Fix misplaced docstring

### DIFF
--- a/src/cider/nrepl/middleware/pprint.clj
+++ b/src/cider/nrepl/middleware/pprint.clj
@@ -16,11 +16,11 @@
   (handler (assoc msg :eval 'cider.nrepl.middleware.pprint/pprint-eval)))
 
 (defn wrap-pprint
-  [handler]
   "Middleware that adds a pretty printing option to the eval op.
   Passing a non-nil value in the `:pprint` slot will cause eval to call
   clojure.pprint/pprint on its result. The `:right-margin` slot can be used to
   bind `*clojure.pprint/*print-right-margin*` during the evaluation."
+  [handler]
   (fn [{:keys [op pprint right-margin] :as msg}]
     (if (and pprint (= op "eval"))
       (wrap-pprint-reply handler msg)


### PR DESCRIPTION
Whoops :blush:.

Found using Eastwood btw, I'm going through the [rest of the errors](https://gist.github.com/cichli/13bccd2cb3fcd89b0124) now. Might be useful to add this to Travis once they're all fixed so we don't introduce any more?