### PR TITLE
Bump cljs-tooling dep to 0.1.5-SNAPSHOT

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
   :exclusions [org.clojure/clojure]
   :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
-             :1.7 {:dependencies [[org.clojure/clojure "1.7.0-master-SNAPSHOT"]]}
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0-alpha5"]]}
              :dev {:repl-options {:nrepl-middleware [cider.nrepl.middleware.apropos/wrap-apropos
                                                      cider.nrepl.middleware.classpath/wrap-classpath
                                                      cider.nrepl.middleware.complete/wrap-complete

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[compliment "0.2.1-SNAPSHOT"]
-                 [cljs-tooling "0.1.3"]
+                 [cljs-tooling "0.1.5-SNAPSHOT"]
                  [cljfmt "0.1.10"]
                  [org.tcrawley/dynapath "0.2.3"]
                  [org.clojure/tools.nrepl "0.2.7"]


### PR DESCRIPTION
This fixes cljs completion on 0.9.0-SNAPSHOT / latest CIDER. I still haven't sorted the Travis issue but received confirmation on the mailing list that it should be working - I think we should just use alpha5 instead of master until I get this figured out.