### PR TITLE
don't attempt to read file paths unless they are actually files.

### DIFF
--- a/src/cider/nrepl/middleware/info.clj
+++ b/src/cider/nrepl/middleware/info.clj
@@ -87,7 +87,7 @@
                 (when (= "file" (.getProtocol rsrc))
                   (io/as-file rsrc))
                 (io/as-file filename))]
-    (when (and file (.exists file))
+    (when (and file (.exists file) (.isFile file))
       (with-open [in (io/input-stream file)]
         (.skip in (max 0 (- (.length file) 1024)))
         (->> (slurp in)


### PR DESCRIPTION
Fixes instances where cljx files have the same name as directories in the classpath.