### PR TITLE
Bump tools.namespace dep to 0.2.10

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
                  [org.tcrawley/dynapath "0.2.3"]
                  [org.clojure/tools.nrepl "0.2.7"]
                  [org.clojure/java.classpath "0.2.0"]
-                 [org.clojure/tools.namespace "0.2.5"]
+                 [org.clojure/tools.namespace "0.2.10"]
                  [org.clojure/tools.trace "0.7.8"]
                  [org.clojure/tools.reader "0.8.13"]]
   :exclusions [org.clojure/clojure]


### PR DESCRIPTION
Changelog is [here](https://github.com/clojure/tools.namespace#change-log).

AFAICT this is only used by inlined code in the client, but moving to middleware would be useful. A potential `refresh` op could have the optional args:

* `before` - fully-qualified name of a function to run before refreshing
* `after` - fully-qualified name of a function to pass as the `:after` option to `refresh`

edit: ah just noticed #13 :-).