### PR TITLE
don't override apple.awt.UIElement system property if explicitly set.

### DIFF
--- a/src/cider/nrepl/middleware/util/java/parser.clj
+++ b/src/cider/nrepl/middleware/util/java/parser.clj
@@ -115,8 +115,10 @@
 ;; The HTML parser and DTD classes are in the `javax.swing` package, and have
 ;; internal references to the `sun.awt.AppContext` class. On Mac OS X, any use
 ;; of this class causes a stray GUI window to pop up. Setting the system
-;; property below prevents this.
-(System/setProperty "apple.awt.UIElement" "true")
+;; property below prevents this. We only set the property if it
+;; hasn't already been explicitly set.
+(when (nil? (System/getProperty "apple.awt.UIElement"))
+  (System/setProperty "apple.awt.UIElement" "true"))
 
 ;; We parse html and emit text in a single pass -- there's no need to build a
 ;; tree. The syntax map defines most of the output format, but a few stateful


### PR DESCRIPTION
Currently, the system property "apple.awt.UIElement" is unconditionally to "true" set right before the system property is used to decided whether or not the application will show an application icon in the osx dock. There is no way to override this behavior when using the repl. This commit only sets "apple.awt.UIElement" to "true" when the property is not already set via jvm flags or otherwise.

I'm working on a swing application where I would actually like the default behavior when apple.awt.UIElement is not set to true or is left unset. Basically, I like being able to command-tab between the GUI I'm working on and emacs where I'm making edits to the GUI.  
 
