### PR TITLE
Find full path for stacktrace frames

### DIFF
--- a/src/cider/nrepl/middleware/stacktrace.clj
+++ b/src/cider/nrepl/middleware/stacktrace.clj
@@ -63,7 +63,8 @@
   "Add namespace, fn, and var to the frame map when the source is a Clojure
   function."
   [{:keys [file type class method] :as frame}]
-  (if (= :clj type)
+  (if (or (= :clj type)
+          (= :cljc type))
     (let [[ns fn & anons] (-> (repl/demunge class)
                               (str/replace #"--\d+" "")
                               (str/split #"/"))


### PR DESCRIPTION
This makes it easier for tooling which has a native concept of error list to
integrate with the stacktrace op.

In this case, that tool is Vim.

Another change I made arbitrarily is to include cljc files as things upon which
ns & var are resolved for. I have tested this, and it works.

It would be get to some additional feedback on:
* Does this make things better for Emacs in terms of cljc?
* Is this an improvement that would be useful to emacs
* Does my additional step for invokeStatic's make sense? ( I wasn't getting files without it! )

I looked at adding line-shift to the server, but I found it to be grossly inaccurate in most cases. An explanation for it would be useful, as I suspect I was using it wrong given the massively incorrect offsets it caused for, e.g. `load$invoke`.

Before submitting a PR make sure the following things have been done:

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [X] You've added tests to cover your change(s)
- [X] All tests are passing
- [X] The new code is not generating reflection warnings
- [X] You've updated the readme (if adding/changing middleware)
