### PR TITLE
Supply CIDER version info via nREPL "describe" op

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ middleware to `:nrepl-middleware` under `:repl-options`.
                   cider.nrepl.middleware.test/wrap-test
                   cider.nrepl.middleware.trace/wrap-trace
                   cider.nrepl.middleware.out/wrap-out
-                  cider.nrepl.middleware.undef/wrap-undef]}
+                  cider.nrepl.middleware.undef/wrap-undef
+                  cider.nrepl.middleware.version/wrap-version]}
 
 ```
 
@@ -146,6 +147,7 @@ Middleware        | Op(s)      | Description
 `wrap-trace`      | `toggle-trace-var`/`toggle-trace-ns` | Toggle tracing of a given var or ns.
 `wrap-out`        | | Echo the server's output stream to client sessions.
 `wrap-undef`      | `undef`    | Undefine a var.
+`wrap-version`    | `cider-version` | The CIDER-nREPL version map.
 
 ## Release policy
 

--- a/project.clj
+++ b/project.clj
@@ -45,7 +45,8 @@
                                                      cider.nrepl.middleware.test/wrap-test
                                                      cider.nrepl.middleware.trace/wrap-trace
                                                      cider.nrepl.middleware.track-state/wrap-tracker
-                                                     cider.nrepl.middleware.undef/wrap-undef]}
+                                                     cider.nrepl.middleware.undef/wrap-undef
+                                                     cider.nrepl.middleware.version/wrap-version]}
                    :dependencies [[org.clojure/tools.nrepl "0.2.12"]
                                   ;; For developing the Leiningen plugin.
                                   [leiningen-core "2.6.1"]]}

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -19,7 +19,8 @@
             [cider.nrepl.middleware.test]
             [cider.nrepl.middleware.trace]
             [cider.nrepl.middleware.track-state]
-            [cider.nrepl.middleware.undef]))
+            [cider.nrepl.middleware.undef]
+            [cider.nrepl.middleware.version]))
 
 (def cider-middleware
   "A vector containing all CIDER middleware."
@@ -42,7 +43,8 @@
     cider.nrepl.middleware.test/wrap-test
     cider.nrepl.middleware.trace/wrap-trace
     cider.nrepl.middleware.track-state/wrap-tracker
-    cider.nrepl.middleware.undef/wrap-undef])
+    cider.nrepl.middleware.undef/wrap-undef
+    cider.nrepl.middleware.version/wrap-version])
 
 (def cider-nrepl-handler
   "CIDER's nREPL handler."

--- a/src/cider/nrepl/middleware/version.clj
+++ b/src/cider/nrepl/middleware/version.clj
@@ -1,0 +1,28 @@
+(ns cider.nrepl.middleware.version
+  "Return version info of the CIDER-nREPL middleware itself."
+  (:require [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
+            [cider.nrepl.version :as version]
+            [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]))
+
+(defn- cider-version-reply
+  "Returns CIDER-nREPL's version as a map which contains `:major`,
+  `:minor`, `:incremental`, and `:qualifier` keys, just as
+  `*clojure-version*` does."
+  [msg]
+  {:cider-version version/version})
+
+(defn wrap-version
+  "Middleware that provides CIDER-nREPL version information."
+  [handler]
+  (with-safe-transport handler
+    "cider-version" cider-version-reply))
+
+(set-descriptor!
+ #'wrap-version
+ {:describe-fn #'cider-version-reply ;; For the "describe" op. Merged in `:aux`
+  :handles
+  {"cider-version"
+   {:doc "Returns the version of the CIDER-nREPL middleware."
+    :requires {}
+    :returns {"cider-version" "CIDER-nREPL's version map."
+              "status" "done"}}}})

--- a/test/clj/cider/nrepl/middleware/version_test.clj
+++ b/test/clj/cider/nrepl/middleware/version_test.clj
@@ -1,0 +1,34 @@
+(ns cider.nrepl.middleware.version-test
+  (:require [cider.nrepl.middleware.version :as v]
+            [cider.nrepl.test-session :as session]
+            [clojure.test :refer :all]))
+
+(deftest test-cider-version
+  (let [outer-map (#'v/cider-version-reply {})
+        version-map (:cider-version outer-map)]
+    (is (contains? version-map :major))
+    (is (contains? version-map :minor))
+    (is (contains? version-map :incremental))
+    (is (contains? version-map :version-string))))
+
+(use-fixtures :once session/session-fixture)
+
+(deftest integration-test
+  (testing "cider-version op"
+    (let [response (session/message {:op "cider-version"})
+          version-map (:cider-version response)]
+      (is (= #{"done"} (:status response)))
+      (is (contains? version-map :major))
+      (is (contains? version-map :minor))
+      (is (contains? version-map :incremental))
+      (is (contains? version-map :version-string))))
+
+  (testing "describe op"
+    (let [response (session/message {:op "describe"})
+          aux-map  (:aux response)
+          version-map (:cider-version aux-map)]
+      (is (= #{"done"} (:status response)))
+      (is (contains? version-map :major))
+      (is (contains? version-map :minor))
+      (is (contains? version-map :incremental))
+      (is (contains? version-map :version-string)))))


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the readme (if adding/changing middleware)

Thanks!

This middleware is mostly here to address bug #202
https://github.com/clojure-emacs/cider-nrepl/issues/202. The descriptor
has a :describe-fn key, providing a function which will return a
map. This map will be merged into the :aux map returned by nRPEL's
built-in "describe" op. A regular op version of this same functionality
is provided via the "cider-version" op.