### PR TITLE
Add test for session fixture

### DIFF
--- a/test/common/cider/nrepl/test_session.clj
+++ b/test/common/cider/nrepl/test_session.clj
@@ -19,3 +19,15 @@
 (defn message
   [msg]
   (nrepl/combine-responses (nrepl/message *session* msg)))
+
+(use-fixtures :each session-fixture)
+
+(deftest sanity
+  (testing "eval works"
+    (is (= ["(true false true false true false)"]
+           (:value (message {:op :eval
+                             :code (nrepl/code (map even? (range 6)))})))))
+
+  (testing "unsupported op"
+    (is (= #{"error" "unknown-op" "done"}
+           (:status (message {:op "abcdefg"}))))))


### PR DESCRIPTION
The unsupported op test will hopefully stabilise the test coverage reports by ensuring the `(handler msg)` branch is always called for all middlewares (currently it seems to depend on how nREPL orders them which is not deterministic).