### PR TITLE
Portable inspector

### DIFF
--- a/test/cider/nrepl/middleware/inspect_test.clj
+++ b/test/cider/nrepl/middleware/inspect_test.clj
@@ -1,0 +1,237 @@
+(ns cider.nrepl.middleware.inspect-test
+  (:require [cider.nrepl.middleware.inspect :refer :all]
+            [cider.nrepl.middleware.util.inspect :as inspect]
+            [cider.nrepl.middleware.test-session :as session]
+            [clojure.test :refer :all]))
+
+(def nil-result ["(\"nil\" (:newline))"])
+
+(def var-result ["(\"Class\" \": \" (:value \"clojure.lang.Var\" 0) (:newline) \"Meta Information: \" (:newline) \"  \" (:value \":added\" 1) \" = \" (:value \"\\\"1.0\\\"\" 2) (:newline) \"  \" (:value \":tag\" 3) \" = \" (:value \"clojure.lang.Agent\" 4) (:newline) \"  \" (:value \":ns\" 5) \" = \" (:value \"clojure.core\" 6) (:newline) \"  \" (:value \":name\" 7) \" = \" (:value \"*agent*\" 8) (:newline) \"  \" (:value \":doc\" 9) \" = \" (:value \"\\\"The agent currently running an action on this thread, else nil\\\"\" 10) (:newline) \"Value: \" (:value \"\" 11))"])
+
+(def code "(sorted-map :a {:b 1} :c \"a\" :d 'e :f [2 3])")
+
+(def eval-result (eval (read-string code)))
+
+(def inspect-result ["(\"Class\" \": \" (:value \"clojure.lang.PersistentTreeMap\" 0) (:newline) \"Contents: \" (:newline) \"  \" \"0\" \". \" (:value \"[ :a { :b 1 } ]\" 1) (:newline) \"  \" \"1\" \". \" (:value \"[ :c \\\"a\\\" ]\" 2) (:newline) \"  \" \"2\" \". \" (:value \"[ :d e ]\" 3) (:newline) \"  \" \"3\" \". \" (:value \"[ :f [ 2 3 ] ]\" 4) (:newline))"])
+
+(def push-result ["(\"Class\" \": \" (:value \"clojure.lang.PersistentTreeMap$BlackVal\" 0) (:newline) \"Contents: \" (:newline) \"  \" \"0\" \". \" (:value \":a\" 1) (:newline) \"  \" \"1\" \". \" (:value \"{ :b 1 }\" 2) (:newline))"])
+
+(defn inspect
+  [value]
+  (inspect/start (inspect/fresh) value))
+
+(defn render
+  [inspector]
+  (vector (pr-str (:rendered inspector))))
+
+(deftest nil-test
+  (testing "nil renders correctly"
+    (is (= nil-result
+           (-> nil
+               inspect
+               render)))))
+
+(deftest pop-empty-test
+  (testing "popping an empty inspector renders nil"
+    (is (= nil-result
+           (-> (inspect/fresh)
+               inspect/up
+               render)))))
+
+(deftest pop-empty-idempotent-test
+  (testing "popping an empty inspector is idempotent"
+    (is (= nil-result
+           (-> (inspect/fresh)
+               inspect/up
+               inspect/up
+               render)))))
+
+(deftest push-empty-test
+  (testing "pushing an empty inspector index renders nil"
+    (is (= nil-result
+           (-> (inspect/fresh)
+               (inspect/down 1)
+               render)))))
+
+(deftest push-empty-idempotent-test
+  (testing "pushing an empty inspector index is idempotent"
+    (is (= nil-result
+           (-> (inspect/fresh)
+               (inspect/down 1)
+               (inspect/down 1)
+               render)))))
+
+(deftest inspect-var-test
+  (testing "rendering a var"
+    (is (= var-result
+           (-> #'*agent*
+               inspect
+               render)))))
+
+(deftest inspect-expr-test
+  (testing "rendering an expr"
+    (is (= inspect-result
+           (-> eval-result
+               inspect
+               render)))))
+
+(deftest push-test
+  (testing "pushing a rendered expr inspector idx"
+    (is (= push-result
+           (-> eval-result
+               inspect
+               (inspect/down 1)
+               render)))))
+
+(deftest pop-test
+  (testing "popping a rendered expr inspector"
+    (is (= inspect-result
+           (-> eval-result
+               inspect
+               (inspect/down 1)
+               inspect/up
+               render)))))
+
+;; integration tests
+
+(defn inspector-fixture
+  [f]
+  (binding [session/*handler* #'wrap-inspect]
+    (f)))
+
+(use-fixtures :each (compose-fixtures inspector-fixture session/session-fixture))
+
+(deftest nil-integration-test
+  (testing "nil renders correctly"
+    (is (= nil-result
+           (:value (session/message {:op "eval"
+                                     :inspect "true"
+                                     :code "nil"}))))))
+
+(deftest pop-empty-integration-test
+  (testing "popping an empty inspector renders nil"
+    (is (= nil-result
+           (:value (session/message {:op "inspect-pop"}))))))
+
+(deftest pop-empty-idempotent-integration-test
+  (testing "popping an empty inspector is idempotent"
+    (is (= nil-result
+           (:value (do
+                     (session/message {:op "inspect-pop"})
+                     (session/message {:op "inspect-pop"})))))))
+
+(deftest push-empty-integration-test
+  (testing "pushing an empty inspector index renders nil"
+    (is (= nil-result
+           (:value (session/message {:op "inspect-push"
+                                     :idx "1"}))))))
+
+(deftest push-empty-idempotent-integration-test
+  (testing "pushing an empty inspector index is idempotent"
+    (is (= nil-result
+           (:value (do
+                     (session/message {:op "inspect-push"
+                                       :idx "1"})
+                     (session/message {:op "inspect-push"
+                                       :idx "1"})))))))
+
+(deftest refresh-empty-integration-test
+  (testing "refreshing an empty inspector renders nil"
+    (is (= nil-result
+           (:value (session/message {:op "inspect-refresh"}))))))
+
+(deftest refresh-empty-idempotent-integration-test
+  (testing "refreshing an empty inspector renders nil"
+    (is (= nil-result
+           (:value (do
+                     (session/message {:op "inspect-refresh"})
+                     (session/message {:op "inspect-refresh"})))))))
+
+(deftest exception-integration-test
+  (let [exception-response (session/message {:op "eval"
+                                             :inspect "true"
+                                             :code "(first 1)"})]
+
+    (testing "exprs that throw exceptions return an `ex` slot"
+      (is (= "class java.lang.IllegalArgumentException"
+             (:ex exception-response))))
+
+    (testing "exprs that throw exceptions return an `err` slot"
+      (is (.startsWith (:err exception-response)
+                       "IllegalArgumentException")))))
+
+(deftest inspect-var-integration-test
+  (testing "rendering a var"
+    (is (= var-result
+           (:value (session/message {:op "eval"
+                                     :inspect "true"
+                                     :code "#'*agent*"}))))))
+
+(deftest inspect-expr-integration-test
+  (testing "rendering an expr"
+    (is (= inspect-result
+           (:value (session/message {:op "eval"
+                                     :inspect "true"
+                                     :code code}))))))
+
+(deftest push-integration-test
+  (testing "pushing a rendered expr inspector idx"
+    (is (= push-result
+           (:value (do
+                     (session/message {:op "eval"
+                                       :inspect "true"
+                                       :code code})
+                     (session/message {:op "inspect-push"
+                                       :idx "1"})))))))
+
+(deftest pop-integration-test
+  (testing "popping a rendered expr inspector"
+    (is (= inspect-result
+           (:value (do
+                     (session/message {:op "eval"
+                                       :inspect "true"
+                                       :code code})
+                     (session/message {:op "inspect-push"
+                                       :idx "1"})
+                     (session/message {:op "inspect-pop"})))))))
+
+(deftest refresh-integration-test
+  (testing "refreshing a rendered expr inspector"
+    (is (= inspect-result
+           (:value (do
+                     (session/message {:op "eval"
+                                       :inspect "true"
+                                       :code code})
+                     (session/message {:op "inspect-refresh"})))))))
+
+(deftest refresh-idempotent-integration-test
+  (testing "refreshing a rendered expr inspector is idempotent"
+    (is (= inspect-result
+           (:value (do
+                     (session/message {:op "eval"
+                                       :inspect "true"
+                                       :code code})
+                     (session/message {:op "inspect-refresh"})
+                     (session/message {:op "inspect-refresh"})))))))
+
+(deftest refresh-after-push-integration-test
+  (testing "refreshing a rendered expr inspector after an idx is pushed"
+    (is (= push-result
+           (:value (do
+                     (session/message {:op "eval"
+                                       :inspect "true"
+                                       :code code})
+                     (session/message {:op "inspect-push"
+                                       :idx "1"})
+                     (session/message {:op "inspect-refresh"})))))))
+
+(deftest session-binding-integration-test
+  (testing "session bindings can be inspected"
+    (is (= inspect-result
+           (:value (do
+                     (session/message {:op "eval"
+                                       :inspect "true"
+                                       :code code})
+                     (session/message {:op "eval"
+                                       :inspect "true"
+                                       :code "*1"})))))))

--- a/test/cider/nrepl/middleware/pprint_test.clj
+++ b/test/cider/nrepl/middleware/pprint_test.clj
@@ -1,41 +1,41 @@
 (ns cider.nrepl.middleware.pprint-test
   (:require [cider.nrepl.middleware.pprint :refer [wrap-pprint]]
-            [clojure.test :refer :all]
-            [clojure.tools.nrepl :as nrepl]
-            [clojure.tools.nrepl.server :as server]
-            [clojure.tools.nrepl.transport :as transport]))
+            [cider.nrepl.middleware.test-session :as session]
+            [clojure.test :refer :all]))
 
-(defn send-message
-  [message]
-  (with-open [server (server/start-server :handler (server/default-handler #'wrap-pprint))
-              transport (nrepl/connect :port (:port server))]
-    (let [client (nrepl/client transport 1000)
-          session (nrepl/client-session client)
-          response (nrepl/message session message)]
-      (nrepl/combine-responses response))))
+(defn pprint-fixture
+  [f]
+  (binding [session/*handler* #'wrap-pprint]
+    (f)))
+
+(use-fixtures :once (compose-fixtures pprint-fixture session/session-fixture))
 
 (deftest test-wrap-pprint
   (let [code "[1 2 3 4 5 6 7 8 9 0]"]
     (testing "wrap-pprint does not interfere with normal :eval requests"
       (is (= [code]
-             (:value (send-message {:op :eval
-                                    :code code}))))
+             (:value (session/message {:op :eval
+                                       :code code}))))
+
       (is (= nil
-             (:out (send-message {:op :eval
-                                  :code code})))))
+             (:out (session/message {:op :eval
+                                     :code code})))))
+
     (testing "wrap-pprint does not clobber the :value slot"
       (is (= [code]
-             (:value (send-message {:op :eval
-                                    :code code
-                                    :pprint "true"})))))
+             (:value (session/message {:op :eval
+                                       :code code
+                                       :pprint "true"})))))
+
     (testing "wrap-pprint ensures that :eval requests are pretty-printed"
       (is (= "[1 2 3 4 5 6 7 8 9 0]\n"
-             (:out (send-message {:op :eval
-                                  :code code
-                                  :pprint "true"})))))
+             (:out (session/message {:op :eval
+                                     :code code
+                                     :pprint "true"})))))
+
     (testing "wrap-pprint respects the :right-margin slot"
       (is (= "[1\n 2\n 3\n 4\n 5\n 6\n 7\n 8\n 9\n 0]\n"
-             (:out (send-message {:op :eval
-                                  :code code
-                                  :pprint "true"
-                                  :right-margin 10})))))))
+             (:out (session/message {:op :eval
+                                     :code code
+                                     :pprint "true"
+                                     :right-margin 10})))))))

--- a/test/cider/nrepl/middleware/test_session.clj
+++ b/test/cider/nrepl/middleware/test_session.clj
@@ -1,0 +1,20 @@
+(ns cider.nrepl.middleware.test-session
+  (:require [clojure.test :refer :all]
+            [clojure.tools.nrepl :as nrepl]
+            [clojure.tools.nrepl.server :as server]
+            [clojure.tools.nrepl.transport :as transport]))
+
+(def ^:dynamic *handler* nil)
+(def ^:dynamic *session* nil)
+
+(defn session-fixture
+  [f]
+  (with-open [server (server/start-server :handler (server/default-handler *handler*))
+              transport (nrepl/connect :port (:port server))]
+    (let [client (nrepl/client transport 1000)]
+      (binding [*session* (nrepl/client-session client)]
+        (f)))))
+
+(defn message
+  [msg]
+  (nrepl/combine-responses (nrepl/message *session* msg)))


### PR DESCRIPTION
see clojure-emacs/cider#1009

* The magic around inspecting vars is now gone. It's possible to inspect either `map` or `#'map` depending on if you want to inspect the function itself or the var.

* Inspector state now lives in the session bindings map rather than a global atom.

* I've removed the reset op for now as the client was not using it. Easy to add it back in, which I will do in a separate PR when I add support to the client.

* We no longer serialise the result, as `pr-values` is now doing it for us.