### PR TITLE
Find relative path for cljs & boot in info [#421]

### DIFF
--- a/src/cider/nrepl/middleware/info.clj
+++ b/src/cider/nrepl/middleware/info.clj
@@ -12,11 +12,6 @@
             [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
             [cider.nrepl.middleware.util.spec :as spec]))
 
-(defn- boot-project? []
-  ;; fake.class.path under boot contains the original directories with source
-  ;; files, see https://github.com/boot-clj/boot/issues/249
-  (not (nil? (System/getProperty "fake.class.path"))))
-
 (defn- boot-class-loader
   "Creates a class-loader that knows original source files paths in Boot project."
   []
@@ -83,7 +78,7 @@
           (update
             :file
             (fn [f]
-              (if (boot-project?)
+              (if (u/boot-project?)
                 ;; Boot stores files in a temporary directory & clojurescript
                 ;; stores the :file metadata location absolutely instead of
                 ;; relatively to the classpath. This means when doing jump to


### PR DESCRIPTION
This fixes a case where in clojurescript the `:file` is stored as an
absolute path, meaning it points to a temporary file in boot.

It uses java.nio.file.Path to find all paths with the prefixes deleted,
and filters them until it finds one on the classpath. This implicitly
finds the longest one.

If it cannot find a contracted version of the file on the classpath, it
will pass through the original absolute path which points to a temporary
file.

A small optimisation here is doing this only for boot. But that does
mean that the results will be different for boot & lein as opposed to
previously where it was clj & cljs. I've not tested if there's a
performance improvement, but it will likely reduce unexpected behaviour.

| | CLJ | CLJS |
|-|-----|----------
| Boot | `:resource` |`:resource` most of the time |
| Lein | `:resource` | `:resource` unset |

Currently cljs never has `:resource`. I have no idea if this will matter
to any consumers, only future ones if at all, and it can be enabled by
disabling the check.

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md). *NB: I'm skipping the testing because it would require launching a real version of boot, which is a major extension to the testing*
- [X] You've added tests to cover your change(s)
- [X] All tests are passing
- [X] The new code is not generating reflection warnings *NB: Doesn't seem to be*
- [X] You've updated the readme (if adding/changing middleware)
