### PR TITLE
Add complete-flush-caches command to force clear Compliment's caches

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [org.tcrawley/dynapath "0.2.5"]
                  ^:source-dep [mvxcvi/puget "1.0.1"]
                  ^:source-dep [fipp "0.6.6"]
-                 ^:source-dep [compliment "0.3.2"]
+                 ^:source-dep [compliment "0.3.3"]
                  ^:source-dep [cljs-tooling "0.2.0"]
                  ^:source-dep [cljfmt "0.5.6" :exclusions [org.clojure/clojurescript]]
                  ^:source-dep [org.clojure/java.classpath "0.2.3"]

--- a/src/cider/nrepl/middleware/complete.clj
+++ b/src/cider/nrepl/middleware/complete.clj
@@ -5,6 +5,7 @@
             [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
             [cider.nrepl.middleware.util.misc :as u]
             [compliment.core :as jvm-complete]
+            [compliment.utils :as jvm-complete-utils]
             [cljs-tooling.complete :as cljs-complete]))
 
 (defn complete
@@ -31,12 +32,18 @@
   [msg]
   {:completion-doc (completion-doc msg)})
 
+(defn flush-caches-reply
+  [msg]
+  (jvm-complete-utils/flush-caches)
+  {})
+
 (defn wrap-complete
   "Middleware that looks up possible functions for the given (partial) symbol."
   [handler]
   (with-safe-transport handler
     "complete" complete-reply
-    "complete-doc" doc-reply))
+    "complete-doc" doc-reply
+    "complete-flush-caches" flush-caches-reply))
 
 (set-descriptor!
  #'wrap-complete
@@ -54,4 +61,6 @@
     {:doc "Retrieve documentation suitable for display in completion popup"
      :requires {"ns" "The symbol's namespace"
                 "symbol" "The symbol to lookup"}
-     :returns {"completion-doc" "Symbol's documentation"}}}}))
+     :returns {"completion-doc" "Symbol's documentation"}}
+    "complete-flush-caches"
+    {:doc "Forces the completion backend to repopulate all its caches"}}}))

--- a/test/clj/cider/nrepl/middleware/complete_test.clj
+++ b/test/clj/cider/nrepl/middleware/complete_test.clj
@@ -67,6 +67,11 @@
       (is (= (:status response) #{"done"}))
       (is (.startsWith (:completion-doc response) "clojure.core/true?\n([x")))))
 
+(deftest complete-flush-caches-test
+  (testing "basic usage"
+    (let [response (session/message {:op "complete-flush-caches"})]
+      (is (= (:status response) #{"done"})))))
+
 (deftest error-handling-test
   (testing "complete op error handling"
     (with-redefs [c/complete (fn [& _] (throw (Exception. "complete-exc")))]


### PR DESCRIPTION
Related to alexander-yakushev/compliment#45. While the issue is mostly solved automatically, explicit flushing might sometimes still be necessary.

Sister PR is at clojure-emacs/cider#1943.