### PR TITLE
Require tns/session where grab-cljs-env is used

### DIFF
--- a/src/cider/nrepl/middleware/complete.clj
+++ b/src/cider/nrepl/middleware/complete.clj
@@ -1,6 +1,7 @@
 (ns cider.nrepl.middleware.complete
   (:require [clojure.string :as s]
             [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
+            [clojure.tools.nrepl.middleware.session :as session]
             [cider.nrepl.middleware.util.cljs :as cljs]
             [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
             [cider.nrepl.middleware.util.misc :as u]
@@ -48,7 +49,8 @@
 (set-descriptor!
  #'wrap-complete
  (cljs/requires-piggieback
-  {:handles
+  {:requires #{#'session/session}
+   :handles
    {"complete"
     {:doc "Return a list of symbols matching the specified (partial) symbol."
      :requires {"ns" "The symbol's namespace"

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -14,6 +14,7 @@
             [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
             [clojure.tools.nrepl.middleware.interruptible-eval :refer [*msg*]]
             [clojure.tools.nrepl.misc :refer [response-for]]
+            [clojure.tools.nrepl.middleware.session :as session]
             [clojure.tools.nrepl.transport :as transport]
             [cider.nrepl.middleware.util.misc :as u])
   (:import [clojure.lang Compiler$LocalBinding]))
@@ -596,7 +597,7 @@ this map (identified by a key), and will `dissoc` it afterwards."}
  #'wrap-debug
  (cljs/requires-piggieback
   {:expects #{"eval"}
-   :requires #{#'pprint/wrap-pprint-fn}
+   :requires #{#'pprint/wrap-pprint-fn #'session/session}
    :handles
    {"debug-input"
     {:doc "Read client input on debug action."

--- a/src/cider/nrepl/middleware/info.clj
+++ b/src/cider/nrepl/middleware/info.clj
@@ -10,6 +10,7 @@
             [cider.nrepl.middleware.util.meta :as m]
             [cljs-tooling.info :as cljs-info]
             [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
+            [clojure.tools.nrepl.middleware.session :as session]
             [cider.nrepl.middleware.util.spec :as spec]))
 
 (defn- boot-class-loader
@@ -290,7 +291,8 @@
 (set-descriptor!
  #'wrap-info
  (cljs/requires-piggieback
-  {:handles
+  {:requires #{#'session/session}
+   :handles
    {"info"
     {:doc "Return a map of information about the specified symbol."
      :requires {"symbol" "The symbol to lookup"

--- a/src/cider/nrepl/middleware/macroexpand.clj
+++ b/src/cider/nrepl/middleware/macroexpand.clj
@@ -8,6 +8,7 @@
             [clojure.pprint :as pp]
             [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
             [clojure.tools.nrepl.misc :refer [response-for]]
+            [clojure.tools.nrepl.middleware.session :as session]
             [clojure.tools.reader :as reader]
             [clojure.walk :as walk])
   (:import [clojure.lang Var]))
@@ -229,7 +230,8 @@
 (set-descriptor!
  #'wrap-macroexpand
  (cljs/requires-piggieback
-  {:handles
+  {:requires #{#'session/session}
+   :handles
    {"macroexpand"
     {:doc "Produces macroexpansion of some form using the given expander."
      :requires {"code" "The form to macroexpand."}

--- a/src/cider/nrepl/middleware/ns.clj
+++ b/src/cider/nrepl/middleware/ns.clj
@@ -8,7 +8,8 @@
             [cljs-tooling.util.analysis :as cljs-analysis]
             [clojure.tools.nrepl
              [middleware :refer [set-descriptor!]]
-             [misc :refer [response-for]]]))
+             [misc :refer [response-for]]]
+            [clojure.tools.nrepl.middleware.session :as session]))
 
 (defn ns-list-vars-by-name
   "Return a list of vars named `name` amongst all namespaces.
@@ -112,7 +113,8 @@
 (set-descriptor!
  #'wrap-ns
  (cljs/requires-piggieback
-  {:handles
+  {:requires #{#'session/session}
+   :handles
    {"ns-list"
     {:doc "Return a sorted list of all namespaces."
      :returns {"status" "done" "ns-list" "The sorted list of all namespaces."}

--- a/src/cider/nrepl/middleware/track_state.clj
+++ b/src/cider/nrepl/middleware/track_state.clj
@@ -11,6 +11,7 @@
             [clojure.tools.namespace.find :as ns-find]
             [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
             [clojure.tools.nrepl.misc :refer [response-for]]
+            [clojure.tools.nrepl.middleware.session :as session]
             [clojure.tools.nrepl.transport :as transport])
   (:import clojure.lang.Namespace
            clojure.tools.nrepl.transport.Transport
@@ -207,7 +208,7 @@
 (set-descriptor!
  #'wrap-tracker
  (cljs/expects-piggieback
-  {:requires #{#'clojure.tools.nrepl.middleware.session/session}
+  {:requires #{#'session/session}
    :expects ops-that-can-eval
    :handles
    {"track-state-middleware"


### PR DESCRIPTION
`grab-cljs-env` peeks into the message for the resolved `:session` key,
this will only have happened if the tns session middleware has been run
over the message.

TNS is consistent in how it orders middleware, so I wasn't able to
trigger this bug, but #345 seems like it could be caused by this.