### PR TITLE
New feature: Enlighten

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -30,6 +30,7 @@
                                                      cider.nrepl.middleware.classpath/wrap-classpath
                                                      cider.nrepl.middleware.complete/wrap-complete
                                                      cider.nrepl.middleware.debug/wrap-debug
+                                                     cider.nrepl.middleware.enlighten/wrap-enlighten
                                                      cider.nrepl.middleware.format/wrap-format
                                                      cider.nrepl.middleware.info/wrap-info
                                                      cider.nrepl.middleware.inspect/wrap-inspect

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -5,6 +5,7 @@
             [cider.nrepl.middleware.classpath]
             [cider.nrepl.middleware.complete]
             [cider.nrepl.middleware.debug]
+            [cider.nrepl.middleware.enlighten]
             [cider.nrepl.middleware.format]
             [cider.nrepl.middleware.info]
             [cider.nrepl.middleware.inspect]
@@ -26,6 +27,7 @@
     cider.nrepl.middleware.classpath/wrap-classpath
     cider.nrepl.middleware.complete/wrap-complete
     cider.nrepl.middleware.debug/wrap-debug
+    cider.nrepl.middleware.enlighten/wrap-enlighten
     cider.nrepl.middleware.format/wrap-format
     cider.nrepl.middleware.info/wrap-info
     cider.nrepl.middleware.inspect/wrap-inspect

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -410,7 +410,7 @@
   (let [has-debug? (atom false)
         fake-reader (fn [x] (reset! has-debug? true) nil)]
     (binding [*data-readers* (->> (repeat fake-reader)
-                                  (interleave '[dbg break])
+                                  (interleave '[dbg break light])
                                   (apply assoc *data-readers*))]
       (try
         (read-string code)

--- a/src/cider/nrepl/middleware/enlighten.clj
+++ b/src/cider/nrepl/middleware/enlighten.clj
@@ -1,0 +1,92 @@
+(ns cider.nrepl.middleware.enlighten
+  "Instrument user code to \"light up\" when it runs.
+  The instrumented code will report the value of local variables and
+  report its return value.
+  Implemented as an extension of the debugger."
+  {:author "Artur Malabarba"}
+  (:require [cider.nrepl.middleware.debug :as d]
+            [cider.nrepl.middleware.util.instrument :as ins]
+            [cider.nrepl.middleware.util.meta :as m]
+            [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
+            [clojure.walk :as walk]))
+
+(defn pr-very-short [val]
+  (binding [*print-length* 3, *print-level* 2]
+    (pr-str val)))
+
+(defn send-if-local
+  "If locals contains sym, send its value over the debug channel.
+  The value is added to `extras` under :debug-value, and `extras` is
+  sent over the debug channel with the :enlighten status."
+  [sym extras locals]
+  (when (contains? locals sym)
+    ;; Enlightened values are inlined, so let's keep them short.
+    (->> (locals sym) pr-very-short
+         (assoc extras :status :enlighten
+                :erase-previous :true
+                :debug-value)
+         d/debugger-send)))
+
+(defn wrap-function-form
+  "Wrap a form representing a function/macro/special-form call.
+  Return an equivalent form, instrumented to work with enlighten.
+
+  Currently this only instruments forms that could run several times
+  in a single evaluation. This is necessary so that the client can
+  clean-up overlays from previous evaluations."
+  [[head & args :as form] extras]
+  (let [erase `(d/with-debug-bindings ~extras
+                 (d/debugger-send (assoc d/*extras* :status :enlighten
+                                         :erase-previous :true)))]
+    (case head
+      ;; This is still compile-time, so return a form, not a function.
+      fn* `#(do ~erase (apply ~form %&))
+      ;; `defn` expands to `(def name (fn ...))`.
+      def (let [[name val] args]
+            (if (and (seq? val) (= 'fn* (first val)))
+              (list head name
+                    `#(do ~erase
+                          (let [out# (apply ~val %&)]
+                            ;; The only non-symbol form we enlighten
+                            ;; is the `defn`.
+                            (d/with-debug-bindings ~extras
+                              (->> (pr-very-short out#)
+                                   (assoc d/*extras* :status :enlighten :debug-value)
+                                   d/debugger-send))
+                            out#)))
+              form))
+      ;; Ensure that any `recur`s remain in the tail position.
+      loop* (list* head (first args) erase (rest args))
+      ;; Else.
+      form)))
+
+(defmacro light-form
+  "Return the result of form, and maybe enlighten it."
+  [form extras original-form]
+  (cond
+    (symbol? original-form) `(d/with-debug-bindings ~extras
+                               (send-if-local '~original-form d/*extras* d/*locals*)
+                               ~form)
+    (seq? form) (wrap-function-form form extras)
+    :else form))
+
+(defn light-reader [form]
+  (ins/tag-form-recursively form #'light-form))
+
+;;; Middleware
+(defn eval-with-enlighten
+  "Like `eval`, but also enlighten code."
+  [form]
+  (eval (ins/instrument-tagged-code (light-reader form))))
+
+(defn wrap-enlighten [h]
+  (fn [{:keys [op enlighten] :as msg}]
+    (if (and (= op "eval") enlighten)
+      (h (assoc msg :eval "cider.nrepl.middleware.enlighten/eval-with-enlighten"))
+      (h msg))))
+
+(set-descriptor!
+ #'wrap-enlighten
+ ;; We need to come before wrap-debug, so that the debugger can still
+ ;; work if enlighten-mode is on.
+ {:expects #{"eval" #'d/wrap-debug}})

--- a/src/data_readers.clj
+++ b/src/data_readers.clj
@@ -1,2 +1,3 @@
 {dbg cider.nrepl.middleware.debug/debug-reader
- break cider.nrepl.middleware.debug/breakpoint-reader}
+ break cider.nrepl.middleware.debug/breakpoint-reader
+ light cider.nrepl.middleware.enlighten/light-reader}


### PR DESCRIPTION
This adds a middleware that instruments code in “eval” ops that provide an “enlighten” key. When the code is evaluated, information is sent through the debug channel regarding value of local variables and return value of functions.

In addition to the “enlighten” key (which is made available by Emacs as a minor mode), this feature can also be accessed by adding `#light` before a top-level sexp.