### PR TITLE
Fixing the debugger "wrong namespace" issues. 

### DIFF
--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -332,23 +332,23 @@ this map (identified by a key), and will `dissoc` it afterwards."}
       :here       (do (skip-breaks! :before coord (:code dbg-state) force?)
                       value)
       :stacktrace (do (debug-stacktrace)
-                      (read-debug-command value dbg-state))
+                      (recur value dbg-state))
       :trace      (do (skip-breaks! :trace)
                       value)
       :locals     (->> (debug-inspect page-size (:locals dbg-state))
                        (assoc dbg-state :inspect)
-                       (read-debug-command value))
+                       (recur value))
       :inspect    (try-let [val (read-eval-expression "Inspect value: " dbg-state code)]
                     (->> (debug-inspect page-size val)
                          (assoc dbg-state :inspect)
-                         (read-debug-command value))
-                    (read-debug-command value dbg-state))
+                         (recur value))
+                    (recur value dbg-state))
       :inject     (try-let [val (read-eval-expression "Expression to inject: " dbg-state code)]
                     val
-                    (read-debug-command value dbg-state))
+                    (recur value dbg-state))
       :eval       (try-let [val (read-eval-expression "Expression to evaluate: " dbg-state code)]
-                    (read-debug-command value (assoc dbg-state :debug-value (pr-short val)))
-                    (read-debug-command value dbg-state))
+                    (recur value (assoc dbg-state :debug-value (pr-short val)))
+                    (recur value dbg-state))
       :quit       (abort!)
       (do (abort!)
           (throw (ex-info "Invalid input from `read-debug-input`."

--- a/src/cider/nrepl/middleware/enlighten.clj
+++ b/src/cider/nrepl/middleware/enlighten.clj
@@ -35,7 +35,7 @@
   in a single evaluation. This is necessary so that the client can
   clean-up overlays from previous evaluations."
   [[head & args :as form] {:keys [coor] :as extras}]
-  (let [erase `(d/debugger-send (assoc (:msg ~'META__)
+  (let [erase `(d/debugger-send (assoc (:msg ~'STATE__)
                                        :coor ~coor
                                        :status :enlighten
                                        :erase-previous :true))]
@@ -49,7 +49,7 @@
                     `#(do ~erase
                           (let [out# (apply ~val %&)]
                             ;; `defn` is the only non-symbol form that we enlighten.
-                            (->> (assoc (:msg ~'META__)
+                            (->> (assoc (:msg ~'STATE__)
                                         :coor ~coor
                                         :status :enlighten
                                         :debug-value (pr-very-short out#))
@@ -67,7 +67,7 @@
   (cond
     (symbol? original-form) `(do
                                (send-if-local '~original-form
-                                              (assoc (:msg ~'META__) :coor ~coor)
+                                              (assoc (:msg ~'STATE__) :coor ~coor)
                                               ~(d/sanitize-env &env))
                                ~form)
     (seq? form) (wrap-function-form form extras)

--- a/test/clj/cider/nrepl/middleware/debug_test.clj
+++ b/test/clj/cider/nrepl/middleware/debug_test.clj
@@ -73,12 +73,12 @@
           :locals ~(#'d/sanitize-env &env)
           :original-ns "user"))
 
-(deftest read-debug-roundtrip
+(deftest read-debug-input-roundtrip
   (reset! d/promises {})
   (with-redefs [t/send send-override-msg]
-    (is (:test (#'d/read-debug (extras {:test true}) :test-type "prompt")))
+    (is (:test (#'d/read-debug-input (extras {:test true}) :test-type "prompt")))
     (is (empty? @d/promises))
-    (are [pred key] (pred (key (#'d/read-debug (extras {:test true}) :test-type "prompt")))
+    (are [pred key] (pred (key (#'d/read-debug-input (extras {:test true}) :test-type "prompt")))
       true? :test
       :need-debug-input :status
       string? :key
@@ -115,13 +115,13 @@
                            (swap! replies rest))]
       (is (= 'value (#'d/read-debug-command 'value (add-locals {})))))))
 
-(deftest read-debug-eval-expression-test
+(deftest read-eval-expression-test
   (reset! d/debugger-message {})
   (let [x 1]
     (with-redefs [t/send (send-override '(inc 10))]
-      (is (= 11 (#'d/read-debug-eval-expression "" (add-locals {})))))
+      (is (= 11 (#'d/read-eval-expression "" (add-locals {})))))
     (with-redefs [t/send (send-override '(inc x))]
-      (is (= 2 (#'d/read-debug-eval-expression "" (add-locals {})))))))
+      (is (= 2 (#'d/read-eval-expression "" (add-locals {})))))))
 
 (deftest eval-add-locals
   (reset! @#'d/debugger-message {})
@@ -148,11 +148,11 @@
            (#'d/locals-for-message (locals))))))
 
 (deftest eval-expression-with-code-test
-  (is (= (#'d/read-debug-eval-expression
+  (is (= (#'d/read-eval-expression
            "Unused prompt" (add-locals {:some "random", 'meaningless :map}) '(inc 1))
          2))
   (let [x 10]
-    (is (= (#'d/read-debug-eval-expression
+    (is (= (#'d/read-eval-expression
              "Unused prompt" (add-locals {:some "random", 'meaningless :map}) '(inc x))
            11))))
 


### PR DESCRIPTION
Fixing #420,  clojure-emacs/cider#2039 and clojure-emacs/cider#2004 