### PR TITLE
Dynamically load middleware

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,27 +31,27 @@
 
   :profiles {:provided {:dependencies [[org.clojure/clojure "1.7.0"]]}
 
-             :dev {:repl-options {:nrepl-middleware [cider.nrepl.middleware.apropos/wrap-apropos
-                                                     cider.nrepl.middleware.classpath/wrap-classpath
-                                                     cider.nrepl.middleware.complete/wrap-complete
-                                                     cider.nrepl.middleware.debug/wrap-debug
-                                                     cider.nrepl.middleware.enlighten/wrap-enlighten
-                                                     cider.nrepl.middleware.format/wrap-format
-                                                     cider.nrepl.middleware.info/wrap-info
-                                                     cider.nrepl.middleware.inspect/wrap-inspect
-                                                     cider.nrepl.middleware.macroexpand/wrap-macroexpand
-                                                     cider.nrepl.middleware.ns/wrap-ns
-                                                     cider.nrepl.middleware.spec/wrap-spec
-                                                     cider.nrepl.middleware.out/wrap-out
+             :dev {:repl-options {:nrepl-middleware [cider.nrepl/wrap-apropos
+                                                     cider.nrepl/wrap-classpath
+                                                     cider.nrepl/wrap-complete
+                                                     cider.nrepl/wrap-debug
+                                                     cider.nrepl/wrap-enlighten
+                                                     cider.nrepl/wrap-format
+                                                     cider.nrepl/wrap-info
+                                                     cider.nrepl/wrap-inspect
+                                                     cider.nrepl/wrap-macroexpand
+                                                     cider.nrepl/wrap-ns
+                                                     cider.nrepl/wrap-out
+                                                     cider.nrepl/wrap-refresh
+                                                     cider.nrepl/wrap-resource
+                                                     cider.nrepl/wrap-spec
+                                                     cider.nrepl/wrap-stacktrace
+                                                     cider.nrepl/wrap-test
+                                                     cider.nrepl/wrap-trace
+                                                     cider.nrepl/wrap-tracker
+                                                     cider.nrepl/wrap-undef
                                                      cider.nrepl.middleware.pprint/wrap-pprint
                                                      cider.nrepl.middleware.pprint/wrap-pprint-fn
-                                                     cider.nrepl.middleware.refresh/wrap-refresh
-                                                     cider.nrepl.middleware.resource/wrap-resource
-                                                     cider.nrepl.middleware.stacktrace/wrap-stacktrace
-                                                     cider.nrepl.middleware.test/wrap-test
-                                                     cider.nrepl.middleware.trace/wrap-trace
-                                                     cider.nrepl.middleware.track-state/wrap-tracker
-                                                     cider.nrepl.middleware.undef/wrap-undef
                                                      cider.nrepl.middleware.version/wrap-version]}
                    :dependencies [[org.clojure/tools.nrepl "0.2.13"]
                                   ;; For developing the Leiningen plugin.

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -52,7 +52,7 @@
     `(do
        (defn ~name ~doc [~'h]
          (fn [~'msg]
-           (if ~cond
+           (if (and ~cond (not (:inhibit-cider-middleware ~'msg)))
              (run-delayed-handler ~handler-fn ~'h ~'msg)
              (~'h ~'msg))))
        (set-descriptor! #'~name ~descriptor))))

--- a/src/cider/nrepl/middleware/apropos.clj
+++ b/src/cider/nrepl/middleware/apropos.clj
@@ -41,7 +41,7 @@
   and may be case senstive. Types returned correspond to Apropos types.
   Docstring search returns the full doc; symbol search returns an abbreviated
   version."
-  [ns query search-ns docs? privates? case-sensitive? filter-regexps]
+  [{:keys [ns query search-ns docs? privates? case-sensitive? filter-regexps]}]
   (let [ns-vars     (if privates? ns-interns ns-publics)
         var-doc*    (if docs? var-doc (partial var-doc 1))
         search-prop (if docs? var-doc var-name)
@@ -61,24 +61,9 @@
 
 ;;; ## Middleware
 
-(defn handle-apropos
-  "Return a sequence of vars whose name matches the query pattern, or if
-  specified, having the pattern in their docstring."
-  [{:keys [ns query search-ns docs? privates? case-sensitive? filter-regexps] :as msg}]
-  {:apropos-matches (find-symbols ns query search-ns docs? privates? case-sensitive? filter-regexps)})
+(defn apropos [msg]
+  {:apropos-matches (find-symbols msg)})
 
-(defn wrap-apropos
-  "Middleware that handles apropos requests"
-  [handler]
-  (with-safe-transport handler
-    "apropos" handle-apropos))
-
-;; nREPL middleware descriptor info
-(set-descriptor!
- #'wrap-apropos
- {:handles
-  {"apropos"
-   {:doc (:doc (meta #'handle-apropos))
-    :requires {"query" "The search query."}
-    :optional {"filter-regexps" "All vars from namespaces matching any regexp from this list would be dropped from the result."}
-    :returns {"apropos-matches" "A list of matching symbols."}}}})
+(defn handle-apropos [handler msg]
+  (with-safe-transport handler msg
+    "apropos" apropos))

--- a/src/cider/nrepl/middleware/classpath.clj
+++ b/src/cider/nrepl/middleware/classpath.clj
@@ -9,15 +9,6 @@
 (defn classpath-reply [msg]
   {:classpath (classpath)})
 
-(defn wrap-classpath
-  "Middleware that provides the java classpath."
-  [handler]
-  (with-safe-transport handler
+(defn handle-classpath [handler msg]
+  (with-safe-transport handler msg
     "classpath" classpath-reply))
-
-(set-descriptor!
- #'wrap-classpath
- {:handles
-  {"classpath"
-   {:doc "Obtain a list of entries in the Java classpath."
-    :returns {"classpath" "A list of the Java classpath entries."}}}})

--- a/src/cider/nrepl/middleware/complete.clj
+++ b/src/cider/nrepl/middleware/complete.clj
@@ -38,31 +38,8 @@
   (jvm-complete-utils/flush-caches)
   {})
 
-(defn wrap-complete
-  "Middleware that looks up possible functions for the given (partial) symbol."
-  [handler]
-  (with-safe-transport handler
+(defn handle-complete [handler msg]
+  (with-safe-transport handler msg
     "complete" complete-reply
     "complete-doc" doc-reply
     "complete-flush-caches" flush-caches-reply))
-
-(set-descriptor!
- #'wrap-complete
- (cljs/requires-piggieback
-  {:requires #{#'session/session}
-   :handles
-   {"complete"
-    {:doc "Return a list of symbols matching the specified (partial) symbol."
-     :requires {"ns" "The symbol's namespace"
-                "symbol" "The symbol to lookup"
-                "session" "The current session"}
-     :optional {"context" "Completion context for compliment."
-                "extra-metadata" "List of extra-metadata fields. Possible values: arglists, doc."}
-     :returns {"completions" "A list of possible completions"}}
-    "complete-doc"
-    {:doc "Retrieve documentation suitable for display in completion popup"
-     :requires {"ns" "The symbol's namespace"
-                "symbol" "The symbol to lookup"}
-     :returns {"completion-doc" "Symbol's documentation"}}
-    "complete-flush-caches"
-    {:doc "Forces the completion backend to repopulate all its caches"}}}))

--- a/src/cider/nrepl/middleware/enlighten.clj
+++ b/src/cider/nrepl/middleware/enlighten.clj
@@ -85,14 +85,8 @@
     ;; (ins/print-form form1 true)
     (eval form1)))
 
-(defn wrap-enlighten [h]
-  (fn [{:keys [op enlighten] :as msg}]
-    (if (and (= op "eval") enlighten)
-      (h (assoc msg :eval "cider.nrepl.middleware.enlighten/eval-with-enlighten"))
-      (h msg))))
-
-(set-descriptor!
- #'wrap-enlighten
- ;; We need to come before wrap-debug, so that the debugger can still
- ;; work if enlighten-mode is on.
- {:expects #{"eval" #'d/wrap-debug}})
+(defn handle-enlighten
+  [h {:keys [op enlighten] :as msg}]
+  (if (and (= op "eval") enlighten)
+    (h (assoc msg :eval "cider.nrepl.middleware.enlighten/eval-with-enlighten"))
+    (h msg)))

--- a/src/cider/nrepl/middleware/format.clj
+++ b/src/cider/nrepl/middleware/format.clj
@@ -41,24 +41,7 @@
   [{:keys [edn pprint-fn] :as msg}]
   {:formatted-edn (format-edn edn pprint-fn)})
 
-(defn wrap-format
-  "Middleware that provides code formatting."
-  [handler]
-  (with-safe-transport handler
+(defn handle-format [handler msg]
+  (with-safe-transport handler msg
     "format-code" format-code-reply
     "format-edn"  format-edn-reply))
-
-(set-descriptor!
- #'wrap-format
- {:requires #{#'pprint/wrap-pprint-fn}
-  :handles
-  {"format-code"
-   {:doc "Reformats the given Clojure code, returning the result as a string."
-    :requires {"code" "The code to format."}
-    :returns {"formatted-code" "The formatted code."}}
-   "format-edn"
-   {:doc "Reformats the given EDN data, returning the result as a string."
-    :requires {"edn" "The data to format."}
-    :optional {"print-right-margin" "The maximum column width of the formatted result."
-               "pprint-fn" "Fully qualified name of the print function to be used."}
-    :returns {"formatted-edn" "The formatted data."}}}})

--- a/src/cider/nrepl/middleware/info.clj
+++ b/src/cider/nrepl/middleware/info.clj
@@ -9,8 +9,6 @@
             [cider.nrepl.middleware.util.misc :as u]
             [cider.nrepl.middleware.util.meta :as m]
             [cljs-tooling.info :as cljs-info]
-            [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
-            [clojure.tools.nrepl.middleware.session :as session]
             [cider.nrepl.middleware.util.spec :as spec]))
 
 (defn- boot-class-loader
@@ -280,31 +278,8 @@
       {:inputs (format-arglists [inputs])})
     (catch Throwable _ {:status :no-eldoc})))
 
-(defn wrap-info
-  "Middleware that looks up info for a symbol within the context of a particular namespace."
-  [handler]
-  (with-safe-transport handler
+(defn handle-info [handler msg]
+  (with-safe-transport handler msg
     "info" info-reply
     "eldoc" eldoc-reply
     "eldoc-datomic-query" eldoc-datomic-query-reply))
-
-(set-descriptor!
- #'wrap-info
- (cljs/requires-piggieback
-  {:requires #{#'session/session}
-   :handles
-   {"info"
-    {:doc "Return a map of information about the specified symbol."
-     :requires {"symbol" "The symbol to lookup"
-                "ns" "The current namespace"}
-     :returns {"status" "done"}}
-    "eldoc"
-    {:doc "Return a map of information about the specified symbol."
-     :requires {"symbol" "The symbol to lookup"
-                "ns" "The current namespace"}
-     :returns {"status" "done"}}
-    "eldoc-datomic-query"
-    {:doc "Return a map containing the inputs of the datomic query."
-     :requires {"symbol" "The symbol to lookup"
-                "ns" "The current namespace"}
-     :returns {"status" "done"}}}}))

--- a/src/cider/nrepl/middleware/inspect.clj
+++ b/src/cider/nrepl/middleware/inspect.clj
@@ -5,7 +5,6 @@
             [cider.nrepl.middleware.util.misc :as u]
             [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
             [clojure.tools.nrepl.misc :refer [response-for]]
-            [clojure.tools.nrepl.middleware.pr-values :refer [pr-values]]
             [clojure.tools.nrepl.transport :as transport])
   (:import clojure.tools.nrepl.transport.Transport))
 
@@ -82,56 +81,14 @@
   (try (success msg (swap-inspector! msg inspect/set-page-size (:page-size msg)))
        (catch Exception e (failure msg e :inspect-set-page-size-error))))
 
-(defn wrap-inspect
-  "Middleware that adds a value inspector option to the eval op. Passing a
-  non-nil value in the `:inspect` slot will cause the last value returned by
-  eval to be inspected. Returns a string representation of the resulting
-  inspector's state in the `:value` slot."
-  [handler]
-  (fn [{:keys [op] :as msg}]
-    (case op
-      "eval" (eval-reply handler msg)
-      "inspect-pop" (pop-reply msg)
-      "inspect-push" (push-reply msg)
-      "inspect-refresh" (refresh-reply msg)
-      "inspect-get-path" (get-path-reply msg)
-      "inspect-next-page" (next-page-reply msg)
-      "inspect-prev-page" (prev-page-reply msg)
-      "inspect-set-page-size" (set-page-size-reply msg)
-      (handler msg))))
-
-(set-descriptor!
- #'wrap-inspect
- (cljs/expects-piggieback
-  {:requires #{"clone" #'pr-values}
-   :expects #{"eval"}
-   :handles {"inspect-pop"
-             {:doc "Moves one level up in the inspector stack."
-              :requires {"session" "The current session"}
-              :returns {"status" "\"done\""}}
-             "inspect-push"
-             {:doc "Inspects the inside value specified by index."
-              :requires {"idx" "Index of the internal value currently rendered."
-                         "session" "The current session"}
-              :returns {"status" "\"done\""}}
-             "inspect-refresh"
-             {:doc "Re-renders the currently inspected value."
-              :requires {"session" "The current session"}
-              :returns {"status" "\"done\""}}
-             "inspect-get-path"
-             {:doc "Returns the path to the current position in the inspected value."
-              :requires {"session" "The current session"}
-              :returns {"status" "\"done\""}}
-             "inspect-next-page"
-             {:doc "Jumps to the next page in paginated collection view."
-              :requires {"session" "The current session"}
-              :returns {"status" "\"done\""}}
-             "inspect-prev-page"
-             {:doc "Jumps to the previous page in paginated collection view."
-              :requires {"session" "The current session"}
-              :returns {"status" "\"done\""}}
-             "inspect-set-page-size"
-             {:doc "Sets the page size in paginated view to specified value."
-              :requires {"page-size" "New page size."
-                         "session" "The current session"}
-              :returns {"status" "\"done\""}}}}))
+(defn handle-inspect [handler msg]
+  (case (:op msg)
+    "eval" (eval-reply handler msg)
+    "inspect-pop" (pop-reply msg)
+    "inspect-push" (push-reply msg)
+    "inspect-refresh" (refresh-reply msg)
+    "inspect-get-path" (get-path-reply msg)
+    "inspect-next-page" (next-page-reply msg)
+    "inspect-prev-page" (prev-page-reply msg)
+    "inspect-set-page-size" (set-page-size-reply msg)
+    (handler msg)))

--- a/src/cider/nrepl/middleware/macroexpand.clj
+++ b/src/cider/nrepl/middleware/macroexpand.clj
@@ -6,9 +6,6 @@
             [cider.nrepl.middleware.util.misc :as u]
             [cljs-tooling.util.analysis :as cljs-ana]
             [clojure.pprint :as pp]
-            [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
-            [clojure.tools.nrepl.misc :refer [response-for]]
-            [clojure.tools.nrepl.middleware.session :as session]
             [clojure.tools.reader :as reader]
             [clojure.walk :as walk])
   (:import [clojure.lang Var]))
@@ -221,22 +218,6 @@
 (defn macroexpansion-reply [msg]
   {:expansion (macroexpansion msg)})
 
-(defn wrap-macroexpand
-  "Middleware that provides a macroexpand op."
-  [handler]
-  (with-safe-transport handler
+(defn handle-macroexpand [handler msg]
+  (with-safe-transport handler msg
     "macroexpand" [macroexpansion-reply :macroexpand-error]))
-
-(set-descriptor!
- #'wrap-macroexpand
- (cljs/requires-piggieback
-  {:requires #{#'session/session}
-   :handles
-   {"macroexpand"
-    {:doc "Produces macroexpansion of some form using the given expander."
-     :requires {"code" "The form to macroexpand."}
-     :optional {"ns" "The namespace in which to perform the macroexpansion. Defaults to 'user for Clojure and 'cljs.user for ClojureScript."
-                "expander" "The macroexpansion function to use. Possible values are \"macroexpand-1\", \"macroexpand\", or \"macroexpand-all\". Defaults to \"macroexpand\"."
-                "display-namespaces" "How to print namespace-qualified symbols in the result. Possible values are \"qualified\" to leave all namespaces qualified, \"none\" to elide all namespaces, or \"tidy\" to replace namespaces with their aliases in the given namespace. Defaults to \"qualified\"."
-                "print-meta" "If truthy, also print metadata of forms."}
-     :returns {"expansion" "The macroexpanded form."}}}}))

--- a/src/cider/nrepl/middleware/ns.clj
+++ b/src/cider/nrepl/middleware/ns.clj
@@ -5,11 +5,7 @@
             [cider.nrepl.middleware.util.misc :as u]
             [cider.nrepl.middleware.util.namespace :as ns]
             [cljs-tooling.info :as cljs-info]
-            [cljs-tooling.util.analysis :as cljs-analysis]
-            [clojure.tools.nrepl
-             [middleware :refer [set-descriptor!]]
-             [misc :refer [response-for]]]
-            [clojure.tools.nrepl.middleware.session :as session]))
+            [cljs-tooling.util.analysis :as cljs-analysis]))
 
 (defn ns-list-vars-by-name
   "Return a list of vars named `name` amongst all namespaces.
@@ -99,42 +95,11 @@
   [msg]
   {:loaded-ns (ns/load-project-namespaces)})
 
-(defn wrap-ns
-  "Middleware that provides ns listing/browsing functionality."
-  [handler]
-  (with-safe-transport handler
+(defn handle-ns [handler msg]
+  (with-safe-transport handler msg
     "ns-list" ns-list-reply
     "ns-list-vars-by-name" ns-list-vars-by-name-reply
     "ns-vars" ns-vars-reply
     "ns-vars-with-meta" ns-vars-with-meta-reply
     "ns-path" ns-path-reply
     "ns-load-all" ns-load-all-reply))
-
-(set-descriptor!
- #'wrap-ns
- (cljs/requires-piggieback
-  {:requires #{#'session/session}
-   :handles
-   {"ns-list"
-    {:doc "Return a sorted list of all namespaces."
-     :returns {"status" "done" "ns-list" "The sorted list of all namespaces."}
-     :optional {"filter-regexps" "All namespaces matching any regexp from this list would be dropped from the result."}}
-    "ns-list-vars-by-name"
-    {:doc "Return a list of vars named `name` amongst all namespaces."
-     :requires {"name" "The name to use."}
-     :returns {"status" "done" "var-list" "The list obtained."}}
-    "ns-vars"
-    {:doc "Returns a sorted list of all vars in a namespace."
-     :requires {"ns" "The namespace to browse."}
-     :returns {"status" "done" "ns-vars" "The sorted list of all vars in a namespace."}}
-    "ns-vars-with-meta"
-    {:doc "Returns a map of [var-name] to [var-metadata] for all vars in a namespace."
-     :requires {"ns" "The namespace to use."}
-     :returns {"status" "done" "ns-vars-with-meta" "The map of [var-name] to [var-metadata] for all vars in a namespace."}}
-    "ns-path"
-    {:doc "Returns the path to the file containing ns."
-     :requires {"ns" "The namespace to find."}
-     :return {"status" "done" "path" "The path to the file containing ns."}}
-    "ns-load-all"
-    {:doc "Loads all project namespaces."
-     :return {"status" "done" "loaded-ns" "The list of ns that were loaded."}}}}))

--- a/src/cider/nrepl/middleware/out.clj
+++ b/src/cider/nrepl/middleware/out.clj
@@ -12,9 +12,7 @@
   (:require [cider.nrepl.middleware.util.cljs :as cljs]
             [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
             [clojure.string :as s]
-            [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
-            [clojure.tools.nrepl.middleware.interruptible-eval :as ie]
-            [clojure.tools.nrepl.middleware.session :as session])
+            [clojure.tools.nrepl.middleware.interruptible-eval :as ie])
   (:import [java.io PrintWriter Writer PrintStream OutputStream]))
 
 (declare unsubscribe-session)
@@ -107,18 +105,7 @@
     (swap! tracked-sessions-map dissoc removed)
     {:out-unsubscribe removed}))
 
-(defn wrap-out [handler]
-  (with-safe-transport handler
+(defn handle-out [handler msg]
+  (with-safe-transport handler msg
     "out-subscribe" subscribe-session
     "out-unsubscribe" unsubscribe-session))
-
-(set-descriptor!
- #'wrap-out
- (cljs/expects-piggieback
-  {:requires #{#'session/session}
-   :expects #{"eval"}
-   :handles
-   {"out-subscribe"
-    {:doc "Change #'*out* so that it also prints to active sessions, even outside an eval scope."}
-    "out-unsubscribe"
-    {:doc "Change #'*out* so that it no longer prints to active sessions outside an eval scope."}}}))

--- a/src/cider/nrepl/middleware/resource.clj
+++ b/src/cider/nrepl/middleware/resource.clj
@@ -1,7 +1,6 @@
 (ns cider.nrepl.middleware.resource
   (:require [clojure.java.io :as io]
-            [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
-            [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport] :as err]
+            [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
             [compliment.sources.resources :as r]
             [compliment.core :as jvm-complete]))
 
@@ -21,22 +20,7 @@
 (defn resources-list-reply [msg]
   {:resources-list (resources-list msg)})
 
-(defn wrap-resource
-  "Middleware that provides the path to resource."
-  [handler]
-  (with-safe-transport handler
+(defn handle-resource [handler msg]
+  (with-safe-transport handler msg
     "resource" resource-reply
     "resources-list" resources-list-reply))
-
-(set-descriptor!
- #'wrap-resource
- {:handles
-  {"resource"
-   {:doc "Obtain the path to a resource."
-    :requires {"name" "The name of the resource in question."}
-    :returns {"resource-path" "The file path to a resource."}}
-   "resources-list"
-   {:doc "Obtain a list of all resources on the classpath."
-    :returns {"resources-list" "The list of resources."}
-    :optional {"context" "Completion context for compliment."
-               "prefix" "Prefix to filter out resources."}}}})

--- a/src/cider/nrepl/middleware/spec.clj
+++ b/src/cider/nrepl/middleware/spec.clj
@@ -1,9 +1,6 @@
 (ns cider.nrepl.middleware.spec
   (:require [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
             [cider.nrepl.middleware.util.spec :as spec-utils]
-            [clojure.tools.nrepl
-             [middleware :refer [set-descriptor!]]
-             [misc :refer [response-for]]]
             [cider.nrepl.middleware.util.cljs :as cljs]
             [clojure.string :as str]
             [clojure.walk :as walk]
@@ -95,32 +92,8 @@
 (defn spec-example-reply [msg]
   {:spec-example (spec-example (:spec-name msg))})
 
-(defn wrap-spec
-  "Middleware that provides clojure.spec browsing functionality."
-  [handler]
-  (with-safe-transport handler
+(defn handle-spec [handler msg]
+  (with-safe-transport handler msg
     "spec-list" spec-list-reply
     "spec-form" spec-form-reply
     "spec-example" spec-example-reply))
-
-(set-descriptor!
- #'wrap-spec
- (cljs/requires-piggieback
-  {:handles
-   {"spec-list"
-    {:doc "Return a sorted list of all specs in the registry"
-     :returns {"status" "done"
-               "spec-list" "The sorted list of all specs in the registry with their descriptions"}
-     :optional {"filter-regex" "Only the specs that matches filter prefix regex will be returned "}}
-
-    "spec-form"
-    {:doc "Return the form of a given spec"
-     :requires {"spec-name" "The spec namespaced keyword we are looking for"}
-     :returns {"status" "done"
-               "spec-form" "The spec form"}}
-
-    "spec-example"
-    {:doc "Return a string with a pretty printed example for a spec"
-     :requires {"spec-name" "The spec namespaced keyword we want the example for"}
-     :returns {"status" "done"
-               "example" "The pretty printed spec example string"}}}}))

--- a/src/cider/nrepl/middleware/trace.clj
+++ b/src/cider/nrepl/middleware/trace.clj
@@ -1,8 +1,7 @@
 (ns cider.nrepl.middleware.trace
   (:require [clojure.string :as s]
             [clojure.tools.trace :as trace]
-            [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
-            [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport] :as err]))
+            [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]))
 
 (defn toggle-trace-var
   [{:keys [ns sym transport] :as msg}]
@@ -30,23 +29,7 @@
           {:ns-status "traced"}))
     {:ns-status "not-found"}))
 
-(defn wrap-trace
-  "Middleware that toggles tracing of a given var."
-  [handler]
-  (with-safe-transport handler
+(defn handle-trace [handler msg]
+  (with-safe-transport handler msg
     "toggle-trace-var" [toggle-trace-var :toggle-trace-error]
     "toggle-trace-ns"  [toggle-trace-ns :toggle-trace-error]))
-
-(set-descriptor!
- #'wrap-trace
- {:handles
-  {"toggle-trace-var"
-   {:doc "Toggle tracing of a given var."
-    :requires {"sym" "The symbol to trace"
-               "ns" "The current namespace"}
-    :returns {"var-status" "The result of tracing operation"
-              "var-name" "The fully-qualified name of the traced/untraced var"}}
-   "toggle-trace-ns"
-   {:doc "Toggle tracing of a given ns."
-    :requires {"ns" "The namespace to trace"}
-    :returns {"ns-status" "The result of tracing operation"}}}})

--- a/src/cider/nrepl/middleware/undef.clj
+++ b/src/cider/nrepl/middleware/undef.clj
@@ -2,8 +2,7 @@
   "Undefine a symbol"
   (:require
    [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
-   [cider.nrepl.middleware.util.misc :as u]
-   [clojure.tools.nrepl.middleware :refer [set-descriptor!]]))
+   [cider.nrepl.middleware.util.misc :as u]))
 
 (defn undef
   [{:keys [ns symbol] :as msg}]
@@ -16,17 +15,6 @@
   [msg]
   {:undef (undef msg)})
 
-(defn wrap-undef
-  "Middleware to undefine a symbol in a namespace."
-  [handler]
-  (with-safe-transport handler
+(defn handle-undef [handler msg]
+  (with-safe-transport handler msg
     "undef" undef-reply))
-
-(set-descriptor!
- #'wrap-undef
- {:handles
-  {"undef"
-   {:doc "Undefine a symbol"
-    :requires {"symbol" "The symbol to undefine"
-               "ns" "The current namespace"}
-    :returns {"status" "done"}}}})

--- a/src/cider/nrepl/middleware/version.clj
+++ b/src/cider/nrepl/middleware/version.clj
@@ -1,8 +1,10 @@
 (ns cider.nrepl.middleware.version
   "Return version info of the CIDER-nREPL middleware itself."
-  (:require [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
-            [cider.nrepl.version :as version]
-            [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]))
+  (:require [cider.nrepl.version :as version]
+            [clojure.tools.nrepl.misc :refer [response-for]]
+            [clojure.tools.nrepl.transport :as transport]
+            [clojure.tools.nrepl.middleware :refer [set-descriptor!]]))
+
 
 (defn- cider-version-reply
   "Returns CIDER-nREPL's version as a map which contains `:major`,
@@ -11,18 +13,22 @@
   [msg]
   {:cider-version version/version})
 
-(defn wrap-version
-  "Middleware that provides CIDER-nREPL version information."
-  [handler]
-  (with-safe-transport handler
-    "cider-version" cider-version-reply))
+(defn wrap-version [handler]
+  (fn [msg]
+    (if (= (:op msg) "cider-version")
+      (->> (cider-version-reply msg)
+           (merge {:status #{"done"}})
+           (response-for msg)
+           (transport/send (:transport msg)))
+      (handler msg))))
 
 (set-descriptor!
- #'wrap-version
- {:describe-fn #'cider-version-reply ;; For the "describe" op. Merged in `:aux`
-  :handles
-  {"cider-version"
-   {:doc "Returns the version of the CIDER-nREPL middleware."
-    :requires {}
-    :returns {"cider-version" "CIDER-nREPL's version map."
-              "status" "done"}}}})
+  #'wrap-version
+  {:doc "Provides CIDER-nREPL version information."
+   :describe-fn #'cider-version-reply ;; For the "describe" op. Merged in `:aux`
+   :handles
+   {"cider-version"
+    {:doc "Returns the version of the CIDER-nREPL middleware."
+     :requires {}
+     :returns {"cider-version" "CIDER-nREPL's version map."
+               "status" "done"}}}})

--- a/test/clj/cider/nrepl/middleware/debug_integration_test.clj
+++ b/test/clj/cider/nrepl/middleware/debug_integration_test.clj
@@ -25,7 +25,7 @@
       (apply prn args))))
 
 (defn debug-handler []
-  (nrepl.server/default-handler #'d/wrap-debug))
+  (nrepl.server/default-handler #'cider.nrepl/wrap-debug))
 
 (defonce next-id
   (let [id (atom 0)]


### PR DESCRIPTION
Addresses #218  and clojure-emacs/cider#1717. 

It now takes only 0.25s for me to load `cider.nrepl.clj`. So startup time is now compatible with `lein repl` with an empty project.  Some extra work could be done on emacs side to avoid loading extra things (like debugger) on startup. 

I will pile a couple more related commits here in the following days to further fix loading of the debugg.clj, error_handling.clj and maybe something else.  


