### PR TITLE
Add ns and name to eldoc's response

### DIFF
--- a/src/cider/nrepl/middleware/info.clj
+++ b/src/cider/nrepl/middleware/info.clj
@@ -284,15 +284,19 @@
   (map #(mapv str %) raw-eldoc))
 
 (defn eldoc
-  [msg]
-  (if-let [raw-eldoc (extract-eldoc (info msg))]
+  [info]
+  (if-let [raw-eldoc (extract-eldoc info)]
     (format-eldoc raw-eldoc)))
 
 (defn eldoc-reply
   [msg]
-  (if-let [var-eldoc (eldoc msg)]
-    {:eldoc var-eldoc}
-    {:status :no-eldoc}))
+  (let [info (info msg)
+        var-eldoc (eldoc info)]
+    (if var-eldoc
+      {:eldoc var-eldoc
+       :name (:name info)
+       :ns (:ns info)}
+      {:status :no-eldoc})))
 
 (defn wrap-info
   "Middleware that looks up info for a symbol within the context of a particular namespace."


### PR DESCRIPTION
Hey everyone!

Can you take a look at this code and tell me if something looks off to you (or even better - test it). I'm working on some eldoc improvements but this code is locking up every time I try it from Emacs, although the functions work as expected when tested in a REPL). I'm completely at a loss right now... This looks super simple, but for some reason it's not behaving properly. Guess I did something super silly...