### PR TITLE
Fix invalid namespaced keywords

### DIFF
--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -126,8 +126,8 @@
   finds the erring test fixture in the stacktrace and binds it as the current
   test var. Test count is decremented to indicate that no tests were run."
   [ns e]
-  (let [frame (->> (concat (::clojure.test/once-fixtures (meta ns))
-                           (::clojure.test/each-fixtures (meta ns)))
+  (let [frame (->> (concat (:clojure.test/once-fixtures (meta ns))
+                           (:clojure.test/each-fixtures (meta ns)))
                    (map (partial stack-frame e))
                    (filter identity)
                    (first))


### PR DESCRIPTION
When I required the current master branch of this repo I ran into: `Invalid token: ::clojure.test/once-fixtures`. The double colon keyword prefix only works with namespace aliases that are set up in the current namespace. In this case there is not a namespace alias "clojure.test", so these keywords are invalid.

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [ ] All tests are passing

