### PR TITLE
Fix c.n.m.u.namespace/project-namespaces broken for Boot projects

### DIFF
--- a/src/cider/nrepl/middleware/util/namespace.clj
+++ b/src/cider/nrepl/middleware/util/namespace.clj
@@ -34,7 +34,7 @@
   []
   (if (u/boot-project?)
     ;; This has false positives, but it's the best we can do in boot.
-    (remove jar-namespaces (all-ns))
+    (map ns-name (remove jar-namespaces (all-ns)))
     (->> (cp/classpath-directories)
          (filter #(.startsWith (str %) project-root))
          (mapcat ns-find/find-namespaces-in-dir))))


### PR DESCRIPTION
Fixes #348