### PR TITLE
Fix crash when inspecting primitive arrays

### DIFF
--- a/src/cider/nrepl/middleware/util/inspect.clj
+++ b/src/cider/nrepl/middleware/util/inspect.clj
@@ -318,7 +318,7 @@
       (render-ln "Contents: ")
       (render-indexed-values obj)))
 
-(defmethod inspect :array [inspector ^"[Ljava.lang.Object;" obj]
+(defmethod inspect :array [inspector obj]
   (-> inspector
       (render-labeled-value "Class" (class obj))
       (render-labeled-value "Count" (alength obj))


### PR DESCRIPTION
This type hint causes a crash on arrays of primitive types, like [I and [C,
because neither are subclasses of java.lang.Object. Resolves
https://github.com/clojure-emacs/cider/issues/2077.

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [ ] All tests are passing
- [ ] The new code is not generating reflection warnings
- [x] You've updated the readme (if adding/changing middleware)

I'm getting a crash when running the repl or test suite, both on master and with this change.