### PR TITLE
More debugger

### DIFF
--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -254,7 +254,11 @@
       "eval" (h (maybe-debug msg))
       "debug-input" (when-let [pro (@promises (:key msg))]
                       (swap! promises dissoc  (:key msg))
-                      (deliver pro (read-string input))
+                      (try (deliver pro (read-string input))
+                           (catch Exception e
+                             (when-not (realized? pro)
+                               (deliver pro :quit))
+                             (throw e)))
                       (transport/send (:transport msg)
                                       (response-for msg :status :done)))
       "init-debugger" (initialize msg)

--- a/src/cider/nrepl/middleware/util/instrument.clj
+++ b/src/cider/nrepl/middleware/util/instrument.clj
@@ -241,8 +241,13 @@
    (let [map-inner (fn [forms]
                      (map-indexed #(walk-indexed (conj coor %1) f %2)
                                   forms))
-         ;; Order of maps and sets is unpredictable, unfortunately.
-         result (cond (map? form)  form
+         ;; Maps are unordered, but we can try to use the keys (and
+         ;; they're important enough that we're willing to risk
+         ;; getting the position wrong).
+         result (cond (map? form)  (into {} (map (fn [[k v]]
+                                                   [k (walk-indexed (conj coor (pr-str k)) f v)])
+                                                 form))
+                      ;; Order of sets is unpredictable, unfortunately.
                       (set? form)  form
                       ;; Borrowed from clojure.walk/walk
                       (list? form) (apply list (map-inner form))

--- a/src/cider/nrepl/middleware/util/instrument.clj
+++ b/src/cider/nrepl/middleware/util/instrument.clj
@@ -160,7 +160,18 @@
        (println "[DBG]" (not (not cider-breakfunction)) cider-coor form))
      (if (and cider-breakfunction (seq cider-coor))
        (list cider-breakfunction form cider-coor)
-       form))))
+       ;; If the form is a list and has no metadata, maybe it was
+       ;; destroyed by a macro. Try guessing the coor by looking at
+       ;; the first element. This fixes `->`, for instance.
+       (if (listy? form)
+         (let [{:keys [cider-coor cider-breakfunction]} (meta (first form))
+               coor (if (= (last cider-coor) 0)
+                      (pop cider-coor)
+                      cider-coor)]
+           (if (and cider-breakfunction (seq cider-coor))
+             (list cider-breakfunction form coor)
+             form))
+         form)))))
 
 (defn- contains-recur?
   "Return true if form is not a `loop` and a `recur` is found in it."

--- a/test/clj/cider/nrepl/middleware/debug_test.clj
+++ b/test/clj/cider/nrepl/middleware/debug_test.clj
@@ -103,3 +103,14 @@
     (with-locals
       (is (= '(("x" "1"))
              (#'d/locals-for-message d/*locals*))))))
+
+(deftest eval-expression-with-code
+  (with-locals
+    (is (= (#'d/read-debug-eval-expression
+            "Unused prompt" {:some "random", 'meaningless :map} '(inc 1))
+           2)))
+  (let [x 10]
+    (with-locals
+      (is (= (#'d/read-debug-eval-expression
+              "Unused prompt" {:some "random", 'meaningless :map} '(inc x))
+             11)))))

--- a/test/clj/cider/nrepl/middleware/util/instrument_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/instrument_test.clj
@@ -50,12 +50,12 @@
   (with-redefs [d/breakpoint-reader
                 (fn [x] (t/with-meta-safe x {:cider-breakfunction #'bp}))]
     (reset! bp-tracker #{})
-    (clojure.pprint/pprint (walk/macroexpand-all (#'t/instrument-tagged-code (#'d/debug-reader form))))
-    ;; Replace #'bp with 'bp for easier comparison.
+    (walk/macroexpand-all (#'t/instrument-tagged-code (#'d/debug-reader form)))
+    ;; Replace #'bp with 'bp for easier print and comparison.
     (walk/postwalk #(if (= % #'bp) 'bp %) @bp-tracker)))
 
 (deftest instrument-clauses
-  (are [exp res] (= (breakpoint-tester exp) res)
+  (are [exp res] (clojure.set/subset? res (breakpoint-tester exp))
     '(cond-> value
        v2 form
        v3 (boogie oogie form))


### PR DESCRIPTION
- Debugger's eval and inject also accept code non-interactively. Instead of sending :eval on the message's "input" entry, send something like `{:response :eval, :code 123}`. This allows cider.el to integrate regular eval commands with the debugger.  
  *In short*, commands like `C-x C-e` or `C-c M-:` will evaluate code in the lexical context while debug-mode is active.
- Since the order inside maps is unreliable, try to use map keys as a coordinate. Affects #211.  
  ![cider-debug-map](https://cloud.githubusercontent.com/assets/453029/8433109/ba7d05e0-1f3b-11e5-9397-62a4d35f3c67.png)
- There are now commands for inspecting values in the lexical context. `:inspect` and `:locals`, in particular.  
  ![cider-debug-inspect-locals](https://cloud.githubusercontent.com/assets/453029/8433006/54ad1bba-1f3b-11e5-8726-9c98e5934495.png)
- When a form has no :cider-coor metadata, but it is a list and its `first` *does* have that metadata, this is probably a proper code form built by a macro (like the threading macros). The debugger will now use the meta of the `first` to guess the coordinates of the parent form.  
  In other words: added support for `->`, `->>`, etc.  
  ![cider-debug-threading-macro](https://cloud.githubusercontent.com/assets/453029/8433031/65e42734-1f3b-11e5-927f-57f04736f951.png)