### PR TITLE
Force step out

### DIFF
--- a/test/clj/cider/nrepl/middleware/debug_test.clj
+++ b/test/clj/cider/nrepl/middleware/debug_test.clj
@@ -39,7 +39,7 @@
     (is (not (#'d/skip-breaks? [2 2 1])))
 
     (let [code "(foo (bar blah x))"]
-      (#'d/skip-breaks! :deeper [1 2] code)
+      (#'d/skip-breaks! :deeper [1 2] code nil)
       (binding [d/*extras* {:code code}]
         (is (#'d/skip-breaks? []))
         (is (not (#'d/skip-breaks? [1 2])))


### PR DESCRIPTION
NOTE: Depends on https://github.com/clojure-emacs/cider-nrepl/pull/311

Add optional force parameter to :out and :here ops.

When an `:out` or `:here` operation jumps past calls to other
instrumented functions, the debugger will normally stop in those
functions.

Passing a truthy `force` parameter to one of these ops will cause the
debugger to skip all breaks outside of the currently debugged form,
effectively forcing it to immediately step to the location specified in the 
`:out` or `:here` operation.
