### PR TITLE
Make sure see-also.edn can be loaded

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -24,6 +24,8 @@
 
   :test-paths ["test/common"] ;; See `test-clj` and `test-cljs` profiles below.
 
+  :resource-paths ["resources"]
+
   :profiles {:provided {:dependencies [[org.clojure/clojure "1.7.0"]]}
 
              :dev {:repl-options {:nrepl-middleware [cider.nrepl.middleware.apropos/wrap-apropos

--- a/src/cider/nrepl/middleware/info.clj
+++ b/src/cider/nrepl/middleware/info.clj
@@ -140,7 +140,7 @@
     info))
 
 (def see-also-data
-  (edn/read (java.io.PushbackReader. (io/reader "resources/see-also.edn"))))
+  (edn/read (java.io.PushbackReader. (io/reader (io/resource "see-also.edn")))))
 
 (defn info-clj
   [ns sym]


### PR DESCRIPTION
A recent change is causing a regression, see https://github.com/clojure-emacs/cider/issues/1745

```
java.io.FileNotFoundException: resources/see-also.edn (No such file or directory),
 compiling:(info.clj:143:38)
```

I am not sure this is the best way to fix it, but it does get things working again. Opening this in the spirit of "the best way to get an answer on the internet is not to post a question, but to post a wrong answer"

----

Add `resources` to the class path, and load `see-also.edn` as a
resource, because otherwise it's causing a FileNotFoundException.