### PR TITLE
Handle additional overloaded version of write.

### DIFF
--- a/src/cider/nrepl/middleware/out.clj
+++ b/src/cider/nrepl/middleware/out.clj
@@ -64,8 +64,11 @@
     (PrintStream. (proxy [OutputStream] []
                     (close [] (.flush ^OutputStream this))
                     (write
-                      ([bytes]
-                       (.write @(resolve printer) (String. bytes)))
+                      ([int-or-bytes]
+                       (.write @(resolve printer)
+                               (if (instance? Integer int-or-bytes)
+                                 int-or-bytes
+                                 (String. int-or-bytes))))
                       ([bytes ^Integer off ^Integer len]
                        (let [byte-range (byte-array
                                          (take len (drop off bytes)))]


### PR DESCRIPTION
The proxy for `OutputStream/write` was only handling the case that its single argument was a byte array, but the super class also allows for a single character (int) to be passed to `write`.

This was causing a problem for me when I turned on debugging output for SSL connections (using `-Djavax.net.debug=all`).