### PR TITLE
Rewrote inspect-value as a multimethod so developers can write methods for it. 

### DIFF
--- a/src/cider/nrepl/middleware/util/inspect.clj
+++ b/src/cider/nrepl/middleware/util/inspect.clj
@@ -85,48 +85,64 @@
        s/join
        (format fmt)))
 
-(defn inspect-value
-  ([value]
-   (cond (atom? value) (pr-str value)
+(defn value-types [value]
+  (cond
+    (atom? value) :atom
+    (and (instance? Seqable value) (empty? value)) :seq-empty
+    (and (map? value) (< (count value) 5))         :map
+    (map? value)                                   :map-long
+    (and (vector? value) (< (count value) 5))      :vector
+    (vector? value)                                :vector-long
+    (and (list? value) (< (count value) 5))        :list
+    (list? value)                                  :list-long
+    (and (set? value) (< (count value) 5))         :set
+    (set? value)                                   :set-long
+    :else (or (:inspector-tag (meta value))
+              (type value))))
 
-         (and (instance? Seqable value) (empty? value))
-         (pr-str value)
+(defmulti inspect-value #'value-types)
 
-         (and (map? value) (< (count value) 5))
-         (->> value
-              (map (fn [[k v]]
-                     (str (inspect-value k) " " (inspect-value v))))
-              (interpose ", ")
-              s/join
-              (format "{ %s }"))
+(defmethod inspect-value :atom [value]
+  (pr-str value))
 
-         (map? value)
-         (str "{ " (ffirst value) " "
-              (inspect-value (second (first value))) ", ... }")
+(defmethod inspect-value :seq-empty [value]
+  (pr-str value))
 
-         (and (vector? value) (< (count value) 5))
-         (safe-pr-seq value "[ %s ]")
+(defmethod inspect-value :map [value]
+  (->> value
+       (map (fn [[k v]]
+              (str (inspect-value k) " " (inspect-value v))))
+       (interpose ", ")
+       s/join
+       (format "{ %s }")))
 
-         (vector? value)
-         (safe-pr-seq (take 5 value) "[ %s ... ]")
+(defmethod inspect-value :map-long [value]
+  (str "{ " (ffirst value) " "
+       (inspect-value (second (first value))) ", ... }"))
 
-         (and (list? value) (< (count value) 5))
-         (safe-pr-seq value "( %s )")
+(defmethod inspect-value :vector [value]
+  (safe-pr-seq value "[ %s ]"))
 
-         (list? value)
-         (safe-pr-seq (take 5 value) "( %s ... )")
+(defmethod inspect-value :vector-long [value]
+  (safe-pr-seq (take 5 value) "[ %s ... ]"))
 
-         (and (set? value) (< (count value) 5))
-         (safe-pr-seq value "#{ %s }")
+(defmethod inspect-value :list [value]
+  (safe-pr-seq value "( %s )"))
 
-         (set? value)
-         (safe-pr-seq (take 5 value) "#{ %s ... }")
+(defmethod inspect-value :list-long [value]
+  (safe-pr-seq (take 5 value) "( %s ... )"))
 
-         (instance? java.lang.Class value)
-         (pr-str value)
+(defmethod inspect-value :set [value]  
+  (safe-pr-seq value "#{ %s }"))
 
-         :default
-         (str value))))
+(defmethod inspect-value :set-long [value]  
+  (safe-pr-seq (take 5 value) "#{ %s ... }"))
+
+(defmethod inspect-value java.lang.Class [value]  
+  (pr-str value))
+
+(defmethod inspect-value :default [value]  
+  (str value))
 
 (defn render-onto [inspector coll]
   (update-in inspector [:rendered] concat coll))
@@ -370,3 +386,5 @@
 (defn inspect-print [x]
   (doseq [component (:rendered (inspect-render (fresh) x))]
     (inspect-print-component component)))
+
+

--- a/src/cider/nrepl/middleware/util/inspect.clj
+++ b/src/cider/nrepl/middleware/util/inspect.clj
@@ -386,5 +386,3 @@
 (defn inspect-print [x]
   (doseq [component (:rendered (inspect-render (fresh) x))]
     (inspect-print-component component)))
-
-

--- a/test/clj/cider/nrepl/middleware/util/inspect_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/inspect_test.clj
@@ -1,0 +1,27 @@
+(ns cider.nrepl.middleware.util.inspect-test
+  (:require [cider.nrepl.middleware.util.inspect :refer (inspect-value)]
+            [clojure.test :refer :all]))
+
+(defprotocol IMyTestType
+   (^String get-name [this]))
+
+(deftype MyTestType [name]
+  IMyTestType
+  (get-name [this] name))
+
+(defmethod inspect-value MyTestType [obj]
+  (str "#<MyTestType " (get-name obj) ">"))
+
+(deftest inspect-val
+  (testing "inspect-value print types"
+    (are [result form] (= result (inspect-value form))
+      "1" 1
+      "\"2\"" "2"
+      ":foo" :foo
+      ":abc/def" :abc/def
+      "( :a :b :c )" '(:a :b :c)
+      "[ 1 2 3 ]" [1 2 3]
+      "{ :a 1, :b 2 }" {:a 1 :b 2}
+      "#{ :a }" #{:a}
+      "#<MyTestType test1>" (MyTestType. "test1"))))
+


### PR DESCRIPTION
I rewrote inspect-value as a multimethod so that developers can write methods for it. inspect is already multimethods, but inspect-value was an ordinary function. I have a print-method on a type I defined. With this patch, it uses it, even in collections displayed in the inspector.

