### PR TITLE
Disable failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,13 @@ matrix:
       jdk: oraclejdk8
       after_success: bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json
 
+  exclude:
+    # CLJS-1.9 doesn't build on JDK7. This is because of a dependency on the
+    # google/closure-compiler which requires JDK8 or higher.
+    # https://github.com/google/closure-compiler/wiki/Releases#september-10-2017-v20170910
+    - env: VERSION=1.9 TARGET=test-cljs
+      jdk: openjdk7
+
   fast_finish: true      # don't wait for allowed failures before build finish
   allow_failures:
     - env: VERSION=master TARGET=test-clj


### PR DESCRIPTION
These failures are unrelated to the nREPL itself.

1. CLJS doesn't build on JDK9 because it depends on a package deprecated in JDK9 (javax.xml.bind). CLJS-2377 tracks it. It has been fixed on master, but not yet released. After that, we can enable CLJS-1.9 tests on JDK9, but not the others.

2. CLJS-1.9 also doesn't build on JDK7 anymore ? I think this is because of a dependency on the closure-compiler which requires JDK8 or higher (https://github.com/google/closure-compiler/wiki/Releases#september-10-2017-v20170910)

/cc @gonewest818 

Before submitting a PR make sure the following things have been done:

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [ ] All tests are passing
- [ ] The new code is not generating reflection warnings
- [ ] You've updated the readme (if adding/changing middleware)

Thanks!
