### PR TITLE
[Fix #457] Reinstate cloverage testing by omitting problem namespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pom.xml.asc
 .lein-plugins
 .lein-repl-history
 .nrepl-port
+.source-deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,69 +5,52 @@ cache:
   directories:
     - $HOME/.m2
 script:
-  - lein source-deps
-  - |
-    if [ ! -z "$TEST_CMD" ]; then
-      $TEST_CMD;
-    else
-      lein with-profile +$VERSION,+plugin.mranderson/config,+$TEST test;
-    fi
+  - make $TARGET
 env:
-  - VERSION="1.7" TEST="test-clj"
-  - VERSION="1.7" TEST="test-cljs"
-  - VERSION="1.8" TEST="test-clj"
-  - VERSION="1.8" TEST="test-cljs"
-  - VERSION="1.9" TEST="test-clj"
-  - VERSION="1.9" TEST="test-cljs"
+  - VERSION=1.7 TARGET=test-clj
+  - VERSION=1.7 TARGET=test-cljs
+  - VERSION=1.8 TARGET=test-clj
+  - VERSION=1.8 TARGET=test-cljs
+  - VERSION=1.9 TARGET=test-clj
+  - VERSION=1.9 TARGET=test-cljs
 jdk:
   - oraclejdk7
   - oraclejdk8
+  - oraclejdk9
 matrix:
   include:
     # Test OpenJDK against latest Clojure stable
-    - env:
-        - VERSION="1.9"
-        - TEST="test-clj"
+    - env: VERSION=1.9 TARGET=test-clj
       jdk: openjdk8
-    - env:
-        - VERSION="1.9"
-        - TEST="test-cljs"
+    - env: VERSION=1.9 TARGET=test-cljs
       jdk: openjdk8
 
     # Test Clojure master against a single JDK
-    - env:
-        - VERSION="master"
-        - TEST="test-clj"
+    - env: VERSION=master TARGET=test-clj
       jdk: oraclejdk8
-    - env:
-        - VERSION="master"
-        - TEST="test-cljs"
+    - env: VERSION=master TARGET=test-cljs
       jdk: oraclejdk8
 
-    # eastwood
-    - env: TEST_CMD="lein with-profile +1.9,+test-clj,+test-cljs,+eastwood eastwood"
+    # Eastwood linter
+    - env: VERSION=1.9 TARGET=eastwood
       jdk: oraclejdk8
 
-    # cljfmt
-    - env: TEST_CMD="lein with-profile +1.9,+test-clj,+test-cljs,+cljfmt cljfmt check"
+    # Check cljfmt
+    - env: VERSION=1.9 TARGET=cljfmt
       jdk: oraclejdk8
 
-    # codecov
-    - env: TEST_CMD="lein with-profile +1.9,+test-clj,+test-cljs,+cloverage cloverage --codecov"
+    # Coverage analysis
+    - env: VERSION=1.9 TARGET=cloverage
+      jdk: oraclejdk8
       after_success: bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json
-      jdk: oraclejdk8
-
-    # coveralls
-    - env: TEST_CMD="lein with-profile +1.9,+test-clj,+test-cljs,+cloverage cloverage --coveralls"
-      after_success: curl -F json_file=@target/coverage/coveralls.json https://coveralls.io/api/v1/jobs
-      jdk: oraclejdk8
 
   fast_finish: true      # don't wait for allowed failures before build finish
   allow_failures:
-    - env: TEST_CMD="lein with-profile +1.9,+test-clj,+test-cljs,+eastwood eastwood"
-    - env: TEST_CMD="lein with-profile +1.9,+test-clj,+test-cljs,+cljfmt cljfmt check"
-    - env: TEST_CMD="lein with-profile +1.9,+test-clj,+test-cljs,+cloverage cloverage --codecov"
-    - env: TEST_CMD="lein with-profile +1.9,+test-clj,+test-cljs,+cloverage cloverage --coveralls"
+    - env: VERSION=master TARGET=test-clj
+    - env: VERSION=master TARGET=test-cljs
+    - env: VERSION=1.9 TARGET=cloverage
+    - env: VERSION=1.9 TARGET=eastwood
+    - env: VERSION=1.9 TARGET=cljfmt
 
 notifications:
   webhooks:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+.PHONY: clean source-deps test-clj test-cljs eastwood cljfmt cloverage
+
+VERSION ?= 1.9
+export CLOVERAGE_VERSION = 1.0.11-SNAPSHOT
+
+.source-deps:
+	lein source-deps
+	touch .source-deps
+
+source-deps: .source-deps
+
+test-clj: .source-deps
+	lein with-profile +$(VERSION),+plugin.mranderson/config,+test-clj test
+
+test-cljs: .source-deps
+	lein with-profile +$(VERSION),+plugin.mranderson/config,+test-cljs test
+
+eastwood: .source-deps
+	lein with-profile +$(VERSION),+test-clj,+test-cljs,+eastwood eastwood
+
+cljfmt: .source-deps
+	lein with-profile +$(VERSION),+test-clj,+test-cljs,+cljfmt cljfmt check
+
+
+# Cloverage can't handle some of the code in this project.  For now we
+# must filter problematic namespaces (`-e`) and tests (`-t`) from
+# instrumentation. Note: this means for now coverage reporting isn't
+# exact. See issue #457 for details.
+
+cloverage: .source-deps
+	lein with-profile +$(VERSION),+test-clj,+cloverage cloverage --codecov \
+	     -e ".*java.parser" \
+	     -e "cider-nrepl.plugin" \
+	     -e ".*util.instrument" \
+	     -t "^((?!debug-integration-test).)*$$"
+
+clean:
+	lein clean
+	rm .source-deps
+

--- a/project.clj
+++ b/project.clj
@@ -79,7 +79,7 @@
              :test-cljs {:test-paths ["test/cljs"]
                          :dependencies [[com.cemerick/piggieback "0.2.2"]]}
 
-             :cloverage {:plugins [[lein-cloverage "1.0.10"]]}
+             :cloverage {:plugins [[lein-cloverage "1.0.11-SNAPSHOT"]]}
 
              :cljfmt {:plugins [[lein-cljfmt "0.5.7"]]
                       :cljfmt {:indents {as-> [[:inner 0]]

--- a/test/clj/cider/nrepl/middleware/debug_integration_test.clj
+++ b/test/clj/cider/nrepl/middleware/debug_integration_test.clj
@@ -1,5 +1,6 @@
 (ns cider.nrepl.middleware.debug-integration-test
-  (:require [cider.nrepl.middleware.debug :as d]
+  (:require [cider.nrepl :refer [wrap-debug]]
+            [cider.nrepl.middleware.debug :as d]
             [cider.nrepl.test.server :refer [start-server]]
             [clojure.test :refer :all]
             [clojure.tools.nrepl :as nrepl]


### PR DESCRIPTION
This PR introduces the following:
 - adds a `Makefile` with targets to use in `travis.yml`, or can be used manually too
 - excludes some problematic namespaces and tests from `cloverage` instrumentation, where instrumentation would cause tests to throw exceptions and/or fail.
 - drops `cloverage --coveralls` completely, leaving only `cloverage --codecov`
 - adds Oracle JDK 9 to the test matrix

---

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] [n/a] You've added tests to cover your change(s)
- [ ] [broken] All tests are passing
- [ ] [n/a] The new code is not generating reflection warnings
- [ ] [n/a] You've updated the readme (if adding/changing middleware)
