### PR TITLE
multimethod for inspect-value - second try

### DIFF
--- a/test/clj/cider/nrepl/middleware/util/inspect_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/inspect_test.clj
@@ -1,0 +1,26 @@
+(ns cider.nrepl.middleware.util.inspect-test
+  (:require [cider.nrepl.middleware.util.inspect :refer (inspect-value)]
+            [clojure.test :refer :all]))
+
+(defprotocol IMyTestType
+   (^String get-name [this]))
+
+(deftype MyTestType [name]
+  IMyTestType
+  (get-name [this] name))
+
+(defmethod inspect-value MyTestType [obj]
+  (str "#<MyTestType " (get-name obj) ">"))
+
+(deftest inspect-val
+  (testing "inspect-value print types"
+    (are [result form] (= result (inspect-value form))
+      "1" 1
+      "\"2\"" "2"
+      ":foo" :foo
+      ":abc/def" :abc/def
+      "( :a :b :c )" '(:a :b :c)
+      "[ 1 2 3 ]" [1 2 3]
+      "{ :a 1, :b 2 }" {:a 1 :b 2}
+      "#{ :a }" #{:a}
+      "#<MyTestType test1>" (MyTestType. "test1"))))


### PR DESCRIPTION
This addresses the same issue as my first botched pull request: I defined inspect-value as a multimethod so that users could write methods for it.

I am still a total klutz with git. The rebase looked OK, but I don't think I understood the issue with "fast forwarding." Thus I found it easier to start over. My apologies.