### PR TITLE
Rewrite the namespace part of track-state

### DIFF
--- a/test/clj/cider/nrepl/middleware/track_state_test.clj
+++ b/test/clj/cider/nrepl/middleware/track_state_test.clj
@@ -13,8 +13,12 @@
            nil
            (catch Exception e true))))
 
+(deftest track-ns?
+  (is (not (some s/track-ns? s/jar-namespaces))))
+
 (deftest assoc-state
-  (with-redefs [s/ns-cache (atom {})]
+  (with-redefs [s/ns-cache (atom {})
+                s/track-ns? (constantly true)]
     (let [{:keys [repl-type changed-namespaces]} (:state (s/assoc-state {} msg))]
       (is (= repl-type :clj))
       (is (map? changed-namespaces))
@@ -46,18 +50,18 @@
   (is (= (s/update-vals odd? {1 2 3 4 5 6})
          {1 false 3 false 5 false})))
 
-(deftest filter-core
-  (is (= (s/filter-core {'and #'and, 'b #'map, 'c #'deftest})
-         {'c #'clojure.test/deftest}))
+(deftest filter-core-and-get-meta
+  (is (= (s/filter-core-and-get-meta {'and #'and, 'b #'map, 'c #'deftest})
+         '{c {:macro "true", :arglists "([name & body])"}}))
   (is (-> (find-ns 'clojure.core)
-          ns-interns s/filter-core
+          ns-map s/filter-core-and-get-meta
           seq not)))
 
 (deftest relevant-meta
-  (is (= (:macro (s/relevant-meta #'deftest))
+  (is (= (:macro (s/relevant-meta (meta #'deftest)))
          "true"))
   (alter-meta! #'update-vals merge {:indent 1 :cider-instrumented 2 :something-else 3})
-  (is (= (s/relevant-meta #'update-vals)
+  (is (= (s/relevant-meta (meta #'update-vals))
          {:cider-instrumented "2", :indent "1",
           :test (pr-str (:test (meta #'update-vals)))})))
 
@@ -65,10 +69,26 @@
   (alter-meta! #'update-vals
                merge {:indent 1 :cider-instrumented 2 :something-else 3})
   (let [{:keys [interns aliases] :as ns} (s/ns-as-map (find-ns 'cider.nrepl.middleware.track-state-test))]
-    (is (> (count ns) 3))
-    (is (> (count interns) 4))
+    (is (> (count interns) 5))
+    (is (map? interns))
+    (is (interns 'ns-as-map))
+    (is (:test (interns 'ns-as-map)))
     (is (= (into #{} (keys (interns 'update-vals)))
            #{:cider-instrumented :indent :test}))
     (is (> (count aliases) 2))
     (is (= (aliases 's)
-           'cider.nrepl.middleware.track-state))))
+           'cider.nrepl.middleware.track-state)))
+  (with-redefs [s/track-ns? (constantly nil)]
+    (let [{:keys [interns aliases] :as ns}
+          (s/ns-as-map (find-ns 'cider.nrepl.middleware.track-state-test))]
+      (is interns))))
+
+(deftest calculate-used-aliases
+  (let [nsm {'cider.nrepl.middleware.track-state-test
+             (s/ns-as-map (find-ns 'cider.nrepl.middleware.track-state-test))}]
+    (is (contains? (into #{} (keys (s/calculate-used-aliases nsm nil)))
+                   'cider.nrepl.middleware.track-state))
+    (is (contains? (into #{} (keys (s/calculate-used-aliases nsm {'cider.nrepl.middleware.track-state nil})))
+                   'cider.nrepl.middleware.track-state))
+    (is (contains? (into #{} (keys (s/calculate-used-aliases (assoc nsm 'cider.nrepl.middleware.track-state nil) nil)))
+                   'cider.nrepl.middleware.track-state))))


### PR DESCRIPTION
- Don't build the namespace map ourselves, just use ns-map.
- Don't track changes in namespaces from jar files.
- Since the client still needs to know what's in these jar namespaces,
  we send their info on the first message, but we ONLY do that for
  namespaces that are :require'd by a source namespace. This guarantees
  we only send namespaces that are potentially useful, and reduces the
  amount of garbage we send on the first message

This fixes a lag of about 300ms between receiving eval result and
receiving the "done" status, which translated as a lag on printing the
repl prompt.

This might solve clojure-emacs/cider#1320, depending on the size of
project namespaces, but we should probably still offer a way to disable
it.