### PR TITLE
[Fix #196] Rewritten dependencies polluting ns-list

### DIFF
--- a/src/cider/nrepl/middleware/apropos.clj
+++ b/src/cider/nrepl/middleware/apropos.clj
@@ -5,7 +5,8 @@
             [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
             [clojure.tools.nrepl.misc :refer [response-for]]
             [clojure.tools.nrepl.transport :as t]
-            [cider.nrepl.middleware.util.misc :as u]))
+            [cider.nrepl.middleware.util.misc :as u]
+            [cider.nrepl.middleware.ns :as ns]))
 
 ;;; ## Overview
 ;; This middleware provides regular expression search across namespaces for
@@ -56,7 +57,7 @@
                     (and (clojure-ns? x) (not (clojure-ns? y))) -1
                     (and (clojure-ns? y) (not (clojure-ns? x)))  1
                     :else (compare (str x) (str y))))
-            (all-ns)))))
+            (remove ns/inlined-dependency? (all-ns))))))
 
 (defn find-symbols
   "Find symbols or (optionally) docstrings matching `query` in `search-ns` if

--- a/src/cider/nrepl/middleware/ns.clj
+++ b/src/cider/nrepl/middleware/ns.clj
@@ -12,8 +12,20 @@
              [transport :as transport]])
   (:import java.util.jar.JarFile))
 
+(defn inlined-dependency?
+  "Returns true if the namespace matches one of our, or eastwood's,
+  inlined dependencies."
+  [namespace]
+  (let [ns-name (str (ns-name namespace))]
+    (or
+     ;; rewritten by mranderson
+     (.startsWith ns-name "deps.")
+     ;; rewritten by dolly
+     (.startsWith ns-name "eastwood.copieddeps"))))
+
 (defn ns-list-clj []
   (->> (all-ns)
+       (remove inlined-dependency?)
        (map ns-name)
        (map name)
        (sort)))


### PR DESCRIPTION
Our own inlined deps, created by mranderson, as well as the inlined deps
from eastwood were polluting the result of the `ns-list` op.  These are
now filtered out.

This change improves all cider commands relying on a completing read of
some namespace e.g. `cider-browse-ns` and `cider-find-ns`
