### PR TITLE
[Fix cider#1089] Don't instrument symbol in call position

### DIFF
--- a/test/clj/cider/nrepl/middleware/util/instrument_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/instrument_test.clj
@@ -197,3 +197,17 @@
     'tarzan '(false false))
   (is (= (#'t/specifier-destructure "bindings")
          (#'t/specifier-destructure "binding"))))
+
+(deftest instrument-function-call
+  (is (= '(System/currentTimeMillis)
+         (#'t/instrument
+          {:coor [] :breakfunction 'b}
+          '(System/currentTimeMillis))))
+  (is (eval
+       (#'t/instrument
+        {:coor []
+         :breakfunction #'cider.nrepl.middleware.debug/breakpoint}
+        '(defn test-fn []
+           (let [start-time (System/currentTimeMillis)]
+             (Thread/sleep 1000)
+             (- (System/currentTimeMillis) start-time)))))))


### PR DESCRIPTION
Defines a new function instrument-function-call, which is like instrument-coll, except the first element is not instrumented.
This is only used if the first element is a symbol.