### PR TITLE
Extract more detail from compiler exceptions

### DIFF
--- a/src/cider/nrepl/middleware/stacktrace.clj
+++ b/src/cider/nrepl/middleware/stacktrace.clj
@@ -100,11 +100,11 @@
 
 (defn extract-location
   "If the cause is a compiler exception, extract the useful location information
-  from its message and discard the string representation of its inner cause."
+  from its message."
   [{:keys [class] :as cause}]
   (if (= class "clojure.lang.Compiler$CompilerException")
     (update-in cause [:message] str/replace
-               #".* (compiling:)\((.*)\)" "Error $1 $2")
+               #".*?: (.*?), (compiling:)\((.*)\)" "Error $2 $3 $1")
     cause))
 
 ;; CLJS REPLs use :repl-env to store huge amounts of analyzer/compiler state

--- a/test/clj/cider/nrepl/middleware/stacktrace_test.clj
+++ b/test/clj/cider/nrepl/middleware/stacktrace_test.clj
@@ -25,11 +25,13 @@
 (def form1 '(throw (ex-info "oops" {:x 1} (ex-info "cause" {:y 2}))))
 (def form2 '(do (defn oops [] (+ 1 "2"))
                 (oops)))
+(def form3 '(not-defined))
 
 (def frames1 (stack-frames form1))
 (def frames2 (stack-frames form2))
 (def causes1 (causes form1))
 (def causes2 (causes form2))
+(def causes3 (causes form3))
 
 ;; ## Tests
 
@@ -103,4 +105,7 @@
            (:data (analyze-cause (ex-info "" {:a (range)}) 3 nil)))))
   (testing "print-level"
     (is (= "{:a {#}}\n"
-           (:data (analyze-cause (ex-info "" {:a {:b {:c {:d {:e nil}}}}}) nil 3))))))
+           (:data (analyze-cause (ex-info "" {:a {:b {:c {:d {:e nil}}}}}) nil 3)))))
+  (testing "compilation errors"
+    (is (re-find #"Error compiling: .* Unable to resolve symbol: not-defined in this context"
+                 (:message (first causes3))))))


### PR DESCRIPTION
This patch re-introduces the inner 'cause' of compiler exceptions.

These exceptions are not always informative, which may be why they were
hidden in 0a57231f1. For example when the compiler is complaining about
a syntax error, the exception often refers to a line number far from the
actual syntax problem.

However, the exceptions *can* be quite useful, for example when they
complain about an undeclared variable.

This patch re-introduces this additional detail. I'd be equally happy
with completely removing `extract-location`.  The output from the two
approaches is similar, and perhaps less code is better.