### PR TITLE
Swap oraclejdk7 with openjdk7 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   - VERSION=1.9 TARGET=test-clj
   - VERSION=1.9 TARGET=test-cljs
 jdk:
-  - oraclejdk7
+  - openjdk7
   - oraclejdk8
   - oraclejdk9
 matrix:


### PR DESCRIPTION

As mentioned in https://github.com/clojure-emacs/orchard/pull/5, Travis CI dropped support for `oraclejdk7` when Oracle discontinued their support. We'll have to use `openjdk7` instead.

----

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] N/A You've added tests to cover your change(s)
- [ ] N/A All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the readme (if adding/changing middleware)

Thanks!
