### PR TITLE
parser.clj (parse-info): Return :type for fields and methods

### DIFF
--- a/src/cider/nrepl/middleware/util/java/parser.clj
+++ b/src/cider/nrepl/middleware/util/java/parser.clj
@@ -216,10 +216,12 @@
   MethodDoc
   (parse-info [m]
     {:argtypes (mapv #(-> ^Parameter % .type typesym) (.parameters m))
-     :argnames (mapv #(-> ^Parameter % .name symbol) (.parameters m))})
+     :argnames (mapv #(-> ^Parameter % .name symbol) (.parameters m))
+     :type (str (.returnType m))})
 
   FieldDoc
-  (parse-info [f])
+  (parse-info [f]
+    {:type (str (.type f))})
 
   ClassDoc
   (parse-info [c]


### PR DESCRIPTION
Allows e.g. to have the following sample of tags for
java.util.ArrayList.java:

    int MAX_ARRAY_SIZE
    void grow (int minCapacity)
    int hugeCapacity (int minCapacity)
    int size ()
    boolean isEmpty ()
    boolean contains (Object o)
    int indexOf (Object o)
    int lastIndexOf (Object o)
    Object clone ()
    Object[] toArray ()
    Object[] toArray (Object[] a)
