### PR TITLE
Fix small inspector errors and improve tests

### DIFF
--- a/src/cider/nrepl/middleware/inspect.clj
+++ b/src/cider/nrepl/middleware/inspect.clj
@@ -1,6 +1,7 @@
 (ns cider.nrepl.middleware.inspect
   (:require [cider.nrepl.middleware.util.cljs :as cljs]
             [cider.nrepl.middleware.util.inspect :as inspect]
+            [cider.nrepl.middleware.util.misc :as u]
             [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
             [clojure.tools.nrepl.misc :refer [response-for]]
             [clojure.tools.nrepl.middleware.pr-values :refer [pr-values]]
@@ -48,47 +49,75 @@
 
 (defn pop-reply
   [{:keys [transport] :as msg}]
-  (let [inspector (swap-inspector! msg inspect/up)]
-    (transport/send
-     transport
-     (response-for msg :value (:rendered inspector) :status :done))))
+  (try
+    (let [inspector (swap-inspector! msg inspect/up)]
+      (transport/send
+       transport
+       (response-for msg :value (:rendered inspector) :status :done)))
+    (catch Exception e
+      (transport/send
+       transport
+       (response-for msg (u/err-info e :inspect-pop-error))))))
 
 (defn push-reply
   [{:keys [idx transport] :as msg}]
-  (let [idx (Integer/parseInt idx)
-        inspector (swap-inspector! msg inspect/down idx)]
-    (transport/send
-     transport
-     (response-for msg :value (:rendered inspector) :status :done))))
+  (try
+    (let [inspector (swap-inspector! msg inspect/down idx)]
+      (transport/send
+       transport
+       (response-for msg :value (:rendered inspector) :status :done)))
+    (catch Exception e
+      (transport/send
+       transport
+       (response-for msg (u/err-info e :inspect-push-error))))))
 
 (defn refresh-reply
   [{:keys [transport] :as msg}]
-  (let [inspector (swap-inspector! msg #(or % (inspect/fresh)))]
-    (transport/send
-     transport
-     (response-for msg :value (:rendered inspector) :status :done))))
+  (try
+    (let [inspector (swap-inspector! msg #(or % (inspect/fresh)))]
+      (transport/send
+       transport
+       (response-for msg :value (:rendered inspector) :status :done)))
+    (catch Exception e
+      (transport/send
+       transport
+       (response-for msg (u/err-info e :inspect-refresh-error))))))
 
 (defn next-page-reply
   [{:keys [transport] :as msg}]
-  (let [inspector (swap-inspector! msg inspect/next-page)]
-    (transport/send
-     transport
-     (response-for msg :value (:rendered inspector) :status :done))))
+  (try
+    (let [inspector (swap-inspector! msg inspect/next-page)]
+      (transport/send
+       transport
+       (response-for msg :value (:rendered inspector) :status :done)))
+    (catch Exception e
+      (transport/send
+       transport
+       (response-for msg (u/err-info e :inspect-next-page-error))))))
 
 (defn prev-page-reply
   [{:keys [transport] :as msg}]
-  (let [inspector (swap-inspector! msg inspect/prev-page)]
-    (transport/send
-     transport
-     (response-for msg :value (:rendered inspector) :status :done))))
+  (try
+    (let [inspector (swap-inspector! msg inspect/prev-page)]
+      (transport/send
+       transport
+       (response-for msg :value (:rendered inspector) :status :done)))
+    (catch Exception e
+      (transport/send
+       transport
+       (response-for msg (u/err-info e :inspect-prev-page-error))))))
 
 (defn set-page-size-reply
   [{:keys [page-size transport] :as msg}]
-  (let [page-size (Integer/parseInt page-size)
-        inspector (swap-inspector! msg inspect/set-page-size page-size)]
-    (transport/send
-     transport
-     (response-for msg :value (:rendered inspector) :status :done))))
+  (try
+    (let [inspector (swap-inspector! msg inspect/set-page-size page-size)]
+      (transport/send
+       transport
+       (response-for msg :value (:rendered inspector) :status :done)))
+    (catch Exception e
+      (transport/send
+       transport
+       (response-for msg (u/err-info e :inspect-set-page-size-error))))))
 
 (defn wrap-inspect
   "Middleware that adds a value inspector option to the eval op. Passing a

--- a/src/cider/nrepl/middleware/util/inspect.clj
+++ b/src/cider/nrepl/middleware/util/inspect.clj
@@ -44,6 +44,7 @@
   "Drill down to an indexed object referred to by the previously
    rendered value"
   [inspector idx]
+  {:pre [(integer? idx)]}
   (let [new (get (:index inspector) idx)
         val (:value inspector)]
     (-> (update-in inspector [:stack] conj val)
@@ -65,6 +66,7 @@
   "Set the page size in pagination mode to the specified value. Current page
   will be reset to zero."
   [inspector new-page-size]
+  {:pre [(integer? new-page-size) (pos? new-page-size)]}
   (inspect-render (assoc inspector
                          :page-size new-page-size
                          :current-page 0)))

--- a/test/clj/cider/nrepl/middleware/util/inspect_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/inspect_test.clj
@@ -3,7 +3,7 @@
             [clojure.test :refer :all]))
 
 (defprotocol IMyTestType
-   (^String get-name [this]))
+  (^String get-name [this]))
 
 (deftype MyTestType [name]
   IMyTestType


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [n/a] You've updated the readme (if adding/changing middleware)

Thanks!

A couple of small bugs/inconsistencies in the inspector middleware.

1 - Setting the page size on the fly while using the inspector was not
working. Emacs was sending an integer to Cider, which was expecting a
string, causing a type conversion error (the tests were sending a
string, which is why it wasn't caught before). Also, the user can pass
in negative integers or a zero which would break the system, so added a
sanity check.

2 - Similarly, the push op expects a stringified integer in the :idx
slot. The elisp code was converting the supplied integer to a string
prior to sending it over the wire, so there was no error in the code,
but the inconsistencies suggests we should either be more liberal with
our input types or have strict preconditions to catch these errors earlier.

To address the above, added a parse-int function to convert the
argument as needed. Perhaps this should be moved to a util namespace?

Finally, added error handling try/catch blocks around all the messaging
operations. Added tests to exercise these.