### PR TITLE
quote project dir when used in regex

### DIFF
--- a/src/cider/nrepl/middleware/util/namespace.clj
+++ b/src/cider/nrepl/middleware/util/namespace.clj
@@ -28,8 +28,7 @@
   "Find all namespaces defined in source paths within the current project."
   []
   (->> (cp/classpath-directories)
-       (filter #(re-find (re-pattern (str "^" project-root))
-                         (str %)))
+       (filter #(.startsWith (str %) project-root))
        (mapcat ns-find/find-namespaces-in-dir)))
 
 (defn inlined-dependency?

--- a/test/clj/cider/nrepl/middleware/util/namespace_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/namespace_test.clj
@@ -1,0 +1,7 @@
+(ns cider.nrepl.middleware.util.namespace-test
+  (:require [clojure.test :refer :all])
+  (:require [cider.nrepl.middleware.util.namespace :as n]))
+
+(deftest test-project-namespaces
+  (is (contains? (into #{} (n/project-namespaces))
+                 'cider.nrepl.middleware.util.namespace)))


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done:

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [ ] All tests are passing
- [ ] The new code is not generating reflection warnings
- [ ] You've updated the readme (if adding/changing middleware)

Thanks!

Since windows uses backslashes this results in an invalid regular
expression throwing a PatternSyntaxException. By passing the
project-root through Pattern/quote it is escaped properly for use in
a regular expression