### PR TITLE
Include docstring in ns-vars-with-meta

### DIFF
--- a/src/cider/nrepl/middleware/util/meta.clj
+++ b/src/cider/nrepl/middleware/util/meta.clj
@@ -52,7 +52,7 @@
   "Metadata keys that are useful to us.
   This is used so that we don't crowd the ns cache with useless or
   redudant information, such as :name and :ns."
-  [:indent :deprecated :macro :arglists :test
+  [:indent :deprecated :macro :arglists :test :doc
    :cider.nrepl.middleware.util.instrument/breakfunction
    :style/indent :clojure.tools.trace/traced])
 

--- a/test/clj/cider/nrepl/middleware/ns_test.clj
+++ b/test/clj/cider/nrepl/middleware/ns_test.clj
@@ -54,10 +54,14 @@
                                              :ns "clojure.core"}))]
     (is (every? (comp map? second) ns-vars-with-meta))
     (is (= (:+ ns-vars-with-meta)
-           {:arglists "([] [x] [x y] [x y & more])"}))
+           {:arglists "([] [x] [x y] [x y & more])"
+            :doc "\"Returns the sum of nums. (+) returns 0. Does not auto-promote\\n  longs, will throw on overflow. See also: +'\""}))
     (is (= (:doseq ns-vars-with-meta)
-           {:arglists "([seq-exprs & body])" :macro "true"}))
-    (is (= (:*ns* ns-vars-with-meta) {}))))
+           {:arglists "([seq-exprs & body])"
+            :macro "true"
+            :doc "\"Repeatedly executes body (presumably for side-effects) with\\n  bindings and filtering as provided by \\\"for\\\".  Does not retain\\n  the head of the sequence. Returns nil.\""}))
+    (is (= (:*ns* ns-vars-with-meta)
+           {:doc "\"A clojure.lang.Namespace object representing the current namespace.\""}))))
 
 (deftest ns-path-integration-test
   (let [ns-path (:path (session/message {:op "ns-path"

--- a/test/clj/cider/nrepl/middleware/track_state_test.clj
+++ b/test/clj/cider/nrepl/middleware/track_state_test.clj
@@ -59,7 +59,9 @@
 
 (deftest filter-core-and-get-meta
   (is (= (st/filter-core-and-get-meta {'and #'and, 'b #'map, 'c #'deftest})
-         '{c {:macro "true", :arglists "([name & body])"}}))
+         '{c {:macro "true",
+              :arglists "([name & body])"
+              :doc "\"Defines a test function with no arguments.  Test functions may call\\n  other tests, so tests may be composed.  If you compose tests, you\\n  should also define a function named test-ns-hook; run-tests will\\n  call test-ns-hook instead of testing all vars.\\n\\n  Note: Actually, the test body goes in the :test metadata on the var,\\n  and the real function (the value of the var) calls test-var on\\n  itself.\\n\\n  When *load-tests* is false, deftest is ignored.\""}}))
   (is (-> (find-ns 'clojure.core)
           ns-map st/filter-core-and-get-meta
           seq not)))

--- a/test/clj/cider/nrepl/middleware/util/meta_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/meta_test.clj
@@ -46,7 +46,8 @@
 
 (deftest relevant-meta
   (is (= (m/relevant-meta (meta #'test-fn))
-         {:arglists "([a b] [a] [])"}))
+         {:arglists "([a b] [a] [])"
+          :doc "\"docstring\""}))
   (is (= (:macro (m/relevant-meta (meta #'deftest)))
          "true"))
   (let [m (meta #'strip-meta)]

--- a/test/cljs/cider/nrepl/middleware/cljs_ns_test.clj
+++ b/test/cljs/cider/nrepl/middleware/cljs_ns_test.clj
@@ -23,7 +23,8 @@
                                                :ns "cljs.core"}))]
       (is (every? (comp map? second) ns-vars-with-meta))
       (is (= (:+ ns-vars-with-meta)
-             {:arglists "(quote ([] [x] [x y] [x y & more]))"}))))
+             {:arglists "(quote ([] [x] [x y] [x y & more]))"
+              :doc "\"Returns the sum of nums. (+) returns 0.\""}))))
 
   (testing "ns-path op"
     (let [{:keys [path]} (session/message {:op "ns-path"


### PR DESCRIPTION
Include docstring in ns-vars-with-meta to be able to show first line of docstring in cider namespace browser (https://github.com/clojure-emacs/cider/issues/1577).

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [ ] The new code is not generating reflection warnings
- [ ] You've updated the readme (if adding/changing middleware)
