### PR TITLE
Fix [#418] Add boot as a dev dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -49,7 +49,10 @@
                                                      cider.nrepl.middleware.version/wrap-version]}
                    :dependencies [[org.clojure/tools.nrepl "0.2.13"]
                                   ;; For developing the Leiningen plugin.
-                                  [leiningen-core "2.7.1"]]}
+                                  [leiningen-core "2.7.1"]
+                                  ;; For the boot tasks namespace
+                                  [boot/base "2.7.1"]
+                                  [boot/core "2.7.1"]]}
 
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}


### PR DESCRIPTION
Both boot/base and boot/core seem necessary. For reasons I'm uncertain
of, neither depends on the other through their pom.xml. This could be a
mistake, or it could be due to how boot must isolate it's pods.

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [X] You've added tests to cover your change(s)
- [X] All tests are passing
- [X] The new code is not generating reflection warnings
- [X] You've updated the readme (if adding/changing middleware)