### PR TITLE
Debugger: Step in

### DIFF
--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -294,6 +294,20 @@
                               last :stacktrace)}]})
   (read-debug-command value extras))
 
+(def debug-commands
+  {"c" :continue
+   "e" :eval
+   "h" :here
+   "i" :in
+   "j" :inject
+   "l" :locals
+   "n" :next
+   "o" :out
+   "p" :inspect
+   "q" :quit
+   "s" :stacktrace
+   "t" :trace})
+
 (defn read-debug-command
   "Read and take action on a debugging command.
   Ask for one of the following debug commands using `read-debug`:
@@ -314,8 +328,8 @@
   a :code entry, its value is used for operations such as :eval, which
   would otherwise interactively prompt for an expression."
   [value extras]
-  (let [commands (cond->> [:next :in :continue :out :here :inspect :locals :inject :eval :stacktrace :trace :quit]
-                   (not (map? *msg*)) (remove #{:quit})
+  (let [commands (cond->> debug-commands
+                   (not (map? *msg*)) (dissoc "q")
                    (cljs/grab-cljs-env *msg*) identity)
         response-raw (read-debug extras commands nil)
 


### PR DESCRIPTION
This commit implements "step in" for the debugger.

When stepping past a form that is a call to a function stored in a var,
prompt the user with the option to step in to the called function.

The prompt takes the form "Step in to foo/bar?", where "foo/bar" is the
function as it appears in the source, and the options are "yes" and "no.

Selecting "no" will display the result of the function, just as it
always has. Note that because the key for "no" is the same as the key
for "next", those in the habit of rapidly hitting "n" will notice little
difference to their workflow, although more presses of "n" will be
required - one extra for each function call.

Selecting "yes" will instrument the called function and then step in to
it. The instrumentation is done in a special way. It is not simply
instrumented in the normal way, because that would cause all subsequent
calls to it to trigger the debugger. Instead, an instrumented version of
the function is compiled and put into the var's metadata, and this
instrumented version is explicitly called in response to the "yes"
command.

Most normal functions can be stepped in to, including both those in
source files and in jars.

Limitations:

The debugger needs to be able to find on-disk source code for a function
in order to instrument it. Functions that have been eval'ed, but not
saved, cannot be stepped into.

Initially, I have disabled the "step in" prompt for functions in
clojure.core, and enabled it for everything else. This could be made
more customizable in the future, perhaps with additional options to the
"step in?" prompt, such as "never", "always", etc.

Only functions that can be resolved to a var can be stepped in to.
Stepping in to higher-order functions does not work (eg: `((:f m) x)`).

Opportunities:

This implements most of the ability to instrument functions without
having to send the source code over from emacs - the var name is enough.
Perhaps we could instrument functions from the namespace browser, or
from a stacktrace view (eg: instrument all the functions that are part
of my project and appear in this stacktrace).