### PR TITLE
Cider's namespaces and vars filtered from ns-list and apropos

### DIFF
--- a/src/cider/nrepl/middleware/ns.clj
+++ b/src/cider/nrepl/middleware/ns.clj
@@ -57,10 +57,10 @@
        (cljs-info/info env)
        (:file)))
 
-(defn ns-list [msg]
+(defn ns-list [{:keys [filter-regexps] :as msg}]
   (if-let [cljs-env (cljs/grab-cljs-env msg)]
     (ns-list-cljs cljs-env)
-    (ns/loaded-namespaces)))
+    (ns/loaded-namespaces filter-regexps)))
 
 (defn ns-vars [{:keys [ns] :as msg}]
   (if-let [cljs-env (cljs/grab-cljs-env msg)]
@@ -115,7 +115,8 @@
   {:handles
    {"ns-list"
     {:doc "Return a sorted list of all namespaces."
-     :returns {"status" "done" "ns-list" "The sorted list of all namespaces."}}
+     :returns {"status" "done" "ns-list" "The sorted list of all namespaces."}
+     :optional {"filter-regexps" "All namespaces matching any regexp from this list would be dropped from the result."}}
     "ns-list-vars-by-name"
     {:doc "Return a list of vars named `name` amongst all namespaces."
      :requires {"name" "The name to use."}

--- a/src/cider/nrepl/middleware/util/namespace.clj
+++ b/src/cider/nrepl/middleware/util/namespace.clj
@@ -41,7 +41,7 @@
 
 (defn inlined-dependency?
   "Returns true if the namespace matches one of our, or eastwood's,
-  inlined dependencies."
+   inlined dependencies."
   [namespace]
   (let [ns-name (str (ns-name namespace))]
     (or
@@ -52,11 +52,22 @@
      ;; rewritten by dolly
      (.startsWith ns-name "eastwood.copieddeps"))))
 
+(defn internal-namespace?
+  "Returns true if the namespace matches the given prefixes."
+  [namespace & [prefixes]]
+  (let [ns-name (str (ns-name namespace))]
+    (->> prefixes
+         (map re-pattern)
+         (map #(re-find % ns-name))
+         (some (complement nil?)))))
+
 (defn loaded-namespaces
-  "Return all loaded namespaces, except those coming from inlined dependencies."
-  []
+  "Return all loaded namespaces, except those coming from inlined dependencies.
+  `filter-regexps` is used to filter out namespaces matching regexps."
+  [& [filter-regexps]]
   (->> (all-ns)
        (remove inlined-dependency?)
+       (remove #(internal-namespace? % filter-regexps))
        (map ns-name)
        (map name)
        (sort)))

--- a/test/clj/cider/nrepl/middleware/apropos_test.clj
+++ b/test/clj/cider/nrepl/middleware/apropos_test.clj
@@ -26,20 +26,24 @@
       (is (= (namespaces ns ns)
              (namespaces nil ns)
              (list (find-ns (symbol ns))))
-          "Should return a list containing only the searched ns."))))
+          "Should return a list containing only the searched ns."))
+
+    (testing "Removal of namespaces with `filter-regexps`"
+      (is (not-any? #(re-find #".*nrepl" (str (ns-name %)))
+                    (namespaces nil nil [".*nrepl"]))))))
 
 (deftest test-search
   (testing "Search results"
-    (is (empty? (find-symbols nil "xxxxxxxx" nil false false false))
+    (is (empty? (find-symbols nil "xxxxxxxx" nil false false false nil))
         "Failing searches should return empty.")
-    (is (= 1 (count (find-symbols nil "handle-apropos" nil false false false)))
+    (is (= 1 (count (find-symbols nil "handle-apropos" nil false false false nil)))
         "Search for specific fn should return it."))
 
   (testing "Symbol vs docstring search"
     ;; Search for the same fn by name and docstring
-    (let [x (first (find-symbols nil "handle-apropos" nil false false false))
+    (let [x (first (find-symbols nil "handle-apropos" nil false false false nil))
           y (first (find-symbols nil "Return a sequence of vars whose name matches"
-                                 nil true false false))]
+                                 nil true false false nil))]
       (is (= (dissoc x :doc)
              (dissoc y :doc))
           "Other than docstring, returned attributes should be the same.")

--- a/test/clj/cider/nrepl/middleware/ns_test.clj
+++ b/test/clj/cider/nrepl/middleware/ns_test.clj
@@ -16,14 +16,22 @@
 (use-fixtures :each session/session-fixture)
 
 (deftest ns-list-integration-test
-  (let [ns-list (:ns-list (session/message {:op "ns-list"}))]
-    (is (sequential? ns-list))
-    (is (every? string? ns-list))
-    (testing "Removal of namespaces created by source rewriting"
+  (testing "Basic checks"
+    (let [ns-list (:ns-list (session/message {:op "ns-list"}))]
+      (is (sequential? ns-list))
+      (is (every? string? ns-list))))
+
+  (testing "Removal of namespaces created by source rewriting"
+    (let [ns-list (:ns-list (session/message {:op "ns-list"}))]
       (is (not-any? #(or (.startsWith % "deps.")
                          (.startsWith % "mranderson")
                          (.startsWith % "eastwood.copieddeps"))
-                    ns-list)))))
+                    ns-list))))
+
+  (testing "Removal of namespaces with `filter-regexps`"
+    (let [ns-list (:ns-list (session/message {:op "ns-list"
+                                              :filter-regexps [".*nrepl"]}))]
+      (is (not-any? #(re-find #".*nrepl" %) ns-list)))))
 
 (deftest ns-list-vars-by-name-integration-test
   (let [response (session/message {:op "ns-list-vars-by-name"

--- a/test/clj/cider/nrepl/middleware/track_state_test.clj
+++ b/test/clj/cider/nrepl/middleware/track_state_test.clj
@@ -100,8 +100,8 @@
                  :requires {'sym-4 'some-namespace}}
         {:keys [aliases interns]} (st/ns-as-map cljs-ns)]
     (is (= aliases '{sym-3 some-namespace sym-4 some-namespace}))
-    (is (= interns '{sym-0 {:arglists "([a b] [a] [])"}
-                     sym-1 {}
+    (is (= interns '{sym-0 {:arglists ([]) :macro true}
+                     sym-1 {:arglists ([])}
                      sym-2 {}}))))
 
 (deftest calculate-used-aliases

--- a/test/clj/cider/nrepl/middleware/util/namespace_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/namespace_test.clj
@@ -5,3 +5,10 @@
 (deftest test-project-namespaces
   (is (contains? (into #{} (n/project-namespaces))
                  'cider.nrepl.middleware.util.namespace)))
+
+(deftest test-loaded-namespaces
+  ;; If we don't pass the second arg, some cider ns will be returned
+  (is (some #(re-find #".*nrepl" %) (n/loaded-namespaces)))
+  ;; Shouldn't return any cider.nrepl namespaces
+  (is (not-any? #(re-find #".*nrepl" %)
+                (n/loaded-namespaces [".*nrepl"]))))


### PR DESCRIPTION
For clojure-emacs/cider#1564. I still have to write the tests, update documentation etc. But is the basic idea correct ?

And on emacs, we can have a custom var like,

```
(defcustom cider-filter-prefixes '("cider.nrepl" "refactor-nrepl")
  "Cider middleware would filter out information from namespaces starting with `cider-filter-prefixes'"
  :type 'list
  :group 'cider
  :package-version '(cider . "0.13.0"))
```
which will be nil, if we want all the internals visible. Also, if we jack-in from `cider-nrepl` project, we don't have to set it to nil. It picks up the un-inlined versions of deps. But its good to keep it configurable.

Some screenshots;

ns-browser
<img width="1436" alt="screen shot 2016-04-26 at 1 12 56 am" src="https://cloud.githubusercontent.com/assets/5201497/14797383/3133aaa8-0b50-11e6-8c1c-840fcd717578.png">

apropos
<img width="740" alt="screen shot 2016-04-26 at 1 13 14 am" src="https://cloud.githubusercontent.com/assets/5201497/14797404/4eccb190-0b50-11e6-802f-edc7aac34caf.png">

If the user types out the entire ns form the ns-browser, he'll still get the vars listed. But thats ok I guess.