### PR TITLE
Feature/mark project in stacktrace

### DIFF
--- a/test/clj/cider/nrepl/middleware/stacktrace_test.clj
+++ b/test/clj/cider/nrepl/middleware/stacktrace_test.clj
@@ -26,9 +26,12 @@
 (def form2 '(do (defn oops [] (+ 1 "2"))
                 (oops)))
 (def form3 '(not-defined))
+(defn divi [x y] (/ x y))
+(def form4 '(divi 1 0))
 
 (def frames1 (stack-frames form1))
 (def frames2 (stack-frames form2))
+(def frames4 (stack-frames form4))
 (def causes1 (causes form1))
 (def causes2 (causes form2))
 (def causes3 (causes form3))
@@ -68,6 +71,8 @@
                 (filter (comp :tooling :flags) frames1)))
       (is (some #(re-find #"(clojure|nrepl|run)" (:name %))
                 (filter (comp :tooling :flags) frames2))))
+    (testing "for project"
+      (is (not-empty (filter (comp :project :flags) frames4))))
     (testing "for duplicate frames"
       ;; Index frames. For all frames flagged as :dup, the frame above it in
       ;; the stack (index i - 1) should be substantially the same source info.


### PR DESCRIPTION
https://github.com/clojure-emacs/cider/issues/1929

In reference to the above. The feature is an easy way to filter down to just the project frames in a stack trace.

An idea given in that request was from a project called Prone which would read the project.clj file. This is deficient for two reasons: 1) it ties the implementation to lein when we are already a little lein heavy and 2) it doesn't work: to wit, cider-nrepl's project name is cider/cider-nrepl which would match 0 namespaces. 

In order to work around this, I look at the class path, determine which are directories, and then call tools.namespace/find-namespaces, which conveniently finds all namespaces in a seq of directories. But I ran into some non-classpath namespaces, since cider-nrepl uses profiles for testing. To accommodate this, I reduce these found namespaces down to a common prefix that I use to match against any namespaces in the stack trace.

Thus the test to see if a namespace is in a project is a) are you a namespace in a directory on the classpath or b) does your namespace begin with the common prefix of those namespaces mentioned in a).