### PR TITLE
Send test coverage data to coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ script:
   - lein2 with-profile +1.5 test
   - lein2 with-profile +1.6 test
   - lein2 with-profile +1.7 test
-  - lein2 with-profile +lint cljfmt check
-  - lein2 with-profile +lint eastwood
+  - lein2 with-profile +cljfmt cljfmt check
+  - lein2 with-profile +eastwood eastwood
 jdk:
   - openjdk6
   - openjdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ script:
   - lein2 with-profile +1.7 test
   - lein2 with-profile +cljfmt cljfmt check
   - lein2 with-profile +eastwood eastwood
+  - lein2 with-profile +cloverage cloverage --coveralls
+  - curl -F 'json_file=@target/coverage/coveralls.json' 'https://coveralls.io/api/v1/jobs'
 jdk:
   - openjdk6
   - openjdk7

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/clojure-emacs/cider-nrepl.png?branch=master)](https://travis-ci.org/clojure-emacs/cider-nrepl)
+[![Build Status](https://travis-ci.org/clojure-emacs/cider-nrepl.png?branch=master)](https://travis-ci.org/clojure-emacs/cider-nrepl) [![Coverage Status](https://coveralls.io/repos/clojure-emacs/cider-nrepl/badge.svg?branch=master)](https://coveralls.io/r/clojure-emacs/cider-nrepl?branch=master)
 
 # CIDER nREPL
 

--- a/project.clj
+++ b/project.clj
@@ -19,9 +19,8 @@
                  [org.clojure/tools.trace "0.7.8"]
                  [org.clojure/tools.reader "0.8.13"]]
   :exclusions [org.clojure/clojure]
-  :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
-             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
-             :1.7 {:dependencies [[org.clojure/clojure "1.7.0-alpha5"]]}
+  :profiles {:provided {:dependencies [[org.clojure/clojure "1.5.1"]]}
+
              :dev {:repl-options {:nrepl-middleware [cider.nrepl.middleware.apropos/wrap-apropos
                                                      cider.nrepl.middleware.classpath/wrap-classpath
                                                      cider.nrepl.middleware.complete/wrap-complete
@@ -48,8 +47,12 @@
                                   [org.clojure/clojure "1.5.1"
                                    :classifier "javadoc"]]
                    :injections [~VERSION-FORM]}
+
              :test {:resource-paths ["test/resources"]}
-             :provided {:dependencies [[org.clojure/clojure "1.5.1"]]}
+             :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
+             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0-alpha5"]]}
+
              :cljfmt {:plugins [[lein-cljfmt "0.1.10"]]}
              :eastwood {:plugins [[jonase/eastwood "0.2.1"]]
                         :eastwood {:config-files ["eastwood.clj"]}}})

--- a/project.clj
+++ b/project.clj
@@ -54,5 +54,6 @@
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0-alpha5"]]}
 
              :cljfmt {:plugins [[lein-cljfmt "0.1.10"]]}
+             :cloverage {:plugins [[lein-cloverage "1.0.2"]]}
              :eastwood {:plugins [[jonase/eastwood "0.2.1"]]
                         :eastwood {:config-files ["eastwood.clj"]}}})

--- a/project.clj
+++ b/project.clj
@@ -50,6 +50,6 @@
                    :injections [~VERSION-FORM]}
              :test {:resource-paths ["test/resources"]}
              :provided {:dependencies [[org.clojure/clojure "1.5.1"]]}
-             :lint {:plugins [[jonase/eastwood "0.2.1"]
-                              [lein-cljfmt "0.1.10"]]
-                    :eastwood {:config-files ["eastwood.clj"]}}})
+             :cljfmt {:plugins [[lein-cljfmt "0.1.10"]]}
+             :eastwood {:plugins [[jonase/eastwood "0.2.1"]]
+                        :eastwood {:config-files ["eastwood.clj"]}}})


### PR DESCRIPTION
I thought this was pretty cool - see what the reports look like [here](https://coveralls.io/r/cichli/cider-nrepl) or for a specific file [here](https://coveralls.io/files/527870364). It doesn't support partial line coverage (see lemurheavy/coveralls-public#216) so cloverage uses 1x line hit for partial coverage and 2x line hits for complete coverage.

PRs will have an extra status added with information on how test coverage has changed if you enable coveralls for the repo at http://coveralls.io (only needs status API permissions).