### PR TITLE
[Fix clojure-emacs/cider#1134] Don't breakpoint maps in arglists

### DIFF
--- a/test/clj/cider/nrepl/middleware/util/instrument_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/instrument_test.clj
@@ -84,12 +84,6 @@
     'pikachu     "Charizard"
     :Blastoise   :Magikarp))
 
-(deftest instrument-map
-  (is (= (#'t/instrument-map dex '{:a 1, (name :b) (inc 2)})
-         {:a 1,
-          (bt '(name :b) [13 2])
-          (bt '(inc 2) [13 3])})))
-
 (deftest instrument-basics
   (are [f o] (= (f dex '(a b c)) o)
     #'t/instrument-all-args          (list (bt 'a [13]) (bt 'b [14]) (bt 'c [15]))


### PR DESCRIPTION
We already didn't instrument inside maps, but we still wrapped breakpoints around them. This is bad sometimes.

The fix is this [one line change](https://github.com/clojure-emacs/cider-nrepl/compare/master...Malabarba:master#diff-156621f66b9a5c16a8d5eabf6bc46cd7L285). The rest of the diff is cleanup related to this map thing.