### PR TITLE
Add path tracking functionality to inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Middleware        | Op(s)      | Description
 `wrap-debug`      | `init-debugger/debug-input` | Establish a channel for `cider-debug` commands, use it to get debug input, and also wrap the eval op.
 `wrap-format`     | `format-(code/edn)` | Code and data formatting.
 `wrap-info`       | `info/eldoc` | File/line, arglists, docstrings and other metadata for vars.
-`wrap-inspect`    |`inspect-(start/refresh/pop/push/reset)` | Inspect a Clojure expression.
+`wrap-inspect`    |`inspect-(start/refresh/pop/push/reset/get-path)` | Inspect a Clojure expression.
 `wrap-macroexpand`| `macroexpand/macroexpand-1/macroexpand-all/macroexpand-step` | Macroexpand a Clojure form.
 `wrap-ns`         | `ns-list/ns-vars/ns-path/ns-load-all` | Namespace browsing & loading.
 `wrap-pprint`     | | Adds pretty-printing support to code evaluation. It also installs a dummy `pprint-middleware` op. Thus `wrap-pprint` is discoverable through the `describe` op.

--- a/src/cider/nrepl/middleware/inspect.clj
+++ b/src/cider/nrepl/middleware/inspect.clj
@@ -66,6 +66,10 @@
   (try (success msg (swap-inspector! msg #(or % (inspect/fresh))))
        (catch Exception e (failure msg e :inspect-refresh-error))))
 
+(defn get-path-reply [{:keys [session] :as msg}]
+  (try (success msg (:path (get session #'*inspector*)))
+       (catch Exception e (failure msg e :inspect-get-path-error))))
+
 (defn next-page-reply [msg]
   (try (success msg (swap-inspector! msg inspect/next-page))
        (catch Exception e (failure msg e :inspect-next-page-error))))
@@ -90,6 +94,7 @@
       "inspect-pop" (pop-reply msg)
       "inspect-push" (push-reply msg)
       "inspect-refresh" (refresh-reply msg)
+      "inspect-get-path" (get-path-reply msg)
       "inspect-next-page" (next-page-reply msg)
       "inspect-prev-page" (prev-page-reply msg)
       "inspect-set-page-size" (set-page-size-reply msg)
@@ -111,6 +116,10 @@
               :returns {"status" "\"done\""}}
              "inspect-refresh"
              {:doc "Re-renders the currently inspected value."
+              :requires {"session" "The current session"}
+              :returns {"status" "\"done\""}}
+             "inspect-get-path"
+             {:doc "Returns the path to the current position in the inspected value."
               :requires {"session" "The current session"}
               :returns {"status" "\"done\""}}
              "inspect-next-page"

--- a/test/clj/cider/nrepl/middleware/inspect_test.clj
+++ b/test/clj/cider/nrepl/middleware/inspect_test.clj
@@ -14,7 +14,7 @@
 
 (def inspect-result ["(\"Class\" \": \" (:value \"clojure.lang.PersistentTreeMap\" 0) (:newline) \"Contents: \" (:newline) \"  \" \"0\" \". \" (:value \"[ :a { :b 1 } ]\" 1) (:newline) \"  \" \"1\" \". \" (:value \"[ :c \\\"a\\\" ]\" 2) (:newline) \"  \" \"2\" \". \" (:value \"[ :d e ]\" 3) (:newline) \"  \" \"3\" \". \" (:value \"[ :f [ 2 3 ] ]\" 4) (:newline))"])
 
-(def push-result ["(\"Class\" \": \" (:value \"clojure.lang.PersistentTreeMap$BlackVal\" 0) (:newline) \"Contents: \" (:newline) \"  \" \"0\" \". \" (:value \":a\" 1) (:newline) \"  \" \"1\" \". \" (:value \"{ :b 1 }\" 2) (:newline))"])
+(def push-result ["(\"Class\" \": \" (:value \"clojure.lang.PersistentTreeMap$BlackVal\" 0) (:newline) \"Contents: \" (:newline) \"  \" \"0\" \". \" (:value \":a\" 1) (:newline) \"  \" \"1\" \". \" (:value \"{ :b 1 }\" 2) (:newline) (:newline) \"  Path: (find :a)\")"])
 
 (def long-sequence (range 70))
 (def long-vector (vec (range 70)))
@@ -160,6 +160,47 @@
                inspect/next-page
                inspect/prev-page
                :current-page)))))
+
+(deftest path-test
+  (testing "inspector tracks the path in the data structure"
+    (is (.endsWith (first (-> long-map
+                              inspect
+                              (inspect/down 20)
+                              render))
+                   "\"  Path: (find 50)\")"))
+    (is (.endsWith (first (-> long-map
+                              inspect
+                              (inspect/down 20)
+                              (inspect/down 1)
+                              render))
+                   "\"  Path: (find 50) first\")"))
+    (is (.endsWith (first (-> long-map
+                              inspect
+                              (inspect/down 20)
+                              (inspect/down 2)
+                              render))
+                   "\"  Path: (get 50)\")"))
+    (is (.endsWith (first (-> long-map
+                              inspect
+                              (inspect/down 20)
+                              (inspect/down 2)
+                              (inspect/down 0)
+                              render))
+                   "\"  Path: (get 50) class\")")))
+  (testing "doesn't show path if unknown navigation has happened"
+    (is (.endsWith (first (-> long-map
+                              inspect
+                              (inspect/down 20)
+                              (inspect/down 2)
+                              (inspect/down 0)
+                              (inspect/down 1)
+                              render))
+                   "(:newline))")))
+  (testing "doesn't show the path in the top level"
+    (is (.endsWith (first (-> [1 2 3]
+                              inspect
+                              render))
+                   "(:newline))"))))
 
 ;; integration tests
 

--- a/test/clj/cider/nrepl/middleware/util/inspect_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/inspect_test.clj
@@ -1,5 +1,5 @@
 (ns cider.nrepl.middleware.util.inspect-test
-  (:require [cider.nrepl.middleware.util.inspect :refer (inspect-value)]
+  (:require [cider.nrepl.middleware.util.inspect :as i :refer [inspect-value]]
             [clojure.test :refer :all]))
 
 (defprotocol IMyTestType
@@ -27,3 +27,25 @@
       "[ ( 1 1 1 1 1 ... ) ]" [(repeat 1)]
       "( 1 2 3 )" (lazy-seq '(1 2 3))
       "#<MyTestType test1>" (MyTestType. "test1"))))
+
+(deftest inspect-path
+  (testing "inspector keeps track of the path in the inspected structure"
+    (let [t {:a (list 1 2 {:b {:c (vec (map (fn [x] {:foo (* x 10)}) (range 100)))}})
+             :z 42}
+          inspector (-> (i/start (i/fresh) t)
+                        (i/down 1) (i/down 2)
+                        (i/up) (i/up)
+                        (i/down 1) (i/down 2)
+                        (i/down 2)
+                        (i/up)
+                        (i/down 3)
+                        (i/down 1) (i/down 2)
+                        (i/down 1) (i/down 2)
+                        (i/down 10)
+                        (i/down 1) (i/down 1))]
+      inspector
+      (is (= '[:a (nth 2) :b :c (nth 9) (find :foo) first] (:path inspector)))
+      (is (= '[:a (nth 2) :b :c (nth 9) (find :foo) first class]
+             (:path (-> inspector (i/down 0)))))
+      (is (= '[:a (nth 2) :b :c (nth 9) (find :foo) first class <unknown>]
+             (:path (-> inspector (i/down 0) (i/down 1))))))))


### PR DESCRIPTION
In the inspector a path is a series of functions to be applied to the inspected data structure to arrive at the current destination. The idea is to render the path in the inspector buffer, and to give ability to copy the path to kill-ring by pressing `w`.

Path is represented as if the inspected value was threaded with `->`.

For example, in a structure:

```clojure
{:a [{:b 1} {:c 2}] :d 42}
```

after navigating to `2` the path shall be `:a (nth 1) :c`. Navigating to `:b` yields `:a (nth 0) (find :b) first`.

Haven't modified the README yet, waiting for the green light for the feature in general.