### PR TITLE
Don't inject the middleware if its version requirements aren't met

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -45,7 +45,9 @@
                                                      cider.nrepl.middleware.trace/wrap-trace
                                                      cider.nrepl.middleware.track-state/wrap-tracker
                                                      cider.nrepl.middleware.undef/wrap-undef]}
-                   :dependencies [[org.clojure/tools.nrepl "0.2.12"]]}
+                   :dependencies [[org.clojure/tools.nrepl "0.2.12"]
+                                  ;; For developing the Leiningen plugin.
+                                  [leiningen-core "2.5.3"]]}
 
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0-RC4"]]}

--- a/src/cider_nrepl/plugin.clj
+++ b/src/cider_nrepl/plugin.clj
@@ -1,6 +1,6 @@
 (ns cider-nrepl.plugin
   (:require [clojure.java.io :as io]
-            [cider.nrepl :refer (cider-middleware)]))
+            [leiningen.core.main :as lein]))
 
 ;; Keep in sync with VERSION-FORM in project.clj
 (defn- version
@@ -15,11 +15,26 @@
     v))
 
 (defn middleware
-  [project]
-  (-> project
-      (update-in [:dependencies]
-                 (fnil into [])
-                 [['cider/cider-nrepl (version)]])
-      (update-in [:repl-options :nrepl-middleware]
-                 (fnil into [])
-                 cider-middleware)))
+  [{:keys [dependencies] :as project}]
+  (let [clojure-version-ok? (->> dependencies
+                                 (some (fn [[id version & {:as opts}]]
+                                         (and (= id 'org.clojure/clojure)
+                                              (lein/version-satisfies? version "1.7.0")))))
+        lein-version-ok? (lein/version-satisfies? (lein/leiningen-version) "2.5.2")]
+
+    (when-not clojure-version-ok?
+      (lein/warn "Warning: cider-nrepl requires Clojure 1.7 or greater."))
+    (when-not lein-version-ok?
+      (lein/warn "Warning: cider-nrepl requires Leiningen 2.5.2 or greater."))
+    (when-not (and clojure-version-ok? lein-version-ok?)
+      (lein/warn "Warning: cider-nrepl will not be included in your project."))
+
+    (cond-> project
+      (and clojure-version-ok? lein-version-ok?)
+      (-> (update-in [:dependencies]
+                     (fnil into [])
+                     [['cider/cider-nrepl (version)]])
+          (update-in [:repl-options :nrepl-middleware]
+                     (fnil into [])
+                     (do (require 'cider.nrepl)
+                         @(resolve 'cider.nrepl/cider-middleware)))))))


### PR DESCRIPTION
Fixes #277.

The REPL will still start, and the client will warn about all the missing ops when it connects. Client-side, we should probably also check the Clojure version (using the `describe` op response), and perhaps sniff the `nrepl-server` buffer for the Leiningen warning. Then we can show a more meaningful warning in the REPL, since I don't think people tend to look at `nrepl-server` that often. That obviously only applies to `cider-jack-in` users - hopefully those connecting to a REPL running at the terminal will see it there :-).