### PR TITLE
[c.n.m.u.inspect] Treat infinite sequences as lists

### DIFF
--- a/src/cider/nrepl/middleware/util/inspect.clj
+++ b/src/cider/nrepl/middleware/util/inspect.clj
@@ -93,8 +93,9 @@
     (map? value)                                   :map-long
     (and (vector? value) (< (count value) 5))      :vector
     (vector? value)                                :vector-long
-    (and (list? value) (< (count value) 5))        :list
-    (list? value)                                  :list-long
+    (and (seq? value) (not (counted? value)))      :lazy-seq
+    (and (seq? value) (< (count value) 5))         :list
+    (seq? value)                                   :list-long
     (and (set? value) (< (count value) 5))         :set
     (set? value)                                   :set-long
     :else (or (:inspector-tag (meta value))
@@ -125,6 +126,12 @@
 
 (defmethod inspect-value :vector-long [value]
   (safe-pr-seq (take 5 value) "[ %s ... ]"))
+
+(defmethod inspect-value :lazy-seq [value]
+  (let [first-six (take 6 value)]
+    (if (= (count first-six) 6)
+      (safe-pr-seq (take 5 value) "( %s ... )")
+      (safe-pr-seq first-six "( %s )"))))
 
 (defmethod inspect-value :list [value]
   (safe-pr-seq value "( %s )"))

--- a/test/clj/cider/nrepl/middleware/util/inspect_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/inspect_test.clj
@@ -23,4 +23,7 @@
       "[ 1 2 3 ]" [1 2 3]
       "{ :a 1, :b 2 }" {:a 1 :b 2}
       "#{ :a }" #{:a}
+      "( 1 1 1 1 1 ... )" (repeat 1)
+      "[ ( 1 1 1 1 1 ... ) ]" [(repeat 1)]
+      "( 1 2 3 )" (lazy-seq '(1 2 3))
       "#<MyTestType test1>" (MyTestType. "test1"))))


### PR DESCRIPTION
This should hopefully fix clojure-emacs/cider#1602.

An infinite syntax is not a `list?`. Neither are Cons cells, and some other things. `sequential?` predicate covers all of them.