### PR TITLE
Display Clojure.spec in the doc buffer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ env:
   - TEST_CMD="./lein-261 with-profile +1.8,+plugin.mranderson/config,+test-clj test"
   - TEST_CMD="./lein-261 with-profile +1.8,+plugin.mranderson/config,+test-cljs test"
 
+  - TEST_CMD="./lein-261 with-profile +1.9,+plugin.mranderson/config,+test-clj test"
+
   - TEST_CMD="./lein-261 with-profile +master,+plugin.mranderson/config,+test-clj test"
   - TEST_CMD="./lein-261 with-profile +master,+plugin.mranderson/config,+test-cljs test"
 jdk:

--- a/project.clj
+++ b/project.clj
@@ -53,6 +53,8 @@
 
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
+             :1.9 {:dependencies [[org.clojure/clojure "1.9.0-alpha12"]]
+                   :test-paths ["test/spec"]}
              :master {:repositories [["snapshots" "https://oss.sonatype.org/content/repositories/snapshots"]]
                       :dependencies [[org.clojure/clojure "1.8.0-master-SNAPSHOT"]]}
 

--- a/src/cider/nrepl/middleware/util/spec.clj
+++ b/src/cider/nrepl/middleware/util/spec.clj
@@ -1,0 +1,13 @@
+(ns cider.nrepl.middleware.util.spec)
+
+(defn get-spec
+  "Return the spec for var `v` if clojure.spec is available."
+  [v]
+  (when-let [f (resolve (symbol "clojure.spec" "get-spec"))]
+    (f v)))
+
+(defn describe
+  "Describe the spec `s` if clojure.spec is available."
+  [s]
+  (when-let [f (resolve (symbol "clojure.spec" "describe"))]
+    (f s)))

--- a/test/clj/cider/nrepl/middleware/info_test.clj
+++ b/test/clj/cider/nrepl/middleware/info_test.clj
@@ -257,7 +257,8 @@
         (is (= (:name response) "testing-function"))
         (is (= (:arglists-str response) "([a b c])"))
         (is (nil? (:macro response)))
-        (is (= (:doc response) "This is used for testing"))))
+        (is (= (:doc response) "This is used for testing"))
+        (is (nil? (:spec response)))))
 
     (testing "get info of a clojure macro"
       (let [response (session/message {:op "info" :symbol "testing-macro" :ns "cider.nrepl.middleware.info-test"})]
@@ -266,7 +267,8 @@
         (is (= (:name response) "testing-macro"))
         (is (= (:arglists-str response) "([pred a b])"))
         (is (= (:macro response) "true"))
-        (is (= (:doc response) "a macro for testing"))))
+        (is (= (:doc response) "a macro for testing"))
+        (is (nil? (:spec response)))))
 
     (testing "get info of a java instance method with return value"
       (let [response (session/message {:op "info"

--- a/test/spec/cider/nrepl/middleware/info_test.clj
+++ b/test/spec/cider/nrepl/middleware/info_test.clj
@@ -1,0 +1,40 @@
+(ns cider.nrepl.middleware.info-test
+  (:require [clojure.spec :as s]
+            [cider.nrepl.test-session :as session]
+            [clojure.test :refer :all]))
+
+(defn ranged-rand
+  "Returns random int in range start <= rand < end."
+  [start end]
+  (+ start (long (rand (- end start)))))
+
+(s/fdef ranged-rand
+        :args (s/and (s/cat :start int? :end int?)
+                     #(< (:start %) (:end %)))
+        :ret int?
+        :fn (s/and #(>= (:ret %) (-> % :args :start))
+                   #(< (:ret %) (-> % :args :end))))
+
+(use-fixtures :each session/session-fixture)
+(deftest integration-test
+  (testing "spec"
+    (let [response (session/message {:op "info" :symbol "ranged-rand" :ns "cider.nrepl.middleware.info-test"})]
+      (is (= (:status response) #{"done"}))
+      (is (= (:ns response) "cider.nrepl.middleware.info-test"))
+      (is (= (:name response) "ranged-rand"))
+      (is (= (:arglists-str response) "([start end])"))
+      (is (nil? (:macro response)))
+      (is (= (:doc response) "Returns random int in range start <= rand < end."))
+      (is (= (:spec response) ["args: (and (cat :start int? :end int?) (< (:start %) (:end %)))"
+                               "ret: int?"
+                               "fn: (and (>= (:ret %) (-> % :args :start)) (< (:ret %) (-> % :args :end)))"])))
+
+    ;; spec is not defined for this function
+    (let [response (session/message {:op "info" :symbol "same-name-testing-function" :ns "cider.test-ns.first-test-ns"})]
+      (is (= (:status response) #{"done"}))
+      (is (= (:ns response) "cider.test-ns.first-test-ns"))
+      (is (= (:name response) "same-name-testing-function"))
+      (is (= (:arglists-str response) "([])"))
+      (is (nil? (:macro response)))
+      (is (= (:doc response) "Multiple vars with the same name in different ns's. Used to test ns-list-vars-by-name."))
+      (is (nil? (:spec response))))))


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done:

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the readme (if adding/changing middleware)

Thanks!

This is not ready for a merge. I'm not really sure how do we make the nREPL use Clojure 1.9, and still maintain backwards compatibility with older versions. While developing this, I just bumped the version for the `:provided` profile, but I'm sure that's not the right way to do it. Please help me figure out the correct `project.clj` for this feature.