### PR TITLE
[Fix #266] Only forward server out to subscribed clients

### DIFF
--- a/test/clj/cider/nrepl/middleware/out_test.clj
+++ b/test/clj/cider/nrepl/middleware/out_test.clj
@@ -9,9 +9,6 @@
 
 (def the-meta {:id (random-str)})
 
-(defn test []
-  {:id (random-str)})
-
 (def msg {:op "eval" :id (random-str)
           :transport 90
           :some-other-key 10
@@ -21,11 +18,11 @@
 
 (deftest maybe-register-session
   (with-redefs [o/tracked-sessions-map (atom {})]
-    (o/maybe-register-session (assoc msg :op "clone"))
-    (is (= @o/tracked-sessions-map {}))
-    (o/maybe-register-session msg)
+    (o/subscribe-session msg)
     (let [{:keys [transport session id some-other-key]} (@o/tracked-sessions-map (:id the-meta))]
       (is (= transport (:transport msg)))
       (is (= session (:session msg)))
       (is (= id (:id msg)))
-      (is (not some-other-key)))))
+      (is (not some-other-key)))
+    (o/unsubscribe-session (:id the-meta))
+    (is (empty? @o/tracked-sessions-map))))


### PR DESCRIPTION
Connected sessions must send a message with an "out-subscribe" op in
order to have server messages forwarded to them. The forwarded outs are then
sent as replies to this message (so it must be able to handle out).