### PR TITLE
Track namespace info as part of track-state

### DIFF
--- a/src/cider/nrepl/middleware/track_state.clj
+++ b/src/cider/nrepl/middleware/track_state.clj
@@ -28,9 +28,9 @@
   "Middleware that tracks relevant server info and notifies the client."
   [handler]
   (fn [{:keys [op] :as msg}]
-    (cond
-      (#{"eval" "load-file"} op) (handler (assoc msg :transport (make-transport msg)))
-      :else (handler msg))))
+    (if (#{"eval" "load-file" "refresh" "refresh-all" "refresh-clear" "undef"} op)
+      (handler (assoc msg :transport (make-transport msg)))
+      (handler msg))))
 
 (set-descriptor!
  #'wrap-tracker

--- a/test/clj/cider/nrepl/middleware/track_state_test.clj
+++ b/test/clj/cider/nrepl/middleware/track_state_test.clj
@@ -5,15 +5,69 @@
             [clojure.tools.nrepl.transport :as t])
   (:import clojure.tools.nrepl.transport.Transport))
 
+(def ^:const msg {:session :dummy})
+
 (deftest make-transport
-  (is (instance? Transport (s/make-transport nil)))
-  (is (try (send (s/make-transport nil) 10)
+  (is (instance? Transport (s/make-transport msg)))
+  (is (try (send (s/make-transport msg) 10)
            nil
            (catch Exception e true))))
 
 (deftest assoc-state
-  (is (= (s/assoc-state {} {})
-         {:state {:repl-type :clj}}))
-  (with-redefs [cljs/grab-cljs-env identity]
-    (is (= (s/assoc-state {} {})
-           {:state {:repl-type :cljs}}))))
+  (with-redefs [s/ns-cache (atom {})]
+    (let [{:keys [repl-type changed-namespaces]} (:state (s/assoc-state {} msg))]
+      (is (= repl-type :clj))
+      (is (map? changed-namespaces))
+      (is (> (count changed-namespaces) 100)))
+    ;; Check the caching
+    (let [changed-again (get-in (s/assoc-state {} msg) [:state :changed-namespaces])]
+      (is (map? changed-again))
+      (is (empty? changed-again)))
+    ;; Remove a value
+    (swap! s/ns-cache update-in [:dummy]
+           #(dissoc % (ffirst %)))
+    ;; Check again
+    (let [changed-again (get-in (s/assoc-state {} msg) [:state :changed-namespaces])]
+      (is (= (count changed-again) 1))))
+  ;; Check repl-type :cljs
+  (with-redefs [cljs/grab-cljs-env (constantly true)
+                s/ns-cache (atom {})]
+    (let [{:keys [repl-type changed-namespaces]} (:state (s/assoc-state {} msg))]
+      (is (= repl-type :cljs))
+      (is (map? changed-namespaces)))))
+
+(deftest update-vals
+  (is (= (s/update-vals {1 2 3 4 5 6} inc)
+         {1 3 3 5 5 7}))
+  (is (= (s/update-vals {1 2 3 4 5 6} range)
+         '{5 (0 1 2 3 4 5), 3 (0 1 2 3), 1 (0 1)}))
+  (is (= (s/update-vals {:a :b :c :d :e :f} str)
+         {:e ":f", :c ":d", :a ":b"}))
+  (is (= (s/update-vals {1 2 3 4 5 6} odd?)
+         {1 false 3 false 5 false})))
+
+(deftest filter-core
+  (is (= (s/filter-core {'and #'and, 'b #'map, 'c #'deftest})
+         {'c #'clojure.test/deftest}))
+  (is (-> (find-ns 'clojure.core)
+          ns-interns s/filter-core
+          seq not)))
+
+(deftest relevant-meta
+  (is (= (:macro (s/relevant-meta #'deftest))
+         true))
+  (alter-meta! #'update-vals merge {:indent 1 :cider-instrumented 2 :something-else 3})
+  (is (= (s/relevant-meta #'update-vals)
+         {:cider-instrumented 2, :indent 1, :test (:test (meta #'update-vals))})))
+
+(deftest ns-as-map
+  (alter-meta! #'update-vals
+               merge {:indent 1 :cider-instrumented 2 :something-else 3})
+  (let [{:keys [interns aliases] :as ns} (s/ns-as-map (find-ns 'cider.nrepl.middleware.track-state-test))]
+    (is (> (count ns) 3))
+    (is (> (count interns) 4))
+    (is (= (into #{} (keys (interns 'update-vals)))
+           #{:cider-instrumented :indent :test}))
+    (is (> (count aliases) 2))
+    (is (= (aliases 's)
+           'cider.nrepl.middleware.track-state))))


### PR DESCRIPTION
Goes with https://github.com/clojure-emacs/cider/pull/1301

The track-state middleware now keeps the client informed of loaded
namespaces as well. For each namespace, we transmit a map of:

- All interns (from symbol to the var's metadata). Only select metadata
  keys are transmitted, currently that's:
  - `:indent`
  - `:cider-instrumented`
  - `:macro`
  - `:arglists`
  - `:test`
- All refers not from clojure.core (from symbol to fully-qualified var name)
- All aliases (from symbol to namespace name)