### PR TITLE
Correctly resolve resource full path in Boot projects

### DIFF
--- a/test/clj/cider/nrepl/middleware/info_test.clj
+++ b/test/clj/cider/nrepl/middleware/info_test.clj
@@ -24,6 +24,22 @@
   (is (relative "clojure/core.clj"))
   (is (nil? (relative "notclojure/core.clj"))))
 
+(deftest test-boot-resource-path
+  (let [tmp-dir-name (System/getProperty "java.io.tmpdir")
+        tmp-file-name "boot-test.txt"
+        tmp-file-path (str tmp-dir-name (System/getProperty "file.separator") tmp-file-name)]
+    (spit tmp-file-path "test")
+    (testing "when fake.class.path is not set"
+      (is (not (= (class (file tmp-file-name))
+                  java.net.URL)))
+      (is (= (file tmp-file-name) tmp-file-name)))
+    (testing "when fake.class.path is set"
+      (System/setProperty "fake.class.path" tmp-dir-name)
+      (is (= (class (file tmp-file-name))
+             java.net.URL))
+      (is (= (.getPath (file tmp-file-name))
+             tmp-file-path)))))
+
 (deftype T [])
 
 (deftest test-info


### PR DESCRIPTION
A followup to https://github.com/clojure-emacs/cider/pull/1374

Short summary: when project is using [Boot](https://github.com/boot-clj/boot), the source files are copied to temporary folder and class path points to that folder. This leads to ```cider-find-var``` opening a source file in temp folder instead of an original one.

The original class-path is stored by [Boot](https://github.com/boot-clj/boot) in a system property named ```fake.class.path``` (see https://github.com/boot-clj/boot/issues/249).

This fix checks if system property ```fake.class.path``` exists and if yes, assumes that ```Boot``` is used and resolves resources through a class-loader that knows about original paths.

I've tested it for my project and it works. I don't know how to cover this with unit tests, though. Any ideas?