### PR TITLE
Add tests for info middleware and small correction

### DIFF
--- a/src/cider/nrepl/middleware/info.clj
+++ b/src/cider/nrepl/middleware/info.clj
@@ -221,8 +221,8 @@
   [info]
   (if-let [candidates (:candidates info)]
     (assoc info :candidates
-           (into {} (for [[k v] candidates]
-                      [k (format-response v)])))
+           (zipmap (keys candidates)
+                   (->> (vals candidates) (map format-response))))
     info))
 
 (defn blacklist
@@ -236,7 +236,7 @@
   (when info
     (-> info
         (merge (when-let [ns (:ns info)]
-                 (:ns (str ns)))
+                 {:ns (str ns)})
                (when-let [args (:arglists info)]
                  {:arglists-str (pr-str args)})
                (when-let [forms (:forms info)]


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done:

- [x ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x ] You've added tests to cover your change(s)
- [x ] All tests are passing
- [x ] The new code is not generating reflection warnings
- [n/a ] You've updated the readme (if adding/changing middleware)

Thanks!

Added coverage tests for the info middleware to get 100% coverage. There
are some TODO's listed in the test code since I wasn't clear on the
precise intent of certain methods.

There was a small correction made to the format-response function (the
stringified namespace wasn't merged into the response map where it
should have been, but no bug resulted since the stringified namespace
was added in subsequent steps anyway).

Slightly changed the format-nested function from an explicit
for loop since it was difficult to test 100% through the macro generated `for` code. The
new code should be equivelent to the old but it looks a bit clunkier.