### PR TITLE
Store exceptions so sync ops can get stacktraces

### DIFF
--- a/src/cider/nrepl/middleware/util/misc.clj
+++ b/src/cider/nrepl/middleware/util/misc.clj
@@ -1,6 +1,7 @@
 (ns cider.nrepl.middleware.util.misc
   (:require [clojure.string :as str]
-            [clojure.stacktrace :as stacktrace]))
+            [clojure.stacktrace :as stacktrace]
+            [cider.nrepl.middleware.util.storage :as c-store]))
 
 (def java-api-version
   (try (-> (System/getProperty "java.version") (str/split #"\.") second)
@@ -60,7 +61,10 @@
 (prefer-method transform-value clojure.lang.Sequential clojure.lang.Associative)
 
 (defn err-info
-  [ex status]
-  {:ex (str (class ex))
-   :err (with-out-str (stacktrace/print-cause-trace ex))
-   :status #{status :done}})
+  [ex & statuses]
+  (let [ex-key (.hashCode ex)]
+    (c-store/add! ex-key ex)
+    {:ex (str (class ex))
+     :err (with-out-str (stacktrace/print-cause-trace ex))
+     :status (set (conj statuses :done))
+     :storage-key ex-key}))

--- a/src/cider/nrepl/middleware/util/storage.clj
+++ b/src/cider/nrepl/middleware/util/storage.clj
@@ -1,0 +1,41 @@
+(ns cider.nrepl.middleware.util.storage)
+
+(def ^:private store (ref {}))
+(def ^:private exp-index (ref '()))
+(def ^:private capacity 10)
+
+(defn add!
+  "Adds the provided kv pair to a single-retrieval store with
+  queue-capacity expiring behavior; i.e. not only is kv removed from
+  the store when sucessfully queried, but if addition of the supplied
+  item causes store size to increase over the default capacity of 10
+  items, then the oldest kv pair in the store is also
+  expired (removed). Returns the value added to the store."
+  [k v]
+  (dosync
+   (let [untrimmed-exp           (conj @exp-index k)
+         untrimmed-store         (assoc @store k v)
+         [trimmed-exp trimmable] (split-at capacity untrimmed-exp)
+         trimmed-store           (apply dissoc untrimmed-store trimmable)]
+     (ref-set store trimmed-store)
+     (ref-set exp-index trimmed-exp)
+     v)))
+
+(defn query!
+  "Queries the single-retrieval store. Finds value associated with the
+  supplied key `k` and then removes the kv pair from storage. If `k`
+  not present, returns nil and no changes are made."
+  [k]
+  (dosync
+   (let [reply (get @store k)]
+     (ref-set store (dissoc @store k))
+     (ref-set exp-index (remove #(= k %) @exp-index))
+     reply)))
+
+(defn refresh!
+  "Refreshes the single-retrieval, queue-capacity store. Removes all kv
+  pairs from the store."
+  []
+  (dosync
+   (ref-set store {})
+   (ref-set exp-index '())))

--- a/test/clj/cider/nrepl/middleware/util/storage_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/storage_test.clj
@@ -1,0 +1,57 @@
+(ns cider.nrepl.middleware.util.storage-test
+  (:require [cider.nrepl.middleware.util.storage :as c-store]
+            [clojure.test :refer :all]))
+
+(use-fixtures :each (fn [f] (c-store/refresh!) (f)))
+
+(deftest test-single-add
+  (is (= 1 (c-store/add! :a 1))))
+
+(deftest multiple-add
+  (is (= 1 (c-store/add! :a 1)))
+  (is (= 2 (c-store/add! :b 2)))
+  (is (= 3 (c-store/add! :c 3))))
+
+(deftest test-empty-query
+  (is (nil? (c-store/query! :a))))
+
+(deftest test-miss-query
+  (c-store/add! :b 2)
+  (is (nil? (c-store/query! :a))))
+
+(deftest test-hit-query
+  (c-store/add! :a 1)
+  (is (= 1 (c-store/query! :a)))
+  (is (nil? (c-store/query! :a))))
+
+(deftest test-over-capacity
+  (c-store/add! :a 1)
+  (c-store/add! :b 2)
+  (c-store/add! :c 3)
+  (c-store/add! :d 4)
+  (c-store/add! :e 5)
+  (c-store/add! :f 6)
+  (c-store/add! :g 7)
+  (c-store/add! :h 8)
+  (c-store/add! :i 9)
+  (c-store/add! :j 10)
+  (c-store/add! :k 11)
+  (is (nil? (c-store/query! :a)))
+  (is (= 11 (c-store/query! :k))))
+
+(deftest test-refresh
+  (c-store/add! :a 1)
+  (c-store/add! :b 2)
+  (c-store/add! :c 3)
+  (c-store/add! :d 4)
+  (c-store/add! :e 5)
+  (c-store/add! :f 6)
+  (c-store/add! :g 7)
+  (c-store/add! :h 8)
+  (c-store/add! :i 9)
+  (c-store/add! :j 10)
+  (c-store/add! :k 11)
+  (c-store/refresh!)
+  (is (nil? (c-store/query! :a)))
+  (is (nil? (c-store/query! :e)))
+  (is (nil? (c-store/query! :k))))


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done:

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [ ] All tests are passing
- [ ] The new code is not generating reflection warnings
- [ ] You've updated the readme (if adding/changing middleware)

Thanks!

The u/err-info function will now automatically store exceptions in
simple map based single-use data store. This will allow the stacktrace
middleware to act on Exceptions that were not bound to *e. See bug 1420
in CIDER: https://github.com/clojure-emacs/cider/issues/1420.

See also CIDER PR 1617: https://github.com/clojure-emacs/cider/pull/1617