### PR TITLE
Custom pretty printing

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,8 @@
 
   :dependencies [[org.clojure/tools.nrepl "0.2.12"]
                  [org.tcrawley/dynapath "0.2.3"]
+                 ^:source-dep [mvxcvi/puget "1.0.0"]
+                 ^:source-dep [fipp "0.6.3"]
                  ^:source-dep [compliment "0.2.5"]
                  ^:source-dep [cljs-tooling "0.1.9"]
                  ^:source-dep [cljfmt "0.3.0"]

--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
                  ^:source-dep [org.clojure/tools.namespace "0.2.11"]
                  ^:source-dep [org.clojure/tools.trace "0.7.9"]
                  ^:source-dep [org.clojure/tools.reader "0.10.0"]]
-  :plugins [[thomasa/mranderson "0.4.5"]]
+  :plugins [[thomasa/mranderson "0.4.6"]]
   :exclusions [org.clojure/clojure]
 
   :filespecs [{:type :bytes :path "cider/cider-nrepl/project.clj" :bytes ~(slurp "project.clj")}]

--- a/src/cider/nrepl/middleware/pprint.clj
+++ b/src/cider/nrepl/middleware/pprint.clj
@@ -7,10 +7,18 @@
             [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
             [clojure.tools.nrepl.middleware.session :as session]
             [clojure.tools.nrepl.misc :refer [response-for]]
-            [clojure.tools.nrepl.transport :as transport])
+            [clojure.tools.nrepl.transport :as transport]
+            [fipp.edn :as fipp]
+            [puget.printer :as puget])
   (:import clojure.tools.nrepl.transport.Transport))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn fipp-pprint [object]
+  (fipp/pprint object {:width (or *print-right-margin* 72)}))
+
+(defn puget-pprint [object]
+  (puget/pprint object {:width (or *print-right-margin* 72)}))
 
 (defn- resolve-pprint-fn
   [sym]

--- a/src/cider/nrepl/middleware/pprint.clj
+++ b/src/cider/nrepl/middleware/pprint.clj
@@ -1,31 +1,79 @@
 (ns cider.nrepl.middleware.pprint
   (:require [cider.nrepl.middleware.util.cljs :as cljs]
+            [cider.nrepl.middleware.util.misc :as u]
             [clojure.pprint :refer [pprint *print-right-margin*]]
-            [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
             [clojure.tools.nrepl.middleware.interruptible-eval :refer [*msg*]]
             [clojure.tools.nrepl.middleware.pr-values :refer [pr-values]]
+            [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
             [clojure.tools.nrepl.middleware.session :as session]
             [clojure.tools.nrepl.misc :refer [response-for]]
             [clojure.tools.nrepl.transport :as transport])
   (:import clojure.tools.nrepl.transport.Transport))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- resolve-pprint-fn
+  [sym]
+  (let [var (some-> sym u/as-sym resolve)]
+
+    (when (or (nil? var) (not (var? var)))
+      (throw (IllegalArgumentException. (format "%s is not resolvable as a var" sym))))
+
+    @var))
+
+(defn wrap-pprint-fn
+  "Middleware that provides a common interface for other middlewares that need
+  to perform customisable pretty-printing.
+
+  A namespace-qualified name of the function to be used for printing can be
+  optionally passed in the `:pprint-fn` slot, the default value being
+  `clojure.pprint/pprint`.
+
+  The `:pprint-fn` slot will be replaced with a closure that calls the given
+  printing function with `*print-length*`, `*print-level*`, `*print-meta*`, and
+  `clojure.pprint/*print-right-margin*` bound to the values of the
+  `:print-length`, `:print-level`, `:print-meta`, and `:print-right-margin`
+  slots respectively.
+
+  Middlewares further down the stack can then look up the `:pprint-fn` slot and
+  call it where necessary."
+  [handler]
+  (fn [{:keys [pprint-fn print-length print-level print-meta print-right-margin session]
+        :or {pprint-fn 'clojure.pprint/pprint}
+        :as msg}]
+    (handler (assoc msg :pprint-fn (fn [object]
+                                     (binding [*print-length* (or print-length (get @session #'*print-length*))
+                                               *print-level* (or print-level (get @session #'*print-level*))
+                                               *print-meta* (or print-meta (get @session #'*print-meta*))
+                                               *print-right-margin* (or print-right-margin (get @session #'*print-right-margin*))]
+                                       ((resolve-pprint-fn pprint-fn) object)))))))
+
+(def wrap-pprint-fn-optional-arguments
+  {"pprint-fn" "The namespace-qualified name of a single-arity function to use for pretty-printing. Defaults to `clojure.pprint/pprint`."
+   "print-length" "Value to bind to `*print-length*` when pretty-printing. Defaults to the value bound in the current REPL session."
+   "print-level" "Value to bind to `*print-level*` when pretty-printing. Defaults to the value bound in the current REPL session."
+   "print-meta" "Value to bind to `*print-meta*` when pretty-printing. Defaults to the value bound in the current REPL session."
+   "print-right-margin" "Value to bind to `clojure.pprint/*print-right-margin*` when pretty-printing. Defaults to the value bound in the current REPL session."})
+
+(set-descriptor!
+ #'wrap-pprint-fn
+ {:requires #{#'session/session}})
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- pprint-writer
   [{:keys [session transport] :as msg}]
   (#'session/session-out :pprint-out (:id (meta session)) transport))
 
 (defn pprint-reply
-  [{:keys [right-margin session transport] :as msg} response]
+  [{:keys [pprint-fn session transport] :as msg} response]
   (with-open [writer (pprint-writer msg)]
     ;; Binding `*msg*` sets the `:id` slot when printing to an nREPL session
     ;; PrintWriter (as created by `pprint-writer`), which the client requires to
     ;; handle the response correctly.
-    (binding [*msg* msg
-              *out* writer
-              *print-length* (get @session #'*print-length*)
-              *print-level* (get @session #'*print-level*)
-              *print-right-margin* right-margin]
+    (binding [*msg* msg *out* writer]
       (let [value (cljs/response-value msg response)
-            print-fn (if (string? value) println pprint)]
+            print-fn (if (string? value) println pprint-fn)]
         (print-fn value))))
   (transport/send transport (response-for msg :pprint-sentinel {})))
 
@@ -40,7 +88,7 @@
       (.send transport (dissoc response :value)))))
 
 (defn wrap-pprint
-  "Middleware that adds a pretty printing option to the eval op.
+  "Middleware that adds a pretty-printing option to the eval op.
   Passing a non-nil value in the `:pprint` slot will cause eval to call
   clojure.pprint/pprint on its result. The `:right-margin` slot can be used to
   bind `*clojure.pprint/*print-right-margin*` during the evaluation."
@@ -53,8 +101,10 @@
 (set-descriptor!
  #'wrap-pprint
  (cljs/expects-piggieback
-  {:requires #{"clone" #'pr-values}
+  {:requires #{"clone" #'pr-values #'wrap-pprint-fn}
    :expects #{"eval"}
    :handles
    {"pprint-middleware"
-    {:doc "Enhances the `eval` op by pretty printing the evaluation result if a `:pprint` slot is found in the msg map. Not an op by itself."}}}))
+    {:doc "Enhances the `eval` op by adding pretty-printing. Not an op in itself."
+     :optional (merge wrap-pprint-fn-optional-arguments
+                      {"pprint" "If present and non-nil, pretty-print the result of evaluation."})}}}))

--- a/src/cider/nrepl/middleware/pprint.clj
+++ b/src/cider/nrepl/middleware/pprint.clj
@@ -45,10 +45,10 @@
   clojure.pprint/pprint on its result. The `:right-margin` slot can be used to
   bind `*clojure.pprint/*print-right-margin*` during the evaluation."
   [handler]
-  (fn [{:keys [op pprint right-margin] :as msg}]
-    (if (and pprint (= op "eval"))
-      (handler (merge msg {:transport (pprint-transport msg)}))
-      (handler msg))))
+  (fn [{:keys [op pprint] :as msg}]
+    (handler (cond-> msg
+               (and (= op "eval") pprint)
+               (assoc :transport (pprint-transport msg))))))
 
 (set-descriptor!
  #'wrap-pprint

--- a/src/cider/nrepl/middleware/refresh.clj
+++ b/src/cider/nrepl/middleware/refresh.clj
@@ -54,7 +54,7 @@
                     (-> (set (:arglists (meta var)))
                         (contains? []))))
       (throw (IllegalArgumentException.
-              (format "%s is not a single-arity fn" sym))))
+              (format "%s is not a function of no arguments" sym))))
 
     (binding [*msg* msg
               *out* (get @session #'*out*)

--- a/test/clj/cider/nrepl/middleware/pprint_test.clj
+++ b/test/clj/cider/nrepl/middleware/pprint_test.clj
@@ -32,7 +32,7 @@
              (:pprint-out (session/message {:op :eval
                                             :code code
                                             :pprint "true"
-                                            :right-margin 10})))))
+                                            :print-right-margin 10})))))
 
     (testing "wrap-pprint does not escape special characters when printing strings"
       (is (= "abc\ndef\tghi\n"

--- a/test/clj/cider/nrepl/middleware/pprint_test.clj
+++ b/test/clj/cider/nrepl/middleware/pprint_test.clj
@@ -51,4 +51,22 @@
                         {:pprint-sentinel {}}
                         {:pprint-out "[4 5 6]\n"}
                         {:pprint-sentinel {}}
-                        {:status ["done"]}])))))
+                        {:status ["done"]}]))))
+
+  (testing "fipp-pprint works"
+    (let [message {:op :eval
+                   :code "{nil [nil nil nil #{nil} nil nil nil]}"
+                   :pprint "true"
+                   :pprint-fn "cider.nrepl.middleware.pprint/fipp-pprint"
+                   :print-right-margin 10}]
+      (is (= "{nil\n [nil\n  nil\n  nil\n  #{nil}\n  nil\n  nil\n  nil]}\n"
+             (:pprint-out (session/message (dissoc message :pprint-fn)))))
+      (is (= "{nil [nil\n      nil\n      nil\n      #{nil}\n      nil\n      nil\n      nil]}\n"
+             (:pprint-out (session/message message))))))
+
+  (testing "puget-pprint works"
+    (is (= "{:a 1, :b 2, :c 3, :d 4, :e 5}\n"
+           (:pprint-out (session/message {:op :eval
+                                          :code "{:b 2 :e 5 :a 1 :d 4 :c 3}"
+                                          :pprint "true"
+                                          :pprint-fn "cider.nrepl.middleware.pprint/puget-pprint"}))))))

--- a/test/clj/cider/nrepl/middleware/stacktrace_test.clj
+++ b/test/clj/cider/nrepl/middleware/stacktrace_test.clj
@@ -1,5 +1,6 @@
 (ns cider.nrepl.middleware.stacktrace-test
   (:require [cider.nrepl.middleware.stacktrace :refer :all]
+            [clojure.pprint :refer [pprint]]
             [clojure.test :refer :all]))
 
 ;; # Utils
@@ -10,8 +11,7 @@
    (try (eval form)
         (catch Exception e
           e))
-   nil
-   nil))
+   pprint))
 
 (defn stack-frames
   [form]
@@ -104,10 +104,14 @@
 (deftest test-cause-data-pretty-printing
   (testing "print-length"
     (is (= "{:a (0 1 2 ...)}\n"
-           (:data (analyze-cause (ex-info "" {:a (range)}) 3 nil)))))
+           (:data (analyze-cause (ex-info "" {:a (range)}) (fn [object]
+                                                             (binding [*print-length* 3]
+                                                               (clojure.pprint/pprint object))))))))
   (testing "print-level"
     (is (= "{:a {#}}\n"
-           (:data (analyze-cause (ex-info "" {:a {:b {:c {:d {:e nil}}}}}) nil 3)))))
+           (:data (analyze-cause (ex-info "" {:a {:b {:c {:d {:e nil}}}}}) (fn [object]
+                                                                             (binding [*print-level* 3]
+                                                                               (clojure.pprint/pprint object))))))))
   (testing "compilation errors"
     (is (re-find #"Error compiling: .* Unable to resolve symbol: not-defined in this context"
                  (:message (first causes3))))))

--- a/test/cljs/cider/nrepl/middleware/cljs_pprint_test.clj
+++ b/test/cljs/cider/nrepl/middleware/cljs_pprint_test.clj
@@ -11,7 +11,7 @@
            (:pprint-out (session/message {:op :eval
                                           :code "[1 2 3 4 5 6 7 8 9 0]"
                                           :pprint "true"
-                                          :right-margin 10})))))
+                                          :print-right-margin 10})))))
 
   (testing "wrap-pprint does not escape special characters when printing strings"
     (is (= "abc\ndef\tghi\n"


### PR DESCRIPTION
Context: clojure-emacs/cider#1179

This PR adds a new `wrap-pprint-fn` middleware, that accepts the set of all printing-related options that we currently use for the eval/stacktrace/test/refresh middlewares, in addition to a new `pprint-fn` option (which must be the name of the function to be used for printing, e.g. `"clojure.pprint/pprint"`). It then constructs a closure that wraps up all the options and the provided printing function, placing it into the request map (again under the `pprint-fn` key) so that subsequent middlewares can just call the function without having to care about all the different options.

Eventually I'd like to provide some alternative printers to `clojure.pprint/pprint` out-of-the-box, but ATM the main candidates ([fipp](https://github.com/brandonbloom/fipp); [puget](https://github.com/greglook/puget); [aprint](https://github.com/razum2um/aprint)) all require at least Clojure 1.6, so I'm holding off on adding them as dependencies for now.

Two places where we could be using this, but aren't yet:

* In the debugger, we call `stacktrace/analyze-causes` in `eval-with-locals` and it would be a bit awkward to pass `pprint-fn` all the way down the stack... @Malabarba thoughts? Just use a dynamic var maybe?

* In the macroexpansion middleware, we call `clojure.pprint/write` directly - I still need to investigate if it makes sense to allow use of a custom printing fn here.

Note that there's a breaking change here - the `right-margin` option has been renamed to `print-right-margin`, for consistency. cc @laurentpetit @tpope 