### PR TITLE
[Fix #425] Using spec middleware spec-form instead of clojure.spec.alpha/form for

### DIFF
--- a/src/cider/nrepl/middleware/spec.clj
+++ b/src/cider/nrepl/middleware/spec.clj
@@ -68,7 +68,7 @@
   "Given a form like (fn* [any-symbol] ... any-symbol...) replace fn* with fn
   and any occurrence of any-symbol with %."
   [[_ [sym] & r]]
-  (concat '(fn [%])
+  (concat '(clojure.core/fn [%])
         (walk/postwalk (fn [form]
                          (if (and (symbol? form) (= form sym))
                            '%
@@ -88,10 +88,11 @@
   "Given a spec symbol as a string, get the spec form and prepare it for
   a response."
   [spec-name]
-  (-> (spec-utils/form (spec-from-string spec-name))
-      add-multi-specs
-      normalize-spec-form
-      str-non-colls))
+  (when-let [spec (spec-from-string spec-name)]
+    (-> (spec-utils/form spec)
+        add-multi-specs
+        normalize-spec-form
+        str-non-colls)))
 
 (defn spec-example
   "Given a spec symbol as a string, returns a string with a pretty printed

--- a/test/clj/cider/nrepl/middleware/spec_test.clj
+++ b/test/clj/cider/nrepl/middleware/spec_test.clj
@@ -26,14 +26,14 @@
                                              :args (clojure.spec.alpha/and
                                                     (fn* [p1__22097#]
                                                          (clojure.core/< (:start p1__22097#) (:end p1__22097#)))
-                                                    (fn [%]
+                                                    (clojure.core/fn [%]
                                                       (clojure.core/< (:start %) (:end %))))
                                              :ret (fn* [p2__33098#]
                                                        (clojure.core/> (:start p2__33098#) (:end p2__33098#)))
                                              :fn nil))
            '(clojure.spec.alpha/fspec
              :args (clojure.spec.alpha/and
-                    (fn [%] (clojure.core/< (:start %) (:end %)))
-                    (fn [%] (clojure.core/< (:start %) (:end %))))
-             :ret (fn [%] (clojure.core/> (:start %) (:end %)))
+                    (clojure.core/fn [%] (clojure.core/< (:start %) (:end %)))
+                    (clojure.core/fn [%] (clojure.core/< (:start %) (:end %))))
+             :ret (clojure.core/fn [%] (clojure.core/> (:start %) (:end %)))
              :fn nil)))))


### PR DESCRIPTION
Make spec meta for info middleware take spec using spec middleware `spec-form` instead of `clojure.spec/describe`

**This needs to be merged together with Cider fix!**  https://github.com/clojure-emacs/cider/issues/2029
 
- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [X] You've added tests to cover your change(s)
- [X] All tests are passing
- [X] The new code is not generating reflection warnings
- [X] You've updated the readme (if adding/changing middleware)

