### PR TITLE
Update to dynapath 0.2.5

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
   :dependencies [[org.clojure/tools.nrepl "0.2.12"]
-                 [org.tcrawley/dynapath "0.2.4"]
+                 [org.tcrawley/dynapath "0.2.5"]
                  ^:source-dep [mvxcvi/puget "1.0.1"]
                  ^:source-dep [fipp "0.6.6"]
                  ^:source-dep [compliment "0.3.2"]


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done:

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [ ] All tests are passing
- [ ] The new code is not generating reflection warnings
- [ ] You've updated the readme (if adding/changing middleware)

Thanks!

This version addresses two Java 9 related issues:

* 0.2.4 would fail under Java 9 if AOT'd
* the latest Java 9 build (9-ea+148) broke dynapath's reflection to make
  URLClassLoader modifiable