### PR TITLE
Fix broken instrumentation of forms with #? conditionals

### DIFF
--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -571,7 +571,7 @@ this map (identified by a key), and will `dissoc` it afterwards."}
                                   (interleave '[dbg break light])
                                   (apply assoc *data-readers*))]
       (try
-        (read-string code)
+        (read-string {:read-cond :allow} code)
         (catch Exception e)))
     (if @has-debug?
       ;; Technically, `instrument-and-eval` acts like a regular eval

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -571,7 +571,9 @@ this map (identified by a key), and will `dissoc` it afterwards."}
                                   (interleave '[dbg break light])
                                   (apply assoc *data-readers*))]
       (try
-        (read-string {:read-cond :allow} code)
+        ;; new-line in REPL always throws; skip for debug convenience
+        (when (> (count code) 3)
+          (read-string {:read-cond :allow} code))
         (catch Exception e)))
     (if @has-debug?
       ;; Technically, `instrument-and-eval` acts like a regular eval


### PR DESCRIPTION
Any forms that contain reader conditionals cannot be instrumented: 

```clj
(defn tt [a]
  (let [b (+ a 1)]
    #?(:clj (println "clj")
       :cljs (println "cljs"))))
```

The reason is that conditionals are disabled by default in clojure's readers. 