### PR TITLE
[Fix #500] simplify java version detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,14 @@ jdk:
 stages:
   - name: test
   - name: check
+  # Deploy only from the home repo where the credentials can be
+  # properly decrypted. Never deploy from a pull request job.
+  # In addition, ensure we're on the master branch (snapshots)
+  # or a branch with semver naming (releases).
   - name: deploy
-    if: branch = master
+    if: repo = clojure-emacs/cider-nrepl
+        AND type != pull_request
+        AND ( branch = master OR branch =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ )
 jobs:
   include:
     # Test OpenJDK against latest Clojure stable

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ VERSION ?= 1.9
 export CLOVERAGE_VERSION = 1.0.11-SNAPSHOT
 
 # The test-cljs target needs to be modified if working with JDK9
-JAVA_VERSION = $(shell lein version | cut -d " " -f 5 | cut -d "." -f 1-2)
+JAVA_VERSION = $(shell lein with-profile +sysutils \
+                       sysutils :java-version-simple | cut -d " " -f 2)
 
 .source-deps:
 	lein source-deps
@@ -16,7 +17,7 @@ test-clj: # .source-deps
 	lein with-profile +$(VERSION),+test-clj test
 
 test-cljs: # .source-deps
-	if [ "$(JAVA_VERSION)" = "9.0" ] || [ "$(JAVA_VERSION)" = "9-internal" ]; then \
+	if [ "$(JAVA_VERSION)" = "9" ]; then \
             lein with-profile +$(VERSION),+test-cljs \
                  update-in :jvm-opts concat '["--add-modules" "java.xml.bind"]' \
                  -- test; \

--- a/Makefile
+++ b/Makefile
@@ -55,19 +55,10 @@ release:
 
 # Deploying requires the caller to set environment variables as
 # specified in project.clj to provide a login and password to the
-# artifact repository.  We're setting TRAVIS_PULL_REQUEST to a default
-# value to avoid accidentally deploying from the command line. Inside
-# Travis CI this variable will be set to the pull request number, or
-# to "false" if it's not a pull request.
-
-TRAVIS_PULL_REQUEST ?= "true"
+# artifact repository.
 
 deploy: .source-deps
-	if [ "$(TRAVIS_PULL_REQUEST)" != "false" ]; then \
-	    echo "Pull request detected. Skipping deploy."; \
-	else \
-	    lein with-profile +$(VERSION),+plugin.mranderson/config deploy clojars; \
-	fi
+	lein with-profile +$(VERSION),+plugin.mranderson/config deploy clojars
 
 clean:
 	lein clean

--- a/project.clj
+++ b/project.clj
@@ -95,6 +95,8 @@
              :test-cljs {:test-paths ["test/cljs"]
                          :dependencies [[com.cemerick/piggieback "0.2.2"]]}
 
+             :sysutils {:plugins [[lein-sysutils "0.2.0"]]}
+
              :cloverage {:plugins [[lein-cloverage "1.0.11-SNAPSHOT"]]}
 
              :cljfmt {:plugins [[lein-cljfmt "0.5.7"]]

--- a/src/cider_nrepl/main.clj
+++ b/src/cider_nrepl/main.clj
@@ -1,7 +1,7 @@
 (ns cider-nrepl.main
   (:require
-    [clojure.java.io :as io]
-    [clojure.tools.nrepl.server :as nrepl.server]))
+   [clojure.java.io :as io]
+   [clojure.tools.nrepl.server :as nrepl.server]))
 
 (defn- require-and-resolve
   [thing]


### PR DESCRIPTION

* `lein-sysutils` offloads the parsing of the JDK version number to the commons-lang3 library. The benefit is that we don't have to invent tricky regex syntax and anticipate new versioning conventions such as JEP 223 (http://openjdk.java.net/jeps/223). `lein-sysutils` uses reflection to parse the available fields in org.apache.commons.lang3.SystemUtils, which means this mechanism should be fairly future-proof as long as the underlying library is actively maintained.

* Also fixes two CI issues by updating the conditional test in the deploy stage in `.travis.yml`
  1. While `make release` creates a new version tag from which the
release should build and deploy, it turns out the resulting CI job
does not run the deploy task, because for those jobs the branch name
is not "master".  With this commit we allow deploys from branches
where the name matches "v#.#.#".
  2. Anyone running Travis CI builds on their own fork of this project
ended up with failed deploy jobs because the Clojars credentials could
not be parsed. With this commit we exclude deploy jobs from even
running if we're on a fork.


----

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s) *N/A*
- [x] All tests are passing *EXCEPT eastwood which was broken before*
- [ ] The new code is not generating reflection warnings *N/A*
- [ ] You've updated the readme (if adding/changing middleware) *N/A*

Thanks!
