### PR TITLE
Avoid overwriting default locale

### DIFF
--- a/src/cider/nrepl/middleware/util/java/parser.clj
+++ b/src/cider/nrepl/middleware/util/java/parser.clj
@@ -63,7 +63,6 @@
           compiler (JavadocTool/make0 context)
           enter    (JavadocEnter/instance0 context)
           docenv   (doto (DocEnv/instance context)
-                     (.setLocale (str (Locale/getDefault)))
                      (.setEncoding "utf-8")
                      (.setSilent true)
                      (set-field! "showAccess" access))


### PR DESCRIPTION
This PR is related to #210.
 
That change causes weird behavior in my environment.
If "ja_JP" (my default locale)  is passed to DocEnv/setLocale, the default locale will be overwritten to "ja_JP_JP_#u-ca-japanese".
When new locale is passed to DocEnv/setLocale again, it becomes the error. 

I've read source code of com.sun.tools.javadoc.DocLocale and found that `getLocale` method returns the default locale itself when passed locale name is empty string.

```clj
user=> (require 'cider.nrepl.middleware.util.java.parser)
nil
user=> (in-ns 'cider.nrepl.middleware.util.java.parser)
#<Namespace cider.nrepl.middleware.util.java.parser>
cider.nrepl.middleware.util.java.parser=> (def docenv (let [access   (ModifierFilter. ModifierFilter/ALL_ACCESS)
                                     #_=>                   context  (doto (Context.) (Messager/preRegister "cider-nrepl-javadoc"))
                                     #_=>                   options  (doto (Options/instance context) (.put "ignore.symbol.file" "y"))
                                     #_=>                   compiler (JavadocTool/make0 context)
                                     #_=>                   enter    (JavadocEnter/instance0 context)]
                                     #_=>               (DocEnv/instance context)))
#'cider.nrepl.middleware.util.java.parser/docenv
cider.nrepl.middleware.util.java.parser=> (Locale/setDefault (Locale. "ja" "JP"))
nil
cider.nrepl.middleware.util.java.parser=> (Locale/getDefault)
#<Locale ja_JP>
cider.nrepl.middleware.util.java.parser=> (.setLocale docenv (str (Locale/getDefault)))
nil
cider.nrepl.middleware.util.java.parser=> (Locale/getDefault)
#<Locale ja_JP_JP_#u-ca-japanese>
cider.nrepl.middleware.util.java.parser=> (.setLocale docenv (str (Locale/getDefault)))
cider-nrepl-javadoc: エラー - ロケールja_JP_JP_#u-ca-japaneseが無効です

ExitJavadoc   com.sun.tools.javadoc.Messager.exit (Messager.java:300)
cider.nrepl.middleware.util.java.parser=> (Locale/setDefault (Locale. "ja" "JP"))
nil
cider.nrepl.middleware.util.java.parser=> (.setLocale docenv "")
nil
cider.nrepl.middleware.util.java.parser=> (Locale/getDefault)
#<Locale ja_JP>
```
