### PR TITLE
source-info should return absolute path

### DIFF
--- a/src/cider/nrepl/middleware/util/java/parser.clj
+++ b/src/cider/nrepl/middleware/util/java/parser.clj
@@ -243,8 +243,10 @@
 
 (defn source-path
   "Return the relative `.java` source path for the top-level class."
-  [class]
-  (-> (str/replace (str class) #"\$.*" "")
+  [klass]
+  (-> (str klass)
+      (str/replace #"^class " "")
+      (str/replace #"\$.*" "")
       (str/replace "." "/")
       (str ".java")))
 

--- a/src/cider/nrepl/middleware/util/java/parser.clj
+++ b/src/cider/nrepl/middleware/util/java/parser.clj
@@ -255,13 +255,14 @@
   and return info to supplement reflection. Specifically, this includes source
   file and position, docstring, and argument name info. Info returned has the
   same structure as that of `cider.nrepl.middleware.util.java/reflect-info`."
-  [class]
-  {:pre [(symbol? class)]}
+  [klass]
+  {:pre [(symbol? klass)]}
   (try
-    (let [path (source-path class)]
+    (let [path (source-path klass)]
       (when-let [root (parse-java path)]
         (assoc (->> (map parse-info (.classes root))
-                    (filter #(= class (:class %)))
+                    (filter #(= klass (:class %)))
                     (first))
-               :file path)))
+               :file path
+               :path (. (io/resource path) getPath))))
     (catch Abort _)))


### PR DESCRIPTION
For example, this should be enough info for goto-definition:

```clojure
((juxt :file :line)
 (cider.nrepl.middleware.util.java.parser/source-info
   'clojure.lang.RT))
```
