### PR TITLE
Ensure pprint is after load-file

### DIFF
--- a/src/cider/nrepl/middleware/pprint.clj
+++ b/src/cider/nrepl/middleware/pprint.clj
@@ -120,7 +120,7 @@
   false, or string representations of the above)."
   [handler]
   (fn [{:keys [op pprint] :as msg}]
-    (handler (if (and pprint (= op "eval"))
+    (handler (if (and pprint (#{"eval" "load-file"} op))
                (assoc msg :transport (pprint-transport msg))
                msg))))
 
@@ -128,7 +128,7 @@
  #'wrap-pprint
  (cljs/expects-piggieback
   {:requires #{"clone" #'pr-values #'wrap-pprint-fn}
-   :expects #{"eval"}
+   :expects #{"eval" "load-file"}
    :handles
    {"pprint-middleware"
     {:doc "Enhances the `eval` op by adding pretty-printing. Not an op in itself."


### PR DESCRIPTION
load-file can produce an eval message. Non-deterministically load-file
was before/after pprint middleware. This would mean that pprint would
sometimes work for load-file, and not other times, dependent upon a JVM
restart.

This makes https://github.com/tpope/vim-fireplace/pull/301 work

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [X] You've added tests to cover your change(s)
- [X] All tests are passing
- [X] The new code is not generating reflection warnings
- [X] You've updated the readme (if adding/changing middleware)

As an aside: I can't get the tests to pass locally even on master, so I'm depending on the CI
