### PR TITLE
[Fix #1914] Proper formatting of spec descriptions

### DIFF
--- a/src/cider/nrepl/middleware/info.clj
+++ b/src/cider/nrepl/middleware/info.clj
@@ -64,6 +64,17 @@
         (assoc :file (ns/ns-path ns)))
     meta-map))
 
+(defn- format-spec-descripton
+  "Format the spec description to display each predicate on a new line."
+  [description]
+  (if (seq? description)
+    ;; drop the first element, format everything else with newlines and tabs,
+    ;; and add the surrounding parens
+    (let [beg (format "(%s " (pr-str (first description)))
+          desc (drop 1 description)]
+      (format "%s%s)" beg (str/join (map #(format "\n\t%s" (pr-str %)) desc))))
+    (pr-str description)))
+
 ;; Similar to `print-doc` from clojure.core
 ;; https://github.com/clojure/clojure/blob/master/src/clj/clojure/repl.clj#L83
 (defn- format-spec
@@ -71,7 +82,9 @@
   (for [role [:args :ret :fn]
         :let [spec' (get fnspec role)]
         :when spec']
-    (str (name role) ": " (pr-str (spec/describe spec')))))
+    (let [desc (spec/describe spec')]
+      ;; the -4s aligns the fdef parameters (args, ret and fn)
+      (str (format "%-4s: " (name role)) (format-spec-descripton desc)))))
 
 (defn maybe-add-spec
   "If the var `v` has a spec has associated with it, assoc that into meta-map.

--- a/test/spec/cider/nrepl/middleware/info_test.clj
+++ b/test/spec/cider/nrepl/middleware/info_test.clj
@@ -25,9 +25,9 @@
       (is (= (:arglists-str response) "([start end])"))
       (is (nil? (:macro response)))
       (is (= (:doc response) "Returns random int in range start <= rand < end."))
-      (is (= (:spec response) ["args: (and (cat :start int? :end int?) (< (:start %) (:end %)))"
-                               "ret: int?"
-                               "fn: (and (>= (:ret %) (-> % :args :start)) (< (:ret %) (-> % :args :end)))"])))
+      (is (= (:spec response) ["args: (and\n\t(cat :start int? :end int?)\n\t(< (:start %) (:end %)))"
+                               "ret : int?"
+                               "fn  : (and\n\t(>= (:ret %) (-> % :args :start))\n\t(< (:ret %) (-> % :args :end)))"])))
 
     ;; spec is not defined for this function
     (let [response (session/message {:op "info" :symbol "same-name-testing-function" :ns "cider.test-ns.first-test-ns"})]


### PR DESCRIPTION
Fixes https://github.com/clojure-emacs/cider/issues/1914 

![right](https://cloud.githubusercontent.com/assets/5201497/21905644/2a88ce28-d8d6-11e6-96ca-3677956fd5f3.png)

Every spec is on a newline, right from the first `(cat :start int? :end int?)` because this way, all them are aligned irrespective of the length of the combinator, `and` in this case.


Before submitting a PR make sure the following things have been done:

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [ ] The new code is not generating reflection warnings
- [ ] You've updated the readme (if adding/changing middleware)

Thanks!
