### PR TITLE
[Fix #399] Catch ns-path exceptions propagated from tools.reader

### DIFF
--- a/src/cider/nrepl/middleware/util/namespace.clj
+++ b/src/cider/nrepl/middleware/util/namespace.clj
@@ -112,11 +112,13 @@
   "Return the path to a file containing namespace `ns`.
   `ns` can be a Namespace object or the name of a namespace."
   [ns]
-  (let [ns (if (instance? clojure.lang.Namespace ns)
-             (ns-name ns) (symbol ns))]
-    (loop [paths (all-clj-files-on-cp)]
-      (when (seq paths)
-        (let [file-ns (second (ns-file/read-file-ns-decl (first paths)))]
-          (if (= file-ns ns)
-            (first paths)
-            (recur (rest paths))))))))
+  (try
+    (let [ns (if (instance? clojure.lang.Namespace ns)
+               (ns-name ns) (symbol ns))]
+      (loop [paths (all-clj-files-on-cp)]
+        (when (seq paths)
+          (let [file-ns (second (ns-file/read-file-ns-decl (first paths)))]
+            (if (= file-ns ns)
+              (first paths)
+              (recur (rest paths)))))))
+    (catch Throwable _ nil)))


### PR DESCRIPTION
This PR adds error handling to the `ns-path` function for catching exceptions propagated from `tools.reader` (breaking change going from 0.2.11 to 0.3.0-alpha1).

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [x] All tests are passing
- [ ] The new code is not generating reflection warnings
- [ ] You've updated the readme (if adding/changing middleware)
