### PR TITLE
add transform-value dispatch value for BigDecimal

### DIFF
--- a/src/cider/nrepl/middleware/util/misc.clj
+++ b/src/cider/nrepl/middleware/util/misc.clj
@@ -32,6 +32,8 @@
 
 (defmethod transform-value :default [v] (str v))
 
+(defmethod transform-value java.math.BigDecimal [v] (str v "M"))
+
 (defmethod transform-value Number [v] v)
 
 (defmethod transform-value nil [v] nil)
@@ -63,6 +65,8 @@
 
 ;; handles vectors
 (prefer-method transform-value clojure.lang.Sequential clojure.lang.Associative)
+
+(prefer-method transform-value java.math.BigDecimal Number)
 
 (defn err-info
   [ex status]

--- a/test/clj/cider/nrepl/middleware/util/misc_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/misc_test.clj
@@ -9,8 +9,9 @@
                                 :e false
                                 :f [:g :h :i]
                                 :j 4
-                                :k nil))
-         '{"a" "b", "c" "d", "e" "false", "f" ("g" "h" "i"), "j" 4, "k" nil}))
+                                :k nil
+                                :l 10.1M))
+         '{"a" "b", "c" "d", "e" "false", "f" ("g" "h" "i"), "j" 4, "k" nil, "l" "10.1M"}))
   (is (-> (misc/transform-value {:k (java.io.File. ".")})
           (get "k")
           java.io.File.


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done:

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [ ] All tests are passing
- [ ] The new code is not generating reflection warnings
- [ ] You've updated the readme (if adding/changing middleware)

Thanks!

BigDecimal was handled as a Number returning the initial value
causing an IllegalStateException in clojure.tools.nrepl.bencode. This
patch adds an additional multimethod dispatching on BigDecimal making
it a string.