### PR TITLE
Fix exception when instrumenting code with embedded namespace

### DIFF
--- a/src/cider/nrepl/middleware/util/meta.clj
+++ b/src/cider/nrepl/middleware/util/meta.clj
@@ -16,7 +16,9 @@
 
 (defn strip-meta [form]
   (if (meta form)
-    (with-meta form nil)
+    (try
+      (with-meta form nil)
+      (catch Exception e form))
     form))
 
 (defn macroexpand-all


### PR DESCRIPTION
Instrumentation would throw when trying to macroexpand code containing a
namespace object with metadata.

The logging macros in clojure.tools.logging embed the current namespace
object into the code at macroexpansion time. Instrumenting a function
that contained logging calls would throw an exception if the current
namespace had metadata (eg: a docstring).

This is because Namespace has the unusual property of implementing
IMeta (so you can call `(meta *ns*)`), but not IObj (so `(with-meta *ns*
...)` throws).