### PR TITLE
Give a middleware name for pprint so it can be discovered dynamically

### DIFF
--- a/src/cider/nrepl/middleware/pprint.clj
+++ b/src/cider/nrepl/middleware/pprint.clj
@@ -45,4 +45,9 @@
  #'wrap-pprint
  (cljs/expects-piggieback
   {:requires #{"clone" #'pr-values}
-   :expects #{"eval"}}))
+   :expects #{"eval"}
+   :handles
+   {"pprint-middleware"
+    {:doc "Enhances the `eval` op by pretty printing the evaluation result if a `:pprint` slot is found in the msg map. Not an op by itself."
+     :requires #{"clone" #'pr-values}
+     :expects #{"eval"}}}}))


### PR DESCRIPTION
For CCW I make use of the `describe` op to discover available middlewares.

The proposed change would enable `pprint` to be discovered like any other middleware.