### PR TITLE
Output to each session's *err* in the same manner as *out*

### DIFF
--- a/src/cider/nrepl/middleware/out.clj
+++ b/src/cider/nrepl/middleware/out.clj
@@ -80,7 +80,9 @@
                       ([bytes]
                        (.write @(resolve printer) (String. bytes)))
                       ([bytes ^Integer off ^Integer len]
-                       (.write @(resolve printer) (String. bytes) off len)))
+                       (let [byte-range (byte-array
+                                         (take len (drop off bytes)))]
+                        (.write @(resolve printer) (String. byte-range)))))
                     (flush []
                       (.flush @(resolve printer))))
                   true)))

--- a/src/cider/nrepl/middleware/out.clj
+++ b/src/cider/nrepl/middleware/out.clj
@@ -14,13 +14,12 @@
             [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
             [clojure.tools.nrepl.middleware.interruptible-eval :as ie]
             [clojure.tools.nrepl.middleware.session :as session])
-  (:import [java.io PrintWriter Writer]))
+  (:import [java.io PrintWriter Writer PrintStream OutputStream]))
 
 ;;; OutStream
 (defonce original-out *out*)
 (defonce original-err *err*)
 
-(declare tracked-sessions-map)
 (declare unsubscribe-session)
 
 (defmacro with-out-binding
@@ -64,6 +63,27 @@
                       (.flush printer))))
                 true))
 
+(defn print-stream
+  "Returns a PrintStream suitable for binding as java.lang.System/out
+  or java.lang.System/err. All operations are forwarded to all output
+  bindings in the sessions of messages in addition to the server's
+  usual PrintWriter (saved in `original-out` or `original-err`).
+  type is either :out or :err."
+  [type]
+  (let [printer (case type
+                  :out '*out*
+                  :err '*err*)]
+    (PrintStream. (proxy [OutputStream] []
+                    (close [] (.flush ^OutputStream this))
+                    (write
+                      ([b]
+                       (.write @(resolve printer) (String. b)))
+                      ([b ^Integer off ^Integer len]
+                       (.write @(resolve printer) (String. b) off len)))
+                    (flush []
+                      (.flush @(resolve printer))))
+                  true)))
+
 ;;; Known eval sessions
 (def tracked-sessions-map
   "Map from session ids to eval `*msg*`s.
@@ -71,12 +91,12 @@
   (atom {}))
 
 (defn tracked-sessions-map-watch [_ _ _ new-state]
-  (let [o (forking-printer (vals new-state) :out)]
-    ;; FIXME: This won't apply to Java loggers unless we also
-    ;; `setOut`, but for that we need to convert a `PrintWriter` to a
-    ;; `PrintStream` (or maybe just not use a `PrintWriter` above).
-    ;; (System/setOut (PrintStream. o))
-    (alter-var-root #'*out* (constantly o))))
+  (let [ow (forking-printer (vals new-state) :out)
+        ew (forking-printer (vals new-state) :err)]
+    (alter-var-root #'*out* (constantly ow))
+    (alter-var-root #'*err* (constantly ew))
+    (System/setOut (print-stream :out))
+    (System/setErr (print-stream :err))))
 
 (add-watch tracked-sessions-map :update-out tracked-sessions-map-watch)
 


### PR DESCRIPTION
This builds on @Malabarba's work in #304 in order to fix https://github.com/clojure-emacs/cider/issues/1588 and https://github.com/clojure-emacs/cider/issues/1896.  In addition, this also redirects Java's `System/out` and `System/err` to `*out*` and `*err*` (they're confusingly not the same) so that everything you'd expect gets printed at the repl.

I didn't add tests because I'm not sure how to go about doing that without actually spinning up an nrepl server.  I'm glad to accept guidance on this, though.  Existing tests do pass.
