### PR TITLE
Improve pprint middleware tests & simplify code

### DIFF
--- a/test/clj/cider/nrepl/middleware/format_test.clj
+++ b/test/clj/cider/nrepl/middleware/format_test.clj
@@ -107,6 +107,6 @@
     (let [{:keys [err ex status]} (session/message {:op "format-edn"
                                                     :edn "{:b 2 :c 3 :a 1}"
                                                     :pprint-fn "fake.nrepl.middleware.pprint/puget-pprint"})]
-      (is (.startsWith err "java.lang.IllegalArgumentException: fake"))
+      (is (.startsWith err "java.lang.IllegalArgumentException: No such namespace: fa"))
       (is (= "class java.lang.IllegalArgumentException" ex))
       (is (= #{"done" "edn-read-error"} status)))))


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the readme (if adding/changing middleware)

Thanks!

The prior code had a difficult to test code block in `resolve-pprint-fn`
as well as a small piece of round about code in `wrap-pprint` , so these
functions were streamlined to help with testing/understanding. Behavior
is slightly changed since the resolve-pprint-fn will now throw different
exceptions based on the root cause of the exception (no such namespace
in classpath, no such var in an existing namespace, etc. This required a
slight change in the format-middleware tests). Otherwise, the
functionality of the code should be the same.

Added coverage tests to get to 100%. Error handling is actually done
elsewhere in the middleware stack (within the `eval` op).