### PR TITLE
Enable stacktrace support for piggieback.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -62,7 +62,7 @@
                         :java-source-paths ["test/java"]
                         :resource-paths ["test/resources"]}
              :test-cljs {:test-paths ["test/cljs"]
-                         :dependencies [[com.cemerick/piggieback "0.2.1"]
+                         :dependencies [[com.cemerick/piggieback "0.2.2"]
                                         [org.clojure/clojurescript "1.7.189"]]}
 
              :cloverage {:plugins [[lein-cloverage "1.0.7-SNAPSHOT"]]}

--- a/src/cider/nrepl/middleware/stacktrace.clj
+++ b/src/cider/nrepl/middleware/stacktrace.clj
@@ -211,8 +211,7 @@
 
 (defn wrap-stacktrace-reply
   [{:keys [session transport pprint-fn] :as msg}]
-  ;; no stacktrace support for cljs currently - they are printed by piggieback anyway
-  (if-let [e (when-not (cljs/grab-cljs-env msg) (@session #'*e))]
+  (if-let [e (@session #'*e)]
     (doseq [cause (analyze-causes e pprint-fn)]
       (t/send transport (response-for msg cause)))
     (t/send transport (response-for msg :status :no-error)))

--- a/test/cljs/cider/nrepl/middleware/cljs_stacktrace_test.clj
+++ b/test/cljs/cider/nrepl/middleware/cljs_stacktrace_test.clj
@@ -6,11 +6,15 @@
 (use-fixtures :each piggieback-fixture)
 
 (deftest cljs-stacktrace-test
-  (testing "stacktrace op is not implemented"
-    (let [response-with-no-error (session/message {:op :stacktrace})
-          response-with-error (do (session/message {:op :eval
-                                                    :code "(ffirst 1)"})
-                                  (session/message {:op :stacktrace}))]
+  (testing "no last error"
+    (let [response (session/message {:op :stacktrace})]
       (is (= #{"no-error" "done"}
-             (:status response-with-no-error)
-             (:status response-with-error))))))
+             (:status response)))))
+  (testing "last error stacktrace"
+    (let [response (do (session/message {:op :eval
+                                         :code "(ffirst 1)"})
+                       (session/message {:op :stacktrace}))]
+      (is (= #{"done"}
+             (:status response)))
+      (is (= "clojure.lang.ExceptionInfo"
+             (:class response))))))


### PR DESCRIPTION
As of https://github.com/cemerick/piggieback/pull/72 piggieback supports *e so this change enables the stacktrace middlware for piggieback.

The change is backwards compatible with older versions of piggieback which don't set *e. A :status :no-error response is sent as before.