### PR TITLE
Include special forms in apropos

### DIFF
--- a/src/cider/nrepl/middleware/info.clj
+++ b/src/cider/nrepl/middleware/info.clj
@@ -139,15 +139,17 @@
   used by `clojure.repl/doc`."
   [sym]
   (try
-    (let [sym (get '{& fn, catch try, finally try} sym sym)
+    (let [orig-sym sym
+          sym (get '{& fn, catch try, finally try} sym sym)
           v   (meta (ns-resolve (find-ns 'clojure.core) sym))]
       (when-let [m (cond (special-symbol? sym) (#'repl/special-doc sym)
                          (:special-form v) v)]
-        (assoc m
-               :url (if (contains? m :url)
-                      (when (:url m)
-                        (str "https://clojure.org/" (:url m)))
-                      (str "https://clojure.org/special_forms#" (:name m))))))
+        (-> m
+            (assoc :name orig-sym)
+            (assoc :url (if (contains? m :url)
+                          (when (:url m)
+                            (str "https://clojure.org/" (:url m)))
+                          (str "https://clojure.org/special_forms#" (:name m)))))))
     (catch NoClassDefFoundError _)
     (catch Exception _)))
 

--- a/test/clj/cider/nrepl/middleware/info_test.clj
+++ b/test/clj/cider/nrepl/middleware/info_test.clj
@@ -53,7 +53,7 @@
     (spit tmp-file-path "test")
     (testing "when fake.class.path is not set"
       (is (not (= (class (file tmp-file-name))
-                  java.net.URL)))
+                java.net.URL)))
       (is (= (file tmp-file-name) tmp-file-name)))
     (testing "when fake.class.path is set"
       (try
@@ -72,6 +72,22 @@
                  "file:fake/clojure.jar"))
           (finally
             (System/clearProperty "fake.class.path")))))))
+
+(deftest resolve-special-test
+  (testing "Resolves all special forms"
+    (let [specials (keys clojure.lang.Compiler/specials)]
+      (is (every? (fn [[sym {:keys [name special-form]}]]
+                    (and (= sym name)
+                         (true? special-form)))
+                  (map #(vector % (info/resolve-special %)) specials)))))
+
+  (testing "Names are correct for symbols #{&, catch, finally}"
+    (is (= '& (:name (info/resolve-special '&))))
+    (is (= 'catch (:name (info/resolve-special 'catch))))
+    (is (= 'finally (:name (info/resolve-special 'finally)))))
+
+  (testing "Returns nil for unknown symbol"
+    (is (nil? (info/resolve-special 'unknown)))))
 
 (deftype T [])
 


### PR DESCRIPTION
Fixes #409.

Some special forms (e.g. `if`) are included in apropos if the `search-ns` is nil or
`clojure.core`.

Included special forms are those those with documentation in `clojure.repl`,
as well as `&`, `catch`, and `finally`, the first of which uses the
documentation of `fn` and the others that of `try`.

**Update**:

With Lein 2.7.1, this passes:

```
$ lein with-profile +master,+test-clj test

Ran 181 tests containing 1118 assertions.
0 failures, 0 errors.
```

Whereas this does not:

```
$ lein with-profile +master,+plugin.mranderson/config,+test-clj test

Exception in thread "main" java.io.FileNotFoundException: Could not locate fipp/edn__init.class or fipp/edn.clj on classpath., compiling:(cider/nrepl/middleware/pprint.clj:1:1)
	at clojure.lang.Compiler.load(Compiler.java:7391)
...
```

Maybe the `thomasa/mranderson` plugin needs to be updated?

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [ ] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the readme (if adding/changing middleware)

Thanks!
