### PR TITLE
Use verbose syntax to get fixture functions

### DIFF
--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -158,8 +158,8 @@
   "Call `test-var` on each var, with the fixtures defined for namespace
   object `ns`."
   [ns vars]
-  (let [once-fixture-fn (test/join-fixtures (::test/once-fixtures (meta ns)))
-        each-fixture-fn (test/join-fixtures (::test/each-fixtures (meta ns)))]
+  (let [once-fixture-fn (test/join-fixtures (:clojure.test/once-fixtures (meta ns)))
+        each-fixture-fn (test/join-fixtures (:clojure.test/each-fixtures (meta ns)))]
     (try (once-fixture-fn
           (fn []
             (doseq [v vars]


### PR DESCRIPTION
I think we might need this change before people start upgrading to clojure-1.9. While trying it out, I got the following runtime exceptions that seemed to be triggered by loading the test middleware. Replacing `::test/once-fixtures` with `:clojure.test/once-fixtures` seems to fix the problem.

```
                                               ...
                                 clojure.core/load                 core.clj: 6034
                                 clojure.core/load                 core.clj: 6050
                              clojure.core/load/fn                 core.clj: 6051
                                               ...
java.lang.RuntimeException: Invalid token: ::clojure.test/once-fixtures
clojure.lang.ExceptionInfo: Invalid token: ::clojure.test/once-fixtures
```