### PR TITLE
[Fix #143] Inline dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,15 @@ cache:
   directories:
     - $HOME/.m2
 script:
+  - lein2 source-deps
   - $TEST_CMD
 env:
-  - TEST_CMD="lein2 with-profile +1.5,+test-clj test"
-  - TEST_CMD="lein2 with-profile +1.6,+test-clj test"
-  - TEST_CMD="lein2 with-profile +1.7,+test-clj test"
+  - TEST_CMD="lein2 with-profile +1.5,+plugin.mranderson/config,+test-clj test"
+  - TEST_CMD="lein2 with-profile +1.6,+plugin.mranderson/config,+test-clj test"
+  - TEST_CMD="lein2 with-profile +1.7,+plugin.mranderson/config,+test-clj test"
 
-  - TEST_CMD="lein2 with-profile +1.6,+test-cljs test"
-  - TEST_CMD="lein2 with-profile +1.7,+test-cljs test"
+  - TEST_CMD="lein2 with-profile +1.6,+plugin.mranderson/config,+test-cljs test"
+  - TEST_CMD="lein2 with-profile +1.7,+plugin.mranderson/config,+test-cljs test"
 jdk:
   - openjdk6
   - openjdk7
@@ -19,9 +20,9 @@ jdk:
   - oraclejdk8
 matrix:
   exclude:
-    - env: TEST_CMD="lein2 with-profile +1.6,+test-cljs test"
+    - env: TEST_CMD="lein2 with-profile +1.6,+plugin.mranderson/config,+test-cljs test"
       jdk: openjdk6
-    - env: TEST_CMD="lein2 with-profile +1.7,+test-cljs test"
+    - env: TEST_CMD="lein2 with-profile +1.7,+plugin.mranderson/config,+test-cljs test"
       jdk: openjdk6
   include:
     - env: TEST_CMD="lein2 with-profile +1.7,+test-clj,+test-cljs,+coveralls coveralls"

--- a/README.md
+++ b/README.md
@@ -144,6 +144,38 @@ Before submitting a patch or a pull request make sure all tests are
 passing and that your patch is in line with the [contribution
 guidelines](CONTRIBUTING.md).
 
+### Working with mranderson (inlining dependencies)
+
+[mranderson](https://github.com/benedekfazekas/mranderson) is used to avoid classpath collisions.
+
+To work with `mranderson` the first thing to do is:
+
+`lein do clean, source-deps`
+
+This creates the munged local dependencies in `target/srcdeps` directory.
+
+After that you can run your tests or your REPL with:
+
+`lein with-profile +plugin.mranderson/config repl`
+
+`lein with-profile +plugin.mranderson/config test`
+
+Note the plus sign before the leiningen profile. For this leiningen profile to work **you need leiningen version 2.5.0+!** If you want to use `mranderson` while developing locally with the REPL the source has to be modified in the `target/srcdeps` directory. When you want to release locally:
+
+`lein with-profile plugin.mranderson/config install`
+
+Release to clojars:
+
+`lein with-profile plugin.mranderson/config deploy clojars`
+
+Or you can use the very sophisticated script to clean, inline, test and run an end target like install or deploy:
+
+`./build.sh install`
+
+`./build.sh deploy clojars`
+
+[build.sh](build.sh) cleans, runs source-deps with the right parameters, runs the tests and then runs the provided lein target.
+
 ## Hall of Fame
 
 Special credit goes to the following people for their contributions:

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# runs source-deps and tests and then provided lein target with mranderson
+
+function check_result {
+    if [ $? -ne 0 ]; then
+        echo "FAILED"
+        exit 1
+    fi
+}
+
+lein do clean, source-deps
+check_result
+lein with-profile +test-clj,+1.6,+plugin.mranderson/config test
+check_result
+lein with-profile plugin.mranderson/config "$@"

--- a/project.clj
+++ b/project.clj
@@ -1,26 +1,24 @@
 (def VERSION "0.9.0-SNAPSHOT")
 
-(def VERSION-FORM `(do (require 'cider-nrepl.plugin)
-                       (alter-var-root #'cider-nrepl.plugin/version
-                                       (constantly (constantly ~VERSION)))))
-
 (defproject cider/cider-nrepl VERSION
   :description "nREPL middlewares for CIDER"
   :url "https://github.com/clojure-emacs/cider-nrepl"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[compliment "0.2.1-SNAPSHOT"]
-                 [cljs-tooling "0.1.5-SNAPSHOT"]
-                 [debugger "0.1.7"]
-                 [cljfmt "0.1.10"]
-                 [org.tcrawley/dynapath "0.2.3"]
+  :dependencies [^:source-dep [compliment "0.2.1-SNAPSHOT"]
+                 ^:source-dep [cljs-tooling "0.1.5-SNAPSHOT"]
+                 ^:source-dep [debugger "0.1.7"]
+                 ^:source-dep [cljfmt "0.1.10"]
+                 ^:source-dep [org.tcrawley/dynapath "0.2.3"]
                  [org.clojure/tools.nrepl "0.2.10"]
-                 [org.clojure/java.classpath "0.2.2"]
-                 [org.clojure/tools.namespace "0.2.10"]
-                 [org.clojure/tools.trace "0.7.8"]
-                 [org.clojure/tools.reader "0.9.1"]]
+                 ^:source-dep [org.clojure/java.classpath "0.2.2"]
+                 ^:source-dep [org.clojure/tools.namespace "0.2.10"]
+                 ^:source-dep [org.clojure/tools.trace "0.7.8"]
+                 ^:source-dep [org.clojure/tools.reader "0.9.1"]]
   :exclusions [org.clojure/clojure]
   :test-paths ["test/common"] ;; See `test-clj` and `test-cljs` profiles below.
+  :plugins [[thomasa/mranderson "0.4.3"]]
+  :filespecs [{:type :bytes :path "cider/cider-nrepl/project.clj" :bytes ~(slurp "project.clj")}]
   :profiles {:provided {:dependencies [[org.clojure/clojure "1.5.1"]]}
 
              :dev {:repl-options {:nrepl-middleware [cider.nrepl.middleware.apropos/wrap-apropos
@@ -49,8 +47,7 @@
                                   [org.clojure/clojure "1.5.2-SNAPSHOT"
                                    :classifier "sources"]
                                   [org.clojure/clojure "1.5.1"
-                                   :classifier "javadoc"]]
-                   :injections [~VERSION-FORM]}
+                                   :classifier "javadoc"]]}
 
              :test {:resource-paths ["test/resources"]}
              :test-clj {:test-paths ["test/clj"]}

--- a/src/cider_nrepl/plugin.clj
+++ b/src/cider_nrepl/plugin.clj
@@ -5,7 +5,7 @@
 ;; Keep in sync with VERSION-FORM in project.clj
 (defn- version
   []
-  (let [v (-> (io/resource "META-INF/leiningen/cider/cider-nrepl/project.clj")
+  (let [v (-> (io/resource "cider/cider-nrepl/project.clj")
               slurp
               read-string
               (nth 2))]


### PR DESCRIPTION
- use mranderson to inline dependencies at package time
- simple build script to help working with mranderson
- bit of explanation in readme
- travis file modified accordingly

tests pass, not yet tested the built middleware tho (will do) but ready for a review I suppose.