### PR TITLE
Fix fns defined with def not font locked as fns

### DIFF
--- a/src/cider/nrepl/middleware/util/meta.clj
+++ b/src/cider/nrepl/middleware/util/meta.clj
@@ -275,7 +275,7 @@
   "Metadata keys that are useful to us.
   This is used so that we don't crowd the ns cache with useless or
   redudant information, such as :name and :ns."
-  [:indent :deprecated :macro :arglists :test :doc
+  [:indent :deprecated :macro :arglists :test :doc :fn
    :cider/instrumented :style/indent :clojure.tools.trace/traced])
 
 (defn relevant-meta


### PR DESCRIPTION
This fixes the problem that functions defined with `def`, e.g. `(def f (fn [] ...))` gets font locked as non-function vars, because they have no `:arglists` in their metadata. Needs https://github.com/clojure-emacs/cider/pull/2086

(I have not updated Cider's CHANGELOG.md, because I didn't know what to call the next version.)