### PR TITLE
Include cider-nrepl anyway when clj is excluded

### DIFF
--- a/src/cider_nrepl/plugin.clj
+++ b/src/cider_nrepl/plugin.clj
@@ -15,21 +15,34 @@
     v))
 
 (defn middleware
-  [{:keys [dependencies] :as project}]
-  (let [lein-version-ok? (lein/version-satisfies? (lein/leiningen-version) "2.5.2")
-        clojure-version (->> dependencies
-                             (some (fn [[id version & _]]
-                                     (when (= id 'org.clojure/clojure)
-                                       version))))
-        clojure-version-ok? (if (nil? clojure-version)
-                              ;; Lein 2.5.2+ uses Clojure 1.7 by default
-                              lein-version-ok?
-                              (lein/version-satisfies? clojure-version "1.7.0"))]
+  [{:keys [dependencies exclusions] :as project}]
+  (let [lein-version-ok?    (lein/version-satisfies? (lein/leiningen-version) "2.5.2")
+        clojure-excluded?   (some #(= % 'org.clojure/clojure) exclusions)
+        clojure-version     (when-not clojure-excluded?
+                              (->> dependencies
+                                   (some (fn [[id version & _]]
+                                           (when (= id 'org.clojure/clojure)
+                                             version)))))
+        clojure-version-ok? (cond clojure-excluded?
+                                  ;; In this case the onus is on the user. A warning will be emitted
+                                  ;; later, but we assume that the user will provide an appropriate
+                                  ;; implementation.
+                                  ,,true
+
+                                  (nil? clojure-version)
+                                  ;; Lein 2.5.2+ uses Clojure 1.7 by default, which would be OK.
+                                  ,,lein-version-ok?
+
+                                  :else
+                                  ;; There is a Clojure version depended on, it must check out.
+                                  ,,(lein/version-satisfies? clojure-version "1.7.0"))]
 
     (when-not lein-version-ok?
       (lein/warn "Warning: cider-nrepl requires Leiningen 2.5.2 or greater."))
     (when-not clojure-version-ok?
       (lein/warn "Warning: cider-nrepl requires Clojure 1.7 or greater."))
+    (when clojure-excluded?
+      (lein/warn "Warning: Clojure is excluded, assuming an appropriate fork (Clojure 1.7 or later) is provided."))
     (when-not (and lein-version-ok? clojure-version-ok?)
       (lein/warn "Warning: cider-nrepl will not be included in your project."))
 


### PR DESCRIPTION
This patch allows the cider-nrepl middleware to be injected into a project which does not depend on `org.clojure/clojure`, if and only if the user has explicitly provided `:exclusions [... org.clojure/clojure]`
in the `project.clj` file. This allows users who know what they're doing to take on the responsibility of providing an appropriate build of Clojure and thus use CIDER with forks albeit with a warning.

Replaces https://github.com/clojure-emacs/cider/pull/1603