### PR TITLE
Add `macroexpand-step`

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Middleware        | Op(s)      | Description
 `wrap-format`     | `format-(code/edn)` | Code and data formatting.
 `wrap-info`       | `info/eldoc` | File/line, arglists, docstrings and other metadata for vars.
 `wrap-inspect`    |`inspect-(start/refresh/pop/push/reset)` | Inspect a Clojure expression.
-`wrap-macroexpand`| `macroexpand/macroexpand-1/macroexpand-all` | Macroexpand a Clojure form.
+`wrap-macroexpand`| `macroexpand/macroexpand-1/macroexpand-all/macroexpand-step` | Macroexpand a Clojure form.
 `wrap-ns`         | `ns-list/ns-vars/ns-path/ns-load-all` | Namespace browsing & loading.
 `wrap-pprint`     | | Adds pretty-printing support to code evaluation. It also installs a dummy `pprint-middleware` op. Thus `wrap-pprint` is discoverable through the `describe` op.
 `wrap-pprint-fn`  | | Provides a common pretty-printing interface for other middlewares that need to perform customisable pretty-printing.

--- a/test/clj/cider/nrepl/middleware/macroexpand_test.clj
+++ b/test/clj/cider/nrepl/middleware/macroexpand_test.clj
@@ -38,6 +38,17 @@
       (is (= (:expanded-all code) expansion))
       (is (= #{"done"} status))))
 
+  (testing "macroexpand-step expander works"
+    (letfn [(mstep [code]
+              (:expansion (session/message {:op "macroexpand"
+                                            :expander "macroexpand-step"
+                                            :code code
+                                            :display-namespaces "none"})))]
+      (let [expansions (take 7 (iterate mstep (:expr code)))]
+        (is (= (:expanded-1 code) (nth expansions 1)))
+        (is (= (:expanded code) (nth expansions 2)))
+        (is (= (:expanded-all code) (nth expansions 6))))))
+
   (testing "macroexpand is the default expander"
     (let [{:keys [expansion status]} (session/message {:op "macroexpand"
                                                        :code (:expr code)


### PR DESCRIPTION
`macroexpand-step` expands a form one macro subform at a time, creating
a [macrostep](https://github.com/joddie/macrostep)-like effect.

This a step (hehe) towards addressing clojure-emacs/cider#1850.