### PR TITLE
Don't send debugger message if the break won't prompt

### DIFF
--- a/test/cider/nrepl/middleware/debug_test.clj
+++ b/test/cider/nrepl/middleware/debug_test.clj
@@ -1,0 +1,10 @@
+(ns cider.nrepl.middleware.debug-test
+  (:require [clojure.test :refer :all]
+            [debugger.time :as t]
+            [debugger.config :as c]
+            [cider.nrepl.middleware.debug :as d]))
+
+(deftest breakpoint
+  (reset! c/*last-quit-at* (t/now))
+  (is (= (d/breakpoint 10 {}) 10)))
+


### PR DESCRIPTION
While debugging something else I noticed a bug in the debugger.

If the user hits `c` to continue without stopping, clj-debugger's `break` statements don't trigger anymore (as expected) but we were still sending the debugger message for cider to "prepare" for a break.

This fixes that.