### PR TITLE
for java9's version checking

### DIFF
--- a/src/cider/nrepl/middleware/util/misc.clj
+++ b/src/cider/nrepl/middleware/util/misc.clj
@@ -17,8 +17,13 @@
   (not (nil? (boot-fake-classpath))))
 
 (def java-api-version
-  (try (-> (System/getProperty "java.version") (str/split #"\.") second)
-       (catch Exception _ "7")))
+  (try
+    (let [java-ver (System/getProperty "java.version")
+          [major minor _] (str/split java-ver #"\.")]
+      (if (> (bigint major) 1)
+        major
+        (or minor "7")))
+    (catch Exception _ "7")))
 
 (defn deep-merge
   "Merge maps recursively. When vals are not maps, last value wins."


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done:

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)  -> It is not function...
- [ ] All tests are passing
- [ ] The new code is not generating reflection warnings
- [ ] You've updated the readme (if adding/changing middleware)

--------

#461 's modify.

There is two versions of java 9.
(https://en.wikipedia.org/wiki/Java_version_history#Java_SE_9)

The one is "JAVA SE 9" released at 2017-09-21. this version returns just "9".
but "JAVA SE 9.0.1" released at 2017-10-17 returns "9.0.1".
The first example is for "JAVA SE 9" and second example is for "JAVA SE 9.0.1" :)

example 1> (case of JAVA SE 9)

    pc:~$ java -version
    java version "9"
    Java(TM) SE Runtime Environment (build 9+181)
    Java HotSpot(TM) 64-Bit Server VM (build 9+181, mixed mode)

    (System/getProperty "java.version")
    > "9"
    java-api-version
    > nil
    (we expect "9")

example 2> (case of JAVA SE 9.0.1)

    pc:~$ java -version
    java version "9.0.1"
    Java(TM) SE Runtime Environment (build 9.0.1+11)
    Java HotSpot(TM) 64-Bit Server VM (build 9.0.1+11, mixed mode)

    (System/getProperty "java.version")
    > "9.0.1"
    java-api-version
    > 0
    (we expect "9" also)

so, there was "java.lang.NumberFormatException : null"(java.clj:81) at example 1.
and "cider-javadoc" was not working at example 2 case cuz the url's java version is null.

I setted the default java version to 7 as you did (when exception).


