### PR TITLE
Add cider.tasks/add-middleware boot task

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def VERSION "0.13.0-SNAPSHOT")
+(def VERSION "0.15.0-SNAPSHOT")
 
 (defproject cider/cider-nrepl VERSION
   :description "nREPL middlewares for CIDER"

--- a/src/cider/nrepl/version.clj
+++ b/src/cider/nrepl/version.clj
@@ -5,7 +5,7 @@
 
 (def version
   "Current version of CIDER nREPL, map of :major, :minor, :incremental, and :qualifier."
-  (let [version-string "0.13.0-snapshot"]
+  (let [version-string "0.15.0-snapshot"]
     (assoc (->> version-string
                 (re-find #"(\d+)\.(\d+)\.(\d+)-?(.*)")
                 rest

--- a/src/cider/tasks.clj
+++ b/src/cider/tasks.clj
@@ -1,0 +1,18 @@
+(ns cider.tasks
+  (:require [boot.core :refer [deftask]]
+            [boot.repl :as repl]
+            [boot.util :as util]))
+
+(deftask add-middleware
+  "CIDER middleware injection task
+
+  This task allows to inject middleware in `boot.repl/*default-middleware*`.
+  Just pass it as -m|-middleware. The input is a name but will be converted to
+  symbol."
+  [m middleware MIDDLEWARE #{sym} "Name of the middleware to inject"]
+  (if-let [default-middleware (resolve 'boot.repl/*default-middleware*)]
+    (do (util/dbug* "Boot's default middleware: %s\n" (vec @@default-middleware))
+        (swap! @default-middleware concat middleware)
+        (util/dbug* "After cider-nrepl injection: %s\n" (vec @@default-middleware)))
+    (util/dbug "Cannot resolve boot.repl/*default-middleware*, skipping middleware injection...\n"))
+  identity)


### PR DESCRIPTION
This adds the task for https://github.com/clojure-emacs/cider/pull/1751

Before submitting a PR make sure the following things have been done:
- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [X] You've added tests to cover your change(s) (see `cider`)
- [X] All tests are passing (_Not really, but I don't think it is on my side_)
- [X] The new code is not generating reflection warnings

In order to try the command:

```
boot -v -d org.clojure/tools.nrepl:0.2.12 -d cider/cider-nrepl:0.15.0-SNAPSHOT -i "(require 'cider.tasks)" cider.tasks/add-middleware -m cider.nrepl/cider-middleware
```

And check the final few lines of the debug log:

```
Boot's default middleware: []
After cider's injection: [cider.nrepl/cider-middleware]
```
