### PR TITLE
Fix jdk source code lookup for boot projects

### DIFF
--- a/src/cider/nrepl/middleware/info.clj
+++ b/src/cider/nrepl/middleware/info.clj
@@ -23,8 +23,13 @@
                             (str "file:" path)
                             (str "file:" path dir-separator))]
                   (new java.net.URL url)))
-              paths)]
-    (new java.net.URLClassLoader (into-array java.net.URL urls))))
+              paths)
+        jdk-sources (->> [#_"see '## Classpath' notes at `cider.nrepl.middleware.util.java`"
+                          ["src.zip"]
+                          ["lib" "tools.jar"]]
+                         (map (partial apply java/jdk-resource-url))
+                         (remove nil?))]
+    (new java.net.URLClassLoader (into-array java.net.URL (concat urls jdk-sources)))))
 
 (defn- resource-full-path [relative-path]
   (if (u/boot-project?)

--- a/src/cider/nrepl/middleware/util/java.clj
+++ b/src/cider/nrepl/middleware/util/java.clj
@@ -44,18 +44,21 @@
   (-> (io/file (System/getProperty "java.home"))
       (.getParentFile)))
 
+(defn jdk-resource-url
+  "Returns url to file at PATH-SEGMENTS relative to `jdk-root`."
+  [& path-segments]
+  (let [f (apply io/file jdk-root path-segments)]
+    (when (.canRead f)
+      (io/as-url f))))
+
 (def jdk-sources
   "The JDK sources path. If available, this is added to the classpath. By
   convention, this is the file `src.zip` in the root of the JDK directory."
-  (let [zip (io/file jdk-root "src.zip")]
-    (when (.canRead zip)
-      (add-classpath! (io/as-url zip)))))
+  (some-> (jdk-resource-url "src.zip") add-classpath!))
 
 (def jdk-tools
   "The JDK `tools.jar` path. If available, this is added to the classpath."
-  (let [jar (io/file jdk-root "lib" "tools.jar")]
-    (when (.canRead jar)
-      (add-classpath! (io/as-url jar)))))
+  (some-> (jdk-resource-url "lib" "tools.jar") add-classpath!))
 
 ;;; ## Javadoc URLs
 ;; Relative Javadoc URLs can be constructed from class/member signatures.

--- a/test/clj/cider/nrepl/middleware/info_test.clj
+++ b/test/clj/cider/nrepl/middleware/info_test.clj
@@ -6,6 +6,7 @@
             [clojure.set :as set]
             [clojure.string :as str]
             [cider.nrepl.middleware.info :as info]
+            [cider.nrepl.middleware.util.java :as java]
             [cider.nrepl.middleware.util.meta :as m]
             [cider.nrepl.middleware.util.misc :as util]
             [cider.nrepl.test-session :as session]
@@ -70,8 +71,16 @@
       (let [tmp-jar-path "jar:file:fake/clojure.jar"]
         (try
           (System/setProperty "fake.class.path" tmp-jar-path)
-          (is (= (-> (#'cider.nrepl.middleware.info/boot-class-loader) .getURLs last str)
-                 "file:fake/clojure.jar"))
+          (is (some #{"file:fake/clojure.jar"}
+                    (->> (#'cider.nrepl.middleware.info/boot-class-loader) .getURLs (map str))))
+          (finally
+            (System/clearProperty "fake.class.path")))))
+    (testing "include sources when avaliable"
+      (when-let [src-url (java/jdk-resource-url "src.zip")]
+        (try
+          (System/setProperty "fake.class.path" tmp-dir-name)
+          (is (some #{src-url}
+                    (.getURLs (#'cider.nrepl.middleware.info/boot-class-loader))))
           (finally
             (System/clearProperty "fake.class.path")))))))
 


### PR DESCRIPTION
Adds available jdk sources to the ClassLoader used to resolve boot project
resources by the 'info' op. This way, e.g. (cider-var-info  "java.lang.String"),
can return a "file" entry with an absolute url to the source, instead of just
the relative resource path.

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the readme (if adding/changing middleware)

Thanks!
