### PR TITLE
Fix CLJS tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,73 +6,68 @@ cache:
     - $HOME/.m2
 script:
   - lein source-deps
-  - $TEST_CMD
+  - |
+    if [ ! -z "$TEST_CMD" ]; then
+      $TEST_CMD;
+    else
+      lein with-profile +$VERSION,+plugin.mranderson/config,+$TEST test;
+    fi
 env:
-  - TEST_CMD="lein with-profile +1.7,+plugin.mranderson/config,+test-clj test"
-  - TEST_CMD="lein with-profile +1.7,+plugin.mranderson/config,+test-cljs test"
-
-  - TEST_CMD="lein with-profile +1.8,+plugin.mranderson/config,+test-clj test"
-  - TEST_CMD="lein with-profile +1.8,+plugin.mranderson/config,+test-cljs test"
-
-  - TEST_CMD="lein with-profile +1.9,+plugin.mranderson/config,+test-clj test"
-  - TEST_CMD="lein with-profile +1.9,+plugin.mranderson/config,+test-cljs test"
-
-  - TEST_CMD="lein with-profile +master,+plugin.mranderson/config,+test-clj test"
-  - TEST_CMD="lein with-profile +master,+plugin.mranderson/config,+test-cljs test"
+  - VERSION="1.7" TEST="test-clj"
+  - VERSION="1.7" TEST="test-cljs"
+  - VERSION="1.8" TEST="test-clj"
+  - VERSION="1.8" TEST="test-cljs"
+  - VERSION="1.9" TEST="test-clj"
+  - VERSION="1.9" TEST="test-cljs"
 jdk:
-  - openjdk7
   - oraclejdk7
   - oraclejdk8
 matrix:
   include:
+    # Test OpenJDK against latest Clojure stable
     - env:
-        - TEST_CMD="lein with-profile +1.7,+test-clj,+test-cljs,+cloverage cloverage --codecov"
+        - VERSION="1.9"
+        - TEST="test-clj"
+      jdk: openjdk8
+    - env:
+        - VERSION="1.9"
+        - TEST="test-cljs"
+      jdk: openjdk8
+
+    # Test Clojure master against a single JDK
+    - env:
+        - VERSION="master"
+        - TEST="test-clj"
+      jdk: oraclejdk8
+    - env:
+        - VERSION="master"
+        - TEST="test-cljs"
+      jdk: oraclejdk8
+
+    # eastwood
+    - env: TEST_CMD="lein with-profile +1.9,+test-clj,+test-cljs,+eastwood eastwood"
+      jdk: oraclejdk8
+
+    # cljfmt
+    - env: TEST_CMD="lein with-profile +1.9,+test-clj,+test-cljs,+cljfmt cljfmt check"
+      jdk: oraclejdk8
+
+    # codecov
+    - env: TEST_CMD="lein with-profile +1.9,+test-clj,+test-cljs,+cloverage cloverage --codecov"
       after_success: bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json
       jdk: oraclejdk8
 
-    - env:
-        - TEST_CMD="lein with-profile +1.7,+test-clj,+test-cljs,+cloverage cloverage --coveralls"
+    # coveralls
+    - env: TEST_CMD="lein with-profile +1.9,+test-clj,+test-cljs,+cloverage cloverage --coveralls"
       after_success: curl -F json_file=@target/coverage/coveralls.json https://coveralls.io/api/v1/jobs
       jdk: oraclejdk8
 
-    - env: TEST_CMD="lein with-profile +1.7,+test-clj,+test-cljs,+eastwood eastwood"
-      jdk: oraclejdk8
-
-    - env: TEST_CMD="lein with-profile +1.7,+test-clj,+test-cljs,+cljfmt cljfmt check"
-      jdk: oraclejdk8
-
-  exclude:
-    # Only test openjdk against the latest Clojure stable.
-    - env: TEST_CMD="lein with-profile +master,+plugin.mranderson/config,+test-clj test"
-      jdk: openjdk7
-    - env: TEST_CMD="lein with-profile +master,+plugin.mranderson/config,+test-cljs test"
-      jdk: openjdk7
-    - env: TEST_CMD="lein with-profile +1.7,+plugin.mranderson/config,+test-clj test"
-      jdk: openjdk7
-    - env: TEST_CMD="lein with-profile +1.7,+plugin.mranderson/config,+test-cljs test"
-      jdk: openjdk7
-
-    # Testing Clojure master is about foreseeing incompatible changes,
-    # not about uncovering incompatibilities with specific jdk
-    # versions, so a single build (oraclejdk8) should be enough.
-    - env: TEST_CMD="lein with-profile +master,+plugin.mranderson/config,+test-clj test"
-      jdk: oraclejdk7
-    - env: TEST_CMD="lein with-profile +master,+plugin.mranderson/config,+test-cljs test"
-      jdk: oraclejdk7
-
-  # "fast_finish" means "don't wait for the allowed failures".
-  fast_finish: true
+  fast_finish: true      # don't wait for allowed failures before build finish
   allow_failures:
-    - env: TEST_CMD="lein with-profile +1.8,+plugin.mranderson/config,+test-cljs test"
-      jdk: oraclejdk7
-    - env: TEST_CMD="lein with-profile +1.7,+plugin.mranderson/config,+test-cljs test"
-      jdk: oraclejdk7
-    - env: TEST_CMD="lein with-profile +1.7,+test-clj,+test-cljs,+cljfmt cljfmt check"
-    - env: TEST_CMD="lein with-profile +1.7,+test-clj,+test-cljs,+eastwood eastwood"
-    - env:
-        - TEST_CMD="lein with-profile +1.7,+test-clj,+test-cljs,+cloverage cloverage --codecov"
-    - env:
-        - TEST_CMD="lein with-profile +1.7,+test-clj,+test-cljs,+cloverage cloverage --coveralls"
+    - env: TEST_CMD="lein with-profile +1.9,+test-clj,+test-cljs,+eastwood eastwood"
+    - env: TEST_CMD="lein with-profile +1.9,+test-clj,+test-cljs,+cljfmt cljfmt check"
+    - env: TEST_CMD="lein with-profile +1.9,+test-clj,+test-cljs,+cloverage cloverage --codecov"
+    - env: TEST_CMD="lein with-profile +1.9,+test-clj,+test-cljs,+cloverage cloverage --coveralls"
 
 notifications:
   webhooks:

--- a/project.clj
+++ b/project.clj
@@ -61,21 +61,23 @@
                                   [boot/base "2.7.2"]
                                   [boot/core "2.7.2"]]}
 
-             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
-             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]
+                                  [org.clojure/clojurescript "1.7.228" :scope "provided"]]}
+             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]
+                                  [org.clojure/clojurescript "1.8.51" :scope "provided"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]
-                                  [org.clojure/clojurescript "1.9.946"]]
+                                  [org.clojure/clojurescript "1.9.946" :scope "provided"]]
                    :test-paths ["test/spec"]}
              :master {:repositories [["snapshots" "https://oss.sonatype.org/content/repositories/snapshots"]]
-                      :dependencies [[org.clojure/clojure "1.10.0-master-SNAPSHOT"]]}
+                      :dependencies [[org.clojure/clojure "1.10.0-master-SNAPSHOT"]
+                                     [org.clojure/clojurescript "1.9.946" :scope "provided"]]}
 
              :test-clj {:source-paths ["test/src"]
                         :java-source-paths ["test/java"]
                         :resource-paths ["test/resources"]
                         :test-paths ["test/clj"]}
              :test-cljs {:test-paths ["test/cljs"]
-                         :dependencies [[com.cemerick/piggieback "0.2.2"]
-                                        [org.clojure/clojurescript "1.7.189"]]}
+                         :dependencies [[com.cemerick/piggieback "0.2.2"]]}
 
              :cloverage {:plugins [[lein-cloverage "1.0.10"]]}
 


### PR DESCRIPTION
The `:test-cljs` profile uses ClojureScript `1.7.189`, which uses `(require ...)` instead of `(:require ...)` in the ns form of `base64_vlq.clj`. This is fixed in clojure/clojurescript@48b83d9.

b63b153 tries to correct this by specifying a higher ClojureScript version in the `:1.9` profile, but this fails because the `:test-cljs` profile comes later.


We resolve this by matching each version of Clojure with a compatible version of Clojurescript in the version profiles.