### PR TITLE
Add extra-metadata options to complete middleware

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
   :dependencies [[org.clojure/tools.nrepl "0.2.10"]
                  [org.tcrawley/dynapath "0.2.3"]
                  ^:source-dep [compliment "0.2.2"]
-                 ^:source-dep [cljs-tooling "0.1.6"]
+                 ^:source-dep [cljs-tooling "0.1.7"]
                  ^:source-dep [cljfmt "0.1.10"]
                  ^:source-dep [org.clojure/java.classpath "0.2.2"]
                  ^:source-dep [org.clojure/tools.namespace "0.2.10"]

--- a/src/cider/nrepl/middleware/complete.clj
+++ b/src/cider/nrepl/middleware/complete.clj
@@ -9,14 +9,17 @@
             [cljs-tooling.complete :as cljs-complete]))
 
 (defn complete
-  [{:keys [symbol ns context] :as msg}]
+  [{:keys [symbol ns context extra-metadata] :as msg}]
   (let [ns (u/as-sym ns)
-        prefix (str symbol)]
+        prefix (str symbol)
+        extra-metadata (set (map keyword extra-metadata))]
     (if-let [cljs-env (cljs/grab-cljs-env msg)]
-      (cljs-complete/completions cljs-env prefix ns)
+      (cljs-complete/completions cljs-env prefix {:context-ns ns
+                                                  :extra-metadata extra-metadata})
       (jvm-complete/completions prefix {:ns ns
                                         :context context
-                                        :tag-candidates true}))))
+                                        :tag-candidates true
+                                        :extra-metadata extra-metadata}))))
 
 (defn completion-doc
   [{:keys [symbol ns] :as msg}]
@@ -57,7 +60,8 @@
      :requires {"symbol" "The symbol to lookup"
                 "ns" "The symbol's namespace"
                 "session" "The current session"}
-     :optional {"context" "Completion context for compliment."}
+     :optional {"context" "Completion context for compliment."
+                "extra-metadata" "List of extra-metadata fields. Possible values: arglists, doc."}
      :returns {"completions" "A list of possible completions"}}
     "complete-doc"
     {:doc "Retrieve documentation suitable for display in completion popup"

--- a/test/clj/cider/nrepl/middleware/complete_test.clj
+++ b/test/clj/cider/nrepl/middleware/complete_test.clj
@@ -1,0 +1,40 @@
+(ns cider.nrepl.middleware.complete-test
+  (:require [cider.nrepl.test-session :as session]
+            [cider.nrepl.test-transport :refer [messages test-transport]]
+            [clojure.test :refer :all]))
+
+(use-fixtures :each session/session-fixture)
+
+(deftest complete
+  (let [response (session/message {:op "complete"
+                                   :ns "user"
+                                   :symbol ""})]
+    (is (= #{"done"} (:status response)))
+    (is (sequential? (:completions response)))
+    (is (every? map? (:completions response))))
+
+  (testing "function arglists"
+    (let [response (session/message {:op "complete"
+                                     :ns "user"
+                                     :symbol "unchecked-a"
+                                     :extra-metadata ["arglists"]})]
+      (is (= {:arglists '("[x y]") :ns "clojure.core", :candidate "unchecked-add", :type "function"}
+             (first (:completions response))))))
+
+  (testing "function metadata"
+    (let [response (session/message {:op "complete"
+                                     :ns "user"
+                                     :symbol "assoc"
+                                     :extra-metadata ["arglists" "doc"]})
+          candidate (first (:completions response))]
+      (is (= '("[map key val]" "[map key val & kvs]") (:arglists candidate)))
+      (is (string? (:doc candidate)))))
+
+  (testing "macro metadata"
+    (let [response (session/message {:op "complete"
+                                     :ns "user"
+                                     :symbol "defprot"
+                                     :extra-metadata ["arglists" "doc"]})
+          candidate (first (:completions response))]
+      (is (= '("[name & opts+sigs]") (:arglists candidate)))
+      (is (string? (:doc candidate))))))

--- a/test/cljs/cider/nrepl/middleware/cljs_complete_test.clj
+++ b/test/cljs/cider/nrepl/middleware/cljs_complete_test.clj
@@ -19,4 +19,22 @@
         candidate (first (:completions response))]
     (is (= "defprotocol" (:candidate candidate)))
     (is (= "cljs.core" (:ns candidate)))
-    (is (= "macro" (:type candidate)))))
+    (is (= "macro" (:type candidate))))
+
+  (testing "function metadata"
+    (let [response (session/message {:op "complete"
+                                     :ns "cljs.user"
+                                     :symbol "assoc"
+                                     :extra-metadata ["arglists" "doc"]})
+          candidate (first (:completions response))]
+      (is (= '("[coll k v]" "[coll k v & kvs]") (:arglists candidate)))
+      (is (string? (:doc candidate)))))
+
+  (testing "macro metadata"
+    (let [response (session/message {:op "complete"
+                                     :ns "cljs.user"
+                                     :symbol "defprot"
+                                     :extra-metadata ["arglists" "doc"]})
+          candidate (first (:completions response))]
+      (is (= '("[psym & doc+methods]") (:arglists candidate)))
+      (is (string? (:doc candidate))))))


### PR DESCRIPTION
Fixes #176 

Merged: alexander-yakushev/compliment#26
Merged: gtrak/cljs-tooling/pull/18
Merged: gtrak/cljs-tooling/pull/19

@bbatsov In relation to alexander-yakushev/compliment#26

I decided to open this PR here for comments even though PR to Compliment is not merged yet and cljs-tooling doesn't have the support for options yet. 

Added options which allow frontends to request arglists and doc for each completion results. Passes the options to Compliment.