### PR TITLE
Use default handlers in session fixture

### DIFF
--- a/test/cider/nrepl/middleware/inspect_test.clj
+++ b/test/cider/nrepl/middleware/inspect_test.clj
@@ -1,6 +1,5 @@
 (ns cider.nrepl.middleware.inspect-test
-  (:require [cider.nrepl.middleware.inspect :refer :all]
-            [cider.nrepl.middleware.util.inspect :as inspect]
+  (:require [cider.nrepl.middleware.util.inspect :as inspect]
             [cider.nrepl.middleware.test-session :as session]
             [clojure.test :refer :all]))
 
@@ -94,12 +93,7 @@
 
 ;; integration tests
 
-(defn inspector-fixture
-  [f]
-  (binding [session/*handler* #'wrap-inspect]
-    (f)))
-
-(use-fixtures :each (compose-fixtures inspector-fixture session/session-fixture))
+(use-fixtures :each session/session-fixture)
 
 (deftest nil-integration-test
   (testing "nil renders correctly"

--- a/test/cider/nrepl/middleware/pprint_test.clj
+++ b/test/cider/nrepl/middleware/pprint_test.clj
@@ -1,14 +1,8 @@
 (ns cider.nrepl.middleware.pprint-test
-  (:require [cider.nrepl.middleware.pprint :refer [wrap-pprint]]
-            [cider.nrepl.middleware.test-session :as session]
+  (:require [cider.nrepl.middleware.test-session :as session]
             [clojure.test :refer :all]))
 
-(defn pprint-fixture
-  [f]
-  (binding [session/*handler* #'wrap-pprint]
-    (f)))
-
-(use-fixtures :once (compose-fixtures pprint-fixture session/session-fixture))
+(use-fixtures :once session/session-fixture)
 
 (deftest test-wrap-pprint
   (let [code "[1 2 3 4 5 6 7 8 9 0]"]

--- a/test/cider/nrepl/middleware/test_session.clj
+++ b/test/cider/nrepl/middleware/test_session.clj
@@ -1,15 +1,15 @@
 (ns cider.nrepl.middleware.test-session
-  (:require [clojure.test :refer :all]
+  (:require [cider.nrepl :refer [cider-nrepl-handler]]
+            [clojure.test :refer :all]
             [clojure.tools.nrepl :as nrepl]
             [clojure.tools.nrepl.server :as server]
             [clojure.tools.nrepl.transport :as transport]))
 
-(def ^:dynamic *handler* nil)
 (def ^:dynamic *session* nil)
 
 (defn session-fixture
   [f]
-  (with-open [server (server/start-server :handler (server/default-handler *handler*))
+  (with-open [server (server/start-server :handler cider-nrepl-handler)
               transport (nrepl/connect :port (:port server))]
     (let [client (nrepl/client transport 1000)]
       (binding [*session* (nrepl/client-session client)]


### PR DESCRIPTION
Both `wrap-inspect` and `wrap-pprint` rely on the eval op, and I think it would be nice to have the tests catch any unexpected interactions between them (and likewise for any other handlers, existing or future).