### PR TITLE
Fix instrumenting try forms

### DIFF
--- a/src/cider/nrepl/middleware/util/instrument.clj
+++ b/src/cider/nrepl/middleware/util/instrument.clj
@@ -16,6 +16,7 @@
   "Set of macros whose return value we don't care about.
   When instrumenting, these will not be wrapped in a breakpoint."
   '#{def fn* deftype* reify* quote
+     catch finally
      monitor-enter monitor-exit})
 
 ;;; We'll probably want to expand this variable. It is used to

--- a/test/clj/cider/nrepl/middleware/util/instrument_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/instrument_test.clj
@@ -145,3 +145,14 @@
                    (bp (. Thread sleep 1000) [3 2])
                    (bp (- (bp (. System currentTimeMillis) [3 3 1]) (bp start-time [3 3 2])) [3 3]))
              [3]]})))
+
+(deftest instrument-try
+  ;; No breakpoints around `catch`, `finally`, `Exception`, or `e`.
+  (is (= (breakpoint-tester '(try
+                               x
+                               (catch Exception e z)
+                               (finally y)))
+         '#{[y [3 1]]
+            [(try (bp x [1]) (catch Exception e (bp z [2 3])) (finally (bp y [3 1]))) []]
+            [x [1]]
+            [z [2 3]]})))


### PR DESCRIPTION
We don't want breakpoints around `catch` or `finally`.