### PR TITLE
Use 'pr-str' for getting a derefed atom string.

### DIFF
--- a/src/cider/nrepl/print_method.clj
+++ b/src/cider/nrepl/print_method.clj
@@ -29,7 +29,7 @@
 ;; Ex: #atom[{:foo :bar} 0x54274a2b]
 (def-print-method Atom c
   "#atom["
-  (print-str @c)
+  (pr-str @c)
   (format " 0x%x]" (System/identityHashCode c)))
 
 ;;; Function objects

--- a/test/clj/cider/nrepl/print_method_test.clj
+++ b/test/clj/cider/nrepl/print_method_test.clj
@@ -6,7 +6,7 @@
 (defn dummy-fn [o])
 
 (deftest print-atoms
-  (is (re-find #"#atom\[ 0x[a-z0-9]+\]" (pr-str (atom ""))))
+  (is (re-find #"#atom\[\"\" 0x[a-z0-9]+\]" (pr-str (atom ""))))
   (is (re-find #"#atom\[nil 0x[a-z0-9]+\]" (pr-str (atom nil))))
   (is (re-find #"#atom\[\{:foo :bar\} 0x[a-z0-9]+\]" (pr-str (atom {:foo :bar}))))
   (is (re-find #"#atom\[#function\[clojure.core/\+\] 0x[a-z0-9]+\]" (pr-str (atom +)))))


### PR DESCRIPTION
Previously, atoms containing strings would print incorrectly.  This way atom with strings will print correctly with both 'pr' and 'print'