### PR TITLE
Piggieback 0.2.x support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  [debugger "0.1.6"]
                  [cljfmt "0.1.10"]
                  [org.tcrawley/dynapath "0.2.3"]
-                 [org.clojure/tools.nrepl "0.2.7"]
+                 [org.clojure/tools.nrepl "0.2.10"]
                  [org.clojure/java.classpath "0.2.0"]
                  [org.clojure/tools.namespace "0.2.10"]
                  [org.clojure/tools.trace "0.7.8"]

--- a/src/cider/nrepl/middleware/complete.clj
+++ b/src/cider/nrepl/middleware/complete.clj
@@ -50,7 +50,7 @@
 
 (set-descriptor!
  #'wrap-complete
- (cljs/maybe-piggieback
+ (cljs/requires-piggieback
   {:handles
    {"complete"
     {:doc "Return a list of symbols matching the specified (partial) symbol."

--- a/src/cider/nrepl/middleware/info.clj
+++ b/src/cider/nrepl/middleware/info.clj
@@ -266,7 +266,7 @@
 
 (set-descriptor!
  #'wrap-info
- (cljs/maybe-piggieback
+ (cljs/requires-piggieback
   {:handles
    {"info"
     {:doc "Return a map of information about the specified symbol."

--- a/src/cider/nrepl/middleware/ns.clj
+++ b/src/cider/nrepl/middleware/ns.clj
@@ -62,7 +62,7 @@
 
 (set-descriptor!
  #'wrap-ns
- (cljs/maybe-piggieback
+ (cljs/requires-piggieback
   {:handles
    {"ns-list"
     {:doc "Return a sorted list of all namespaces."

--- a/src/cider/nrepl/middleware/util/cljs.clj
+++ b/src/cider/nrepl/middleware/util/cljs.clj
@@ -1,25 +1,84 @@
 (ns cider.nrepl.middleware.util.cljs)
 
 (defn try-piggieback
+  "If piggieback is loaded, returns `#'cemerick.piggieback/wrap-cljs-repl`, or
+  false otherwise."
   []
   (try
     (require 'cemerick.piggieback)
     (resolve 'cemerick.piggieback/wrap-cljs-repl)
     (catch Exception _)))
 
-(defn maybe-piggieback
-  "Helper to modify a descriptor to support piggieback"
-  [descriptor]
+;; TODO: warn on usage of piggieback 0.1.x?
+(defn piggieback-0-2+?
+  "Returns true if piggieback 0.2.x is loaded, or false otherwise."
+  []
+  (boolean
+   (try
+     (require 'cemerick.piggieback)
+     (resolve 'cemerick.piggieback/*cljs-compiler-env*)
+     (catch Exception _))))
+
+(defn- maybe-piggieback
+  [descriptor descriptor-key]
   (if-let [piggieback (try-piggieback)]
-    (update-in descriptor [:requires] #(set (conj % piggieback)))
+    (update-in descriptor [descriptor-key] #(set (conj % piggieback)))
     descriptor))
 
+(defn expects-piggieback
+  "If piggieback is loaded, returns the descriptor with piggieback's
+  `wrap-cljs-repl` handler assoc'd into its `:expects` set."
+  [descriptor]
+  (maybe-piggieback descriptor :expects))
+
+(defn requires-piggieback
+  "If piggieback is loaded, returns the descriptor with piggieback's
+  `wrap-cljs-repl` handler assoc'd into its `:requires` set."
+  [descriptor]
+  (maybe-piggieback descriptor :requires))
+
+(defn- cljs-env-path
+  "Returns the path in the session map for the ClojureScript compiler
+  environment used by piggieback."
+  []
+  (if (piggieback-0-2+?)
+    [(resolve 'cemerick.piggieback/*cljs-compiler-env*)]
+    [(resolve 'cemerick.piggieback/*cljs-repl-env*) :cljs.env/compiler]))
+
+(defn- maybe-deref
+  [x]
+  (if (instance? clojure.lang.IDeref x) @x x))
+
 (defn grab-cljs-env
+  "If piggieback is active, returns the ClojureScript compiler environment for
+  the running REPL."
   [msg]
-  (when-let [piggieback-key (resolve 'cemerick.piggieback/*cljs-repl-env*)]
+  (let [path (cljs-env-path)]
     (some-> msg
             :session
-            deref
-            (get piggieback-key)
-            :cljs.env/compiler
-            deref)))
+            maybe-deref
+            (get-in path)
+            maybe-deref)))
+
+(defn cljs-response-value
+  "Returns the :value slot of an eval response from piggieback as a Clojure
+  value."
+  [response]
+  ;; Older versions of piggieback would attempt to read-string the result of
+  ;; `cljs.repl/evaluate-form` and return that as the value, but newer versions
+  ;; just return the output printed by `cljs.repl/repl*`.
+  (let [value (:value response)]
+    (if (and (string? value) (piggieback-0-2+?))
+      (try
+        (read-string value)
+        (catch Exception _
+          value))
+      value)))
+
+(defn response-value
+  "Returns the :value slot of an eval response as a Clojure value, reading the
+  slot if necessary (piggieback 0.2.x)."
+  [msg response]
+  (if (grab-cljs-env msg)
+    (cljs-response-value response)
+    (:value response)))

--- a/test/cider/nrepl/middleware/pprint_test.clj
+++ b/test/cider/nrepl/middleware/pprint_test.clj
@@ -32,4 +32,10 @@
              (:out (session/message {:op :eval
                                      :code code
                                      :pprint "true"
-                                     :right-margin 10})))))))
+                                     :right-margin 10})))))
+
+    (testing "wrap-pprint does not escape special characters when printing strings"
+      (is (= "abc\ndef\tghi\n"
+             (:out (session/message {:op :eval
+                                     :code "\"abc\ndef\tghi\""
+                                     :pprint "true"})))))))


### PR DESCRIPTION
**Please do not merge yet.**

This PR is for adding support to the [0.2.0-SNAPSHOT branch](https://github.com/cemerick/piggieback/compare/new-cljs-repl) of piggieback, in a backwards-compatible way.

- [x] The compiler env is now in `*cljs-compiler-env*`, rather than assoc'd into `*cljs-repl-env*`.
- [x] It's not delegating to the `eval` op in the same way anymore, so the pprint middleware needs updating to not depend on this.
- [x] The `:value` slot used to be the result of calling `read-string`, but it now just contains the (generally readable) printed output from `cljs.repl/repl*` for the eval. We have to do the reading ourselves now in the pprint and inspector middlewares.
- [x] `:eval-error` is now returned when an exception is thrown, but the stacktrace middleware relies on `*e` being set in the session to work - so the error buffer just displays the last thrown Clojure exception when an exception is thrown at the ClojureScript REPL.