### PR TITLE
Don't step in to clojure.core functions

### DIFF
--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -438,6 +438,12 @@
             (eval form)
             (alter-meta! v assoc ::instrumented instrumented)))))))
 
+(defn safe-to-debug?
+  "Some namespaces are not safe to debug, because doing so can cause a stack
+  overflow that crashes the nrepl process."
+  [ns]
+  (not (#{'clojure.core} (ns-name ns))))
+
 (defn step-in?
   "Return true if we can and should step in to the function in the var `v`.
   The \"should\" part is determined by the value in `step-in-to-next?`, which
@@ -464,6 +470,7 @@
       ;; We do not go so far as to actually try to read the code of the function
       ;; at this point, which is at macroexpansion time.
       (and v
+           (safe-to-debug? (:ns m))
            (not (:macro m))
            (not (:inline m))))))
 


### PR DESCRIPTION
The new step-in command makes it easy to step in (often accidentally) to
a function in clojure.core. But instrumenting clojure core functions is
dangerous, and can result in a stack overflow that crashes the nrepl
process. In fact, just instrumenting `clojure.core/symbol?` (without
even debugging it) causes a stack overflow. I'm not entirely sure yet
how this happens, but it seems safest to just prevent stepping in to all
core functions.