### PR TITLE
Fix Javadoc URLs for Java 1.8

### DIFF
--- a/src/cider/nrepl/middleware/util/java.clj
+++ b/src/cider/nrepl/middleware/util/java.clj
@@ -75,7 +75,10 @@
   ([class member argtypes]
    (str (javadoc-url class) "#" member
         (when argtypes
-          (str "(" (str/join ",%20" argtypes) ")")))))
+          (if (< (Integer/parseInt util/java-api-version) 8)
+            ;; Pre JDK 1.8 vs Post JDK 1.8 Javadoc URL style
+            (str "(" (str/join ",%20" argtypes) ")")
+            (str "-" (str/join "-" (map #(str/replace % #"\[\]" ":A") argtypes)) "-"))))))
 
 ;;; ## Class Metadata Assembly
 ;; We construct metadata at the class level, first using `reflect-info` to

--- a/test/clj/cider/nrepl/middleware/info_test.clj
+++ b/test/clj/cider/nrepl/middleware/info_test.clj
@@ -16,6 +16,21 @@
   [x]
   (:resource (info/file-info x)))
 
+(deftest test-javadoc-url
+  (testing "java 1.7"
+    (is (= "http://docs.oracle.com/javase/7/docs/api/java/lang/StringBuilder.html#charAt(int)"
+           (with-redefs [util/java-api-version "7"]
+             (-> (info/info-java 'java.lang.StringBuilder 'charAt)
+                 (info/format-response)
+                 (get "javadoc"))))))
+
+  (testing "java 1.8"
+    (is (= "http://docs.oracle.com/javase/8/docs/api/java/lang/StringBuilder.html#charAt-int-"
+           (with-redefs [util/java-api-version "8"]
+             (-> (info/info-java 'java.lang.StringBuilder 'charAt)
+                 (info/format-response)
+                 (get "javadoc")))))))
+
 (deftest test-resource-path
   (is (= (class (file (subs (str (clojure.java.io/resource "clojure/core.clj")) 4)))
          java.net.URL))

--- a/test/clj/cider/nrepl/middleware/util/java_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/java_test.clj
@@ -1,5 +1,7 @@
 (ns cider.nrepl.middleware.util.java-test
   (:require [cider.nrepl.middleware.util.java :refer :all]
+            [cider.nrepl.middleware.util.misc :refer [java-api-version]]
+            [clojure.string :as str]
             [clojure.test :refer :all]
             [clojure.java.io :as io]))
 
@@ -125,25 +127,49 @@
       (is (= (:javadoc (class-info 'java.io.Closeable))
              "java/io/Closeable.html")))
 
-    (testing "for a member"
-      (testing "with no args"
-        (is (= (:javadoc (member-info 'java.util.Random 'nextLong))
-               "java/util/Random.html#nextLong()")))
-      (testing "with primitive args"
-        (is (= (:javadoc (member-info 'java.util.Random 'setSeed))
-               "java/util/Random.html#setSeed(long)")))
-      (testing "with object args"
-        (is (= (:javadoc (member-info 'java.lang.String 'contains))
-               "java/lang/String.html#contains(java.lang.CharSequence)")))
-      (testing "with array args"
-        (is (= (:javadoc (member-info 'java.lang.Thread 'enumerate))
-               "java/lang/Thread.html#enumerate(java.lang.Thread[])")))
-      (testing "with multiple args"
-        (is (= (:javadoc (member-info 'java.util.ArrayList 'subList))
-               "java/util/ArrayList.html#subList(int,%20int)")))
-      (testing "with generic type erasure"
-        (is (= (:javadoc (member-info 'java.util.Hashtable 'putAll))
-               "java/util/Hashtable.html#putAll(java.util.Map)"))))))
+    (let [java-version (Integer/parseInt java-api-version)]
+      (if (< java-version 8)
+        ;;Testing for pre-JDK 1.8 URLs
+        (testing "for a member"
+          (testing "with no args"
+            (is (= (:javadoc (member-info 'java.util.Random 'nextLong))
+                   "java/util/Random.html#nextLong()")))
+          (testing "with primitive args"
+            (is (= (:javadoc (member-info 'java.util.Random 'setSeed))
+                   "java/util/Random.html#setSeed(long)")))
+          (testing "with object args"
+            (is (= (:javadoc (member-info 'java.lang.String 'contains))
+                   "java/lang/String.html#contains(java.lang.CharSequence)")))
+          (testing "with array args"
+            (is (= (:javadoc (member-info 'java.lang.Thread 'enumerate))
+                   "java/lang/Thread.html#enumerate(java.lang.Thread[])")))
+          (testing "with multiple args"
+            (is (= (:javadoc (member-info 'java.util.ArrayList 'subList))
+                   "java/util/ArrayList.html#subList(int,%20int)")))
+          (testing "with generic type erasure"
+            (is (= (:javadoc (member-info 'java.util.Hashtable 'putAll))
+                   "java/util/Hashtable.html#putAll(java.util.Map)"))))
+
+        ;;Testing for post-JDK 1.8 URLs
+        (testing "for a member"
+          (testing "with no args"
+            (is (= (:javadoc (member-info 'java.util.Random 'nextLong))
+                   "java/util/Random.html#nextLong--")))
+          (testing "with primitive args"
+            (is (= (:javadoc (member-info 'java.util.Random 'setSeed))
+                   "java/util/Random.html#setSeed-long-")))
+          (testing "with object args"
+            (is (= (:javadoc (member-info 'java.lang.String 'contains))
+                   "java/lang/String.html#contains-java.lang.CharSequence-")))
+          (testing "with array args"
+            (is (= (:javadoc (member-info 'java.lang.Thread 'enumerate))
+                   "java/lang/Thread.html#enumerate-java.lang.Thread:A-")))
+          (testing "with multiple args"
+            (is (= (:javadoc (member-info 'java.util.ArrayList 'subList))
+                   "java/util/ArrayList.html#subList-int-int-")))
+          (testing "with generic type erasure"
+            (is (= (:javadoc (member-info 'java.util.Hashtable 'putAll))
+                   "java/util/Hashtable.html#putAll-java.util.Map-"))))))))
 
 (deftest test-class-resolution
   (let [ns (ns-name *ns*)]


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the readme (if adding/changing middleware)

Thanks!

An issue where the URLs for Javadoc in Java 1.8 has a different format
than prior Java version, namely, parenthesis surrounding argument lists
have been changed to dashes. Added tests as well.