### PR TITLE
instrument.clj: Add support for `proxy`, `or`, and `and`

### DIFF
--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -5,7 +5,6 @@
             [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
             [clojure.tools.nrepl.misc :refer [response-for]]
             [clojure.tools.nrepl.middleware.interruptible-eval :refer [*msg*]]
-            [cider.nrepl.middleware.stacktrace :refer [analyze-causes]]
             [cider.nrepl.middleware.util.instrument :refer [instrument]])
   (:import [clojure.lang Compiler$LocalBinding]))
 

--- a/test/clj/cider/nrepl/middleware/util/instrument_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/instrument_test.clj
@@ -99,6 +99,17 @@
     #'t/instrument-second-arg        (list 'a (bt 'b [14]) 'c)
     #'t/instrument-two-args          (list (bt 'a [13]) (bt 'b [14]) 'c)))
 
+(deftest like-fn
+  (is (= (#'t/instrument-like-fn dex '((some-name [args] instrument-this) anything else))
+         (list (list 'some-name '[args]
+                     (bt 'instrument-this [13 2]))
+               'anything 'else)))
+  (is (= (#'t/match-like-fn '((some-name [args] instrument-this) anything else))
+         1))
+  (is (not (#'t/match-like-fn '((some-name not-args instrument-this) anything else))))
+  (is (not (#'t/match-like-fn '((some-name [args]) anything else))))
+  (is (not (#'t/match-like-fn '(not-list anything else)))))
+
 (deftest instrument-clauses
   (are [exp res] (= (#'t/instrument dex exp)
                     res)


### PR DESCRIPTION
As the title says.