### PR TITLE
Update complete op to return annotated candidates

### DIFF
--- a/src/cider/nrepl/middleware/complete.clj
+++ b/src/cider/nrepl/middleware/complete.clj
@@ -14,7 +14,9 @@
         prefix (str symbol)]
     (if-let [cljs-env (cljs/grab-cljs-env msg)]
       (cljs-complete/completions cljs-env prefix ns)
-      (jvm-complete/completions prefix ns context))))
+      (jvm-complete/completions prefix {:ns ns
+                                        :context context
+                                        :tag-candidates true}))))
 
 (defn completion-doc
   [{:keys [symbol ns] :as msg}]


### PR DESCRIPTION
Required by clojure-emacs/cider#993.

The 1.7.0-SNAPSHOT builds still seem to be unavailable but I can confirm locally that it builds and tests pass against 1.7.0-alpha5.