### PR TITLE
Refresh improvements - clear op and support for disabling reloading of namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Middleware        | Op(s)      | Description
 `wrap-macroexpand`| `macroexpand/macroexpand-1/macroexpand-all` | Macroexpand a Clojure form.
 `wrap-ns`         | `ns-list/ns-vars/ns-path` | Namespace browsing.
 `wrap-pprint`     | | Adds pretty-printing support to code evaluation. It also installs a dummy `pprint-middleware` op. Thus `wrap-pprint` is discoverable through the `describe` op.
-`wrap-refresh`    | `refresh/refresh-all` | Code reloading.
+`wrap-refresh`    | `refresh/refresh-all/refresh-clear` | Code reloading.
 `wrap-resource`   | `resource` | Return resource path.
 `wrap-stacktrace` | `stacktrace` | Cause and stacktrace analysis for exceptions.
 `wrap-test`       | `test/retest/test-stacktrace` | Test execution, reporting, and inspection.

--- a/src/cider/nrepl/middleware/refresh.clj
+++ b/src/cider/nrepl/middleware/refresh.clj
@@ -1,4 +1,5 @@
-(ns cider.nrepl.middleware.refresh
+(ns ^{:clojure.tools.namespace.repl/load false
+      :clojure.tools.namespace.repl/unload false} cider.nrepl.middleware.refresh
   (:require [cider.nrepl.middleware.stacktrace :refer [analyze-causes]]
             [cider.nrepl.middleware.util.misc :as u]
             [clojure.main :refer [repl-caught]]


### PR DESCRIPTION
* Sometimes the refresh tracker can get in a state that makes reloading impossible - this can happen if a file has been deleted, or if a circular dependency error occured. The `clear` op does the same thing as `clojure.tools.namespace.repl/clear`, resetting the refresh tracker to its default value. The trade-off of doing this is that stale code from any deleted files may not be completely unloaded - I'll document all of this in the client README when I add support for the op there.

* The problem with using `clojure.tools.namespace.repl/remove-disabled` directly is that it looks up namespaced keywords in each namespace's metadata, and these namespaced keywords are rewritten by mranderson, so will not match those in user code. We workaround this by constructing the correct keywords at runtime, and inlining `remove-disabled`.