### PR TITLE
Update pprint middleware to not hijack *out*

### DIFF
--- a/test/cljs/cider/nrepl/middleware/cljs_pprint_test.clj
+++ b/test/cljs/cider/nrepl/middleware/cljs_pprint_test.clj
@@ -8,13 +8,13 @@
 (deftest cljs-pprint
   (testing "pretty printing works"
     (is (= "[1\n 2\n 3\n 4\n 5\n 6\n 7\n 8\n 9\n 0]\n"
-           (:out (session/message {:op :eval
-                                   :code "[1 2 3 4 5 6 7 8 9 0]"
-                                   :pprint "true"
-                                   :right-margin 10})))))
+           (:pprint-out (session/message {:op :eval
+                                          :code "[1 2 3 4 5 6 7 8 9 0]"
+                                          :pprint "true"
+                                          :right-margin 10})))))
 
   (testing "wrap-pprint does not escape special characters when printing strings"
     (is (= "abc\ndef\tghi\n"
-           (:out (session/message {:op :eval
-                                   :code "\"abc\ndef\tghi\""
-                                   :pprint "true"}))))))
+           (:pprint-out (session/message {:op :eval
+                                          :code "\"abc\ndef\tghi\""
+                                          :pprint "true"}))))))

--- a/test/common/cider/nrepl/test_session.clj
+++ b/test/common/cider/nrepl/test_session.clj
@@ -17,8 +17,12 @@
         (f)))))
 
 (defn message
-  [msg]
-  (nrepl/combine-responses (nrepl/message *session* msg)))
+  ([msg] (message msg true))
+  ([msg combine-responses?]
+   (let [responses (nrepl/message *session* msg)]
+     (if combine-responses?
+       (nrepl/combine-responses responses)
+       responses))))
 
 (use-fixtures :each session-fixture)
 


### PR DESCRIPTION
* The printed result is now streamed via the `:pprint-out` slot
* After each result is printed, a response is sent with a non-nil value in the `:pprint-sentinel` slot
* The `:value` slot is now elided from responses

Fixes #200.

Not including the `:value` slot means the client won't choke trying to decode or print it all at once. The client changes aren't ready yet, but I'm posting this for review + so @laurentpetit can be ready for if/when this merges.

Thoughts? Eventually on the client we'll be able to use this to prevent the interleaving of evaluation results and things written to `*out*` - either by sending them to different buffers, or queuing the `*out*` responses while an evaluation result is being printed.
