### PR TITLE
Get classpath from system property for Java >= 9

### DIFF
--- a/src/cider/nrepl/middleware/classpath.clj
+++ b/src/cider/nrepl/middleware/classpath.clj
@@ -1,16 +1,20 @@
 (ns cider.nrepl.middleware.classpath
   (:require [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
-            [orchard.misc :as u]
             [clojure.java.classpath :as cp]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [orchard.misc :as u])
+  (:import [java.io File]))
 
 (defn classpath
   "Return a list of classpath entries for the current project.
   Takes into account the classpath trickery performed by Boot."
   []
   (if-let [classpath (u/boot-fake-classpath)]
-    (str/split classpath #":")
-    (map str (cp/classpath))))
+    (str/split classpath (re-pattern File/pathSeparator))
+    (if (neg? (compare u/java-api-version "9"))
+      (map str (cp/classpath))
+      (-> (System/getProperty "java.class.path")
+          (str/split (re-pattern File/pathSeparator))))))
 
 (defn classpath-reply [msg]
   {:classpath (classpath)})

--- a/test/clj/cider/nrepl/middleware/classpath_test.clj
+++ b/test/clj/cider/nrepl/middleware/classpath_test.clj
@@ -1,8 +1,10 @@
 (ns cider.nrepl.middleware.classpath-test
-  (:require [cider.nrepl.test-session :as session]
-            [cider.nrepl.middleware.classpath :as cp]
+  (:require [cider.nrepl.middleware.classpath :as cp]
+            [cider.nrepl.test-session :as session]
+            [clojure.set :as set]
             [clojure.string :as str]
-            [clojure.test :refer :all]))
+            [clojure.test :refer :all])
+  (:import [java.io File]))
 
 (use-fixtures :each session/session-fixture)
 (deftest integration-test
@@ -34,3 +36,8 @@
                        (cp/classpath))))
         (finally
           (System/clearProperty "fake.class.path"))))))
+
+(deftest classpath-test
+  (is (set/subset? (set (-> (System/getProperty "java.class.path")
+                            (str/split (re-pattern File/pathSeparator))))
+                   (set (cp/classpath)))))


### PR DESCRIPTION
Fix #481

This is a workaround until `clojure.java.classpath` gets fixed.

See: https://dev.clojure.org/jira/browse/CLASSPATH-8