### PR TITLE
make inspector print nil when value is nil

### DIFF
--- a/src/cider/nrepl/middleware/util/inspect.clj
+++ b/src/cider/nrepl/middleware/util/inspect.clj
@@ -125,6 +125,9 @@
          (instance? java.lang.Class value)
          (pr-str value)
 
+         (nil? value)
+         "nil"
+
          :default
          (str value))))
 


### PR DESCRIPTION
The inspector currently prints nothing when a value is nil. The 3 lines added ensures it prints “nil” (without the quotes).