### PR TITLE
Add error handling for classpath op

### DIFF
--- a/src/cider/nrepl/middleware/classpath.clj
+++ b/src/cider/nrepl/middleware/classpath.clj
@@ -2,18 +2,24 @@
   (:require [clojure.java.classpath :as cp]
             [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
             [clojure.tools.nrepl.misc :refer [response-for]]
-            [clojure.tools.nrepl.transport :as transport]))
+            [clojure.tools.nrepl.transport :as transport]
+            [cider.nrepl.middleware.util.misc :as u]))
 
 (defn classpath []
   (map str (cp/classpath)))
 
 (defn classpath-reply
   [{:keys [transport] :as msg}]
-  (transport/send
-   transport
-   (response-for msg
-                 :classpath (classpath)
-                 :status :done)))
+  (try
+    (transport/send
+     transport
+     (response-for msg
+                   :classpath (classpath)
+                   :status :done))
+    (catch Exception e
+      (transport/send
+       transport
+       (response-for msg (u/err-info e :classpath-error))))))
 
 (defn wrap-classpath
   "Middleware that provides the java classpath."

--- a/test/clj/cider/nrepl/middleware/classpath_test.clj
+++ b/test/clj/cider/nrepl/middleware/classpath_test.clj
@@ -1,9 +1,21 @@
 (ns cider.nrepl.middleware.classpath-test
-  (:require [cider.nrepl.middleware.classpath :refer :all]
-            [cider.nrepl.test-transport :refer :all]
+  (:require [cider.nrepl.test-session :as session]
+            [cider.nrepl.middleware.classpath :as cp]
             [clojure.test :refer :all]))
 
-(deftest test-classpath-op
-  (let [transport (test-transport)]
-    (classpath-reply {:transport transport})
-    (is (= (messages transport) [{:classpath (classpath) :status #{:done}}]))))
+(use-fixtures :each session/session-fixture)
+(deftest integration-test
+  (let [response   (session/message {:op "classpath"})
+        classpaths (:classpath response)]
+    (is (= (:status response) #{"done"}))
+    (is (> (count classpaths) 1))
+    (is (every? string? classpaths))
+    (is (some #(re-find #".*clojure-.*jar" %) classpaths))))
+
+(deftest error-handling
+  (with-redefs [cp/classpath (fn [] (throw (Exception. "cp error")))]
+    (let [response   (session/message {:op "classpath"})]
+      (is (= (:status response) #{"done" "classpath-error"}))
+      (is (.startsWith (:err response) "java.lang.Exception: cp error"))
+      (is (= (:ex response) "class java.lang.Exception")))))
+


### PR DESCRIPTION
Wraps  transport with a try/catch block and returns an error
message if there's a problem with getting the classpath. Added
tests for this as well.