### PR TITLE
Add refresh middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ middleware to `:nrepl-middleware` under `:repl-options`.
                   cider.nrepl.middleware.macroexpand/wrap-macroexpand
                   cider.nrepl.middleware.ns/wrap-ns
                   cider.nrepl.middleware.pprint/wrap-pprint
+                  cider.nrepl.middleware.refresh/wrap-refresh
                   cider.nrepl.middleware.resource/wrap-resource
                   cider.nrepl.middleware.stacktrace/wrap-stacktrace
                   cider.nrepl.middleware.test/wrap-test
@@ -105,6 +106,7 @@ Middleware        | Op(s)      | Description
 `wrap-macroexpand`| `macroexpand/macroexpand-1/macroexpand-all` | Macroexpand a Clojure form.
 `wrap-ns`         | `ns-list/ns-vars` | Namespace browsing.
 `wrap-pprint`     | | Adds pretty-printing support to code evaluation.
+`wrap-refresh`    | `refresh/refresh-all` | Code reloading.
 `wrap-resource`   | `resource` | Return resource path.
 `wrap-stacktrace` | `stacktrace` | Cause and stacktrace analysis for exceptions.
 `wrap-test`       | `test/retest/test-stacktrace` | Test execution, reporting, and inspection.

--- a/project.clj
+++ b/project.clj
@@ -30,6 +30,7 @@
                                                      cider.nrepl.middleware.macroexpand/wrap-macroexpand
                                                      cider.nrepl.middleware.ns/wrap-ns
                                                      cider.nrepl.middleware.pprint/wrap-pprint
+                                                     cider.nrepl.middleware.refresh/wrap-refresh
                                                      cider.nrepl.middleware.resource/wrap-resource
                                                      cider.nrepl.middleware.stacktrace/wrap-stacktrace
                                                      cider.nrepl.middleware.test/wrap-test

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -10,6 +10,7 @@
             [cider.nrepl.middleware.macroexpand]
             [cider.nrepl.middleware.ns]
             [cider.nrepl.middleware.pprint]
+            [cider.nrepl.middleware.refresh]
             [cider.nrepl.middleware.resource]
             [cider.nrepl.middleware.stacktrace]
             [cider.nrepl.middleware.test]
@@ -28,6 +29,7 @@
     cider.nrepl.middleware.macroexpand/wrap-macroexpand
     cider.nrepl.middleware.ns/wrap-ns
     cider.nrepl.middleware.pprint/wrap-pprint
+    cider.nrepl.middleware.refresh/wrap-refresh
     cider.nrepl.middleware.resource/wrap-resource
     cider.nrepl.middleware.stacktrace/wrap-stacktrace
     cider.nrepl.middleware.test/wrap-test

--- a/src/cider/nrepl/middleware/refresh.clj
+++ b/src/cider/nrepl/middleware/refresh.clj
@@ -1,0 +1,76 @@
+(ns cider.nrepl.middleware.refresh
+  (:require [cider.nrepl.middleware.stacktrace :refer [analyze-causes]]
+            [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
+            [clojure.tools.nrepl.misc :refer [response-for]]
+            [clojure.tools.nrepl.transport :as transport]
+            [clojure.tools.namespace.dir :as dir]
+            [clojure.tools.namespace.reload :as reload]
+            [clojure.tools.namespace.repl :as repl]
+            [clojure.tools.namespace.track :as track]))
+
+(defonce ^:private refresh-tracker (atom (track/tracker)))
+
+(defn- scan
+  [tracker scan-fn dirs]
+  (apply scan-fn tracker (or (seq dirs) [])))
+
+(defn- remove-disabled
+  [tracker]
+  (#'repl/remove-disabled tracker))
+
+(defn- reloading-reply
+  [tracker {:keys [transport] :as msg}]
+  (transport/send
+   transport
+   (response-for msg :reloading (::track/load tracker))))
+
+(defn- result-reply
+  [tracker {:keys [print-length print-level transport] :as msg}]
+  (transport/send
+   transport
+   (response-for msg (if-let [error (::reload/error tracker)]
+                       {:status #{:error :done}
+                        :error (analyze-causes error print-length print-level)
+                        :error-ns (::reload/error-ns tracker)}
+                       {:status #{:ok :done}}))))
+
+(defn- refresh-reply
+  [{:keys [dirs scan-fn] :as msg}]
+  (reset! refresh-tracker
+          (-> @refresh-tracker
+              (scan scan-fn dirs)
+              remove-disabled
+              (doto (reloading-reply msg))
+              reload/track-reload
+              (doto (result-reply msg)))))
+
+(defn wrap-refresh
+  "Middleware that provides code reloading."
+  [handler]
+  (fn [{:keys [op] :as msg}]
+    (case op
+      "refresh" (refresh-reply (assoc msg :scan-fn dir/scan))
+      "refresh-all" (refresh-reply (assoc msg :scan-fn dir/scan-all))
+      (handler msg))))
+
+(set-descriptor!
+ #'wrap-refresh
+ {:handles
+  {"refresh"
+   {:doc "Reloads all changed files in dependency order."
+    :optional {"dirs" "List of directories to scan. If no directories given, defaults to all directories on the classpath."
+               "print-length" "Value to bind to `*print-length*` when pretty-printing error data, if an exception is thrown."
+               "print-level" "Value to bind to `*print-level*` when pretty-printing error data, if an exception is thrown."}
+    :returns {"reloading" "List of namespaces that will be reloaded."
+              "status" "`:ok` if reloading was successful; otherwise `:error`."
+              "error" "A sequence of all causes of the thrown exception when `status` is `:error`."
+              "error-ns" "The namespace that caused reloading to fail when `status` is `:error`."}}
+   "refresh-all"
+   {:doc "Reloads all files in dependency order."
+    :optional {"dirs" "List of directories to scan. If no directories given, defaults to all directories on the classpath."
+               "print-length" "Value to bind to `*print-length*` when pretty-printing error data, if an exception is thrown."
+               "print-level" "Value to bind to `*print-level*` when pretty-printing error data, if an exception is thrown."}
+    :returns {"reloading" "List of namespaces that will be reloaded."
+              "status" "`:ok` if reloading was successful; otherwise `:error`."
+              "error" "A sequence of all causes of the thrown exception when `status` is `:error`."
+              "error-ns" "The namespace that caused reloading to fail when `status` is `:error`."}}}})


### PR DESCRIPTION
This just delegates to the `eval` op, similar to nREPL's own `load-file`. Unfortunately it's tricky to call `refresh` directly from the middleware since it sets `*e`, which doesn't play well with nREPL's binding conveyance. Seeing as how `load-file` also sets `*e` and `*1` I think it's acceptable for this middleware to do it too.

The `msg` arg to `refresh-code` is unused as of now, but I plan to add `after`/`before` options to make the reloaded workflow easier to integrate in CIDER - I'm just not sure how this will work client-side. I guess we can prompt for the namespace-qualified symbols of the functions to call before/after refreshing, or have options for them and encourage people to use `.dir-locals.el` to set them on a per-project basis.

Fixes #13.