### PR TITLE
Stop using `mranderson` for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ export CLOVERAGE_VERSION = 1.0.11-SNAPSHOT
 source-deps: .source-deps
 
 test-clj: .source-deps
-	lein with-profile +$(VERSION),+plugin.mranderson/config,+test-clj test
+	lein with-profile +$(VERSION),+test-clj test
 
 test-cljs: .source-deps
-	lein with-profile +$(VERSION),+plugin.mranderson/config,+test-cljs test
+	lein with-profile +$(VERSION),+test-cljs test
 
 eastwood: .source-deps
 	lein with-profile +$(VERSION),+test-clj,+test-cljs,+eastwood eastwood


### PR DESCRIPTION
Workaround for #489. It's important we get CI working properly until the [Orchard](https://github.com/clojure-emacs/orchard) port is complete.