### PR TITLE
[Fix #468] Now special-sym-meta only takes care of special symbols...

### DIFF
--- a/src/cider/nrepl/middleware/info.clj
+++ b/src/cider/nrepl/middleware/info.clj
@@ -43,7 +43,7 @@
 (defn info-clj
   [ns sym]
   (or
-    ;; it's a special (special-symbol? or :special-form)
+    ;; it's a special (special-symbol?)
     (m/special-sym-meta sym)
     ;; it's a var
     (m/var-meta (m/resolve-var ns sym))

--- a/test/clj/cider/nrepl/middleware/info_test.clj
+++ b/test/clj/cider/nrepl/middleware/info_test.clj
@@ -85,18 +85,7 @@
             (System/clearProperty "fake.class.path")))))))
 
 (deftest special-sym-meta-test
-  (testing "Resolves all special forms"
-    (let [compiler-specials (keys clojure.lang.Compiler/specials)
-          core-specials (->> (vals (ns-publics 'clojure.core))
-                             (map meta)
-                             (filter :special-form)
-                             (map :name))
-          specials (concat compiler-specials core-specials)]
-      (is (every? (fn [[sym {:keys [name special-form]}]]
-                    (and (= sym name)
-                         (true? special-form)))
-                  (map #(vector % (m/special-sym-meta %)) specials)))))
-
+  
   (testing "Names are correct for `&`, `catch`, `finally`"
     (is (= '& (:name (m/special-sym-meta '&))))
     (is (= 'catch (:name (m/special-sym-meta 'catch))))

--- a/test/spec/cider/nrepl/middleware/info_test.clj
+++ b/test/spec/cider/nrepl/middleware/info_test.clj
@@ -17,24 +17,31 @@
 
 (use-fixtures :each session/session-fixture)
 (deftest integration-test
-  (testing "spec"
+  (testing "spec info on a normal function with spec"
     (let [response (session/message {:op "info" :symbol "ranged-rand" :ns "cider.nrepl.middleware.info-test"})]
       (is (= (:status response) #{"done"}))
       (is (= (:ns response) "cider.nrepl.middleware.info-test"))
       (is (= (:name response) "ranged-rand"))
-      (is (= (:arglists-str response) "([start end])"))
+      (is (= (:arglists-str response) "[start end]"))
       (is (nil? (:macro response)))
       (is (= (:doc response) "Returns random int in range start <= rand < end."))
-      (is (= (:spec response) ["args: (and\n\t(cat :start int? :end int?)\n\t(< (:start %) (:end %)))"
-                               "ret : int?"
-                               "fn  : (and\n\t(>= (:ret %) (-> % :args :start))\n\t(< (:ret %) (-> % :args :end)))"])))
+      (is (= (:spec response) [["args" "(and\n(cat :start int? :end int?)\n(< (:start %) (:end %)))"]
+                               ["ret"  "int?"]
+                               ["fn"   "(and\n(>= (:ret %) (-> % :args :start))\n(< (:ret %) (-> % :args :end)))"]]))))
+  (testing "spec info on a normal function without a spec"
+      ;; spec is not defined for this function
+      (let [response (session/message {:op "info" :symbol "same-name-testing-function" :ns "cider.test-ns.first-test-ns"})]
+        (is (= (:status response) #{"done"}))
+        (is (= (:ns response) "cider.test-ns.first-test-ns"))
+        (is (= (:name response) "same-name-testing-function"))
+        (is (= (:arglists-str response) "[]"))
+        (is (nil? (:macro response)))
+        (is (= (:doc response) "Multiple vars with the same name in different ns's. Used to test ns-list-vars-by-name."))
+        (is (nil? (:spec response)))))
 
-    ;; spec is not defined for this function
-    (let [response (session/message {:op "info" :symbol "same-name-testing-function" :ns "cider.test-ns.first-test-ns"})]
+  (testing "spec info on clojure.core/let"
+    (let [response (session/message {:op "info" :symbol "let" :ns "cider.nrepl.middleware.info-test"})]
       (is (= (:status response) #{"done"}))
-      (is (= (:ns response) "cider.test-ns.first-test-ns"))
-      (is (= (:name response) "same-name-testing-function"))
-      (is (= (:arglists-str response) "([])"))
-      (is (nil? (:macro response)))
-      (is (= (:doc response) "Multiple vars with the same name in different ns's. Used to test ns-list-vars-by-name."))
-      (is (nil? (:spec response))))))
+      (is (= (:ns response) "clojure.core"))
+      (is (= (:name response) "let"))
+      (is (not-empty (:spec response))))))


### PR DESCRIPTION
Fix for https://github.com/clojure-emacs/cider-nrepl/issues/468

Now special-sym-meta only takes care of special symbols. 
Adds `maybe-add-url`.
Adds and fixes some clojure 1.9 spec tests.

Before submitting a PR make sure the following things have been done:

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [X] You've added tests to cover your change(s)
- [X] All tests are passing
- [X] The new code is not generating reflection warnings
- [X] You've updated the readme (if adding/changing middleware)

Thanks!
