### PR TITLE
Add print method and tests for atoms

### DIFF
--- a/src/cider/nrepl/print_method.clj
+++ b/src/cider/nrepl/print_method.clj
@@ -1,6 +1,6 @@
 (ns cider.nrepl.print-method
   (:require [clojure.string :as s])
-  (:import [clojure.lang AFunction MultiFn Namespace]
+  (:import [clojure.lang AFunction Atom MultiFn Namespace]
            java.io.Writer))
 
 ;; Extending `print-method` defined in clojure.core, to provide
@@ -24,6 +24,13 @@
      (if *pretty-objects*
        (do ~@(map #(list '.write 'w %) strings))
        (#'clojure.core/print-object ~arg ~'w))))
+
+;;; Atoms
+;; Ex: #atom[{:foo :bar} 0x54274a2b]
+(def-print-method Atom c
+  "#atom["
+  (print-str @c)
+  (format " 0x%x]" (System/identityHashCode c)))
 
 ;;; Function objects
 ;; Ex: #function[cider.nrepl.print-method/multifn-name]

--- a/test/clj/cider/nrepl/print_method_test.clj
+++ b/test/clj/cider/nrepl/print_method_test.clj
@@ -5,6 +5,12 @@
 
 (defn dummy-fn [o])
 
+(deftest print-atoms
+  (is (re-find #"#atom\[ 0x[a-z0-9]+\]" (pr-str (atom ""))))
+  (is (re-find #"#atom\[nil 0x[a-z0-9]+\]" (pr-str (atom nil))))
+  (is (re-find #"#atom\[\{:foo :bar\} 0x[a-z0-9]+\]" (pr-str (atom {:foo :bar}))))
+  (is (re-find #"#atom\[#function\[clojure.core/\+\] 0x[a-z0-9]+\]" (pr-str (atom +)))))
+
 (deftest print-functions
   (are [f s] (= (pr-str f) s)
     print-functions "#function[cider.nrepl.print-method-test/print-functions]"


### PR DESCRIPTION
Tests pass.  I've pasted my comment from the issue thread below for reference.

Current print-method for an Atom is here:
https://github.com/clojure/clojure/blob/bc186508ab98514780efbbddb002bf6fd2938aee/src/clj/clojure/core_print.clj#L387-L408

Which looks like:
```
=> (println (atom {:foo :bar}))
#object[clojure.lang.Atom 0x54274a2b {:status :ready, :val {:foo :bar}}]
```
It looks like ':status' will always be ':ready' for an atom since atoms do not implement the "IPending" interface.  I propose we drop this information in the new print method since it's not useful.  New print output looks like the following:

```
=>(println (atom "{:foo :bar}"))
#atom[{:foo :bar} 0x54274a2b]
```

The identity hash code is moved to the end to keep it consistent with the print output for multifn.