### PR TITLE
Use fake.class.path as classpath in Boot projects

### DIFF
--- a/src/cider/nrepl/middleware/classpath.clj
+++ b/src/cider/nrepl/middleware/classpath.clj
@@ -1,10 +1,14 @@
 (ns cider.nrepl.middleware.classpath
   (:require [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
+            [cider.nrepl.middleware.util.misc :as u]
             [clojure.java.classpath :as cp]
+            [clojure.string :as str]
             [clojure.tools.nrepl.middleware :refer [set-descriptor!]]))
 
 (defn classpath []
-  (map str (cp/classpath)))
+  (if-let [classpath (u/boot-fake-classpath)]
+    (str/split classpath #":")
+    (map str (cp/classpath))))
 
 (defn classpath-reply [msg]
   {:classpath (classpath)})

--- a/src/cider/nrepl/middleware/util/misc.clj
+++ b/src/cider/nrepl/middleware/util/misc.clj
@@ -2,10 +2,14 @@
   (:require [clojure.string :as str]
             [clojure.stacktrace :as stacktrace]))
 
-(defn boot-project? []
+(defn boot-fake-classpath
   ;; fake.class.path under boot contains the original directories with source
   ;; files, see https://github.com/boot-clj/boot/issues/249
-  (not (nil? (System/getProperty "fake.class.path"))))
+  []
+  (System/getProperty "fake.class.path"))
+
+(defn boot-project? []
+  (not (nil? (boot-fake-classpath))))
 
 (def java-api-version
   (try (-> (System/getProperty "java.version") (str/split #"\.") second)

--- a/test/clj/cider/nrepl/middleware/classpath_test.clj
+++ b/test/clj/cider/nrepl/middleware/classpath_test.clj
@@ -1,6 +1,7 @@
 (ns cider.nrepl.middleware.classpath-test
   (:require [cider.nrepl.test-session :as session]
             [cider.nrepl.middleware.classpath :as cp]
+            [clojure.string :as str]
             [clojure.test :refer :all]))
 
 (use-fixtures :each session/session-fixture)
@@ -19,3 +20,16 @@
       (is (.startsWith (:err response) "java.lang.Exception: cp error"))
       (is (= (:ex response) "class java.lang.Exception"))
       (is (:pp-stacktrace response)))))
+
+(deftest boot-fake-classpath-test
+  (let [fake-paths [(System/getProperty "java.io.tmpdir")]
+        fake-classpath (str/join ":" fake-paths)]
+    (testing "when fake.class.path is not set"
+      (is (not= fake-classpath (cp/classpath))))
+    (testing "when fake.class.path is set"
+      (try
+        (System/setProperty "fake.class.path" fake-classpath)
+        (is (= ["/some/file/path/src" "/some/file/path/test"]
+               (cp/classpath)))
+        (finally
+          (System/clearProperty "fake.class.path"))))))

--- a/test/clj/cider/nrepl/middleware/util/misc_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/misc_test.clj
@@ -1,6 +1,21 @@
 (ns cider.nrepl.middleware.util.misc-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.string :as str]
+            [clojure.test :refer :all]
             [cider.nrepl.middleware.util.misc :as misc]))
+
+(deftest boot-fake-classpath-test
+  (let [fake-paths [(System/getProperty "java.io.tmpdir")]
+        fake-classpath (str/join ":" fake-paths)]
+    (testing "when fake.class.path is not set"
+      (is (nil? (misc/boot-fake-classpath)))
+      (is (not (misc/boot-project?))))
+    (testing "when fake.class.path is set"
+      (try
+        (System/setProperty "fake.class.path" fake-classpath)
+        (is (= fake-classpath (misc/boot-fake-classpath)))
+        (is (misc/boot-project?))
+        (finally
+          (System/clearProperty "fake.class.path"))))))
 
 (deftest transform-value-test
   (is (= (misc/transform-value (array-map


### PR DESCRIPTION
Boot manages the classpath dynamically through filesets, so
`java.class.path` does not include the source paths. Boot provides
access to the original directories via the `fake.class.path` system
property. Use this `fake.class.path` property instead of
`java.class.path` for Boot projects.

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the readme (if adding/changing middleware)
