### PR TITLE
Fix cljfmt & eastwood checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ test-cljs: # .source-deps
 	fi
 
 eastwood:
-	lein with-profile +$(VERSION),+test-clj,+test-cljs,+eastwood eastwood
+	lein with-profile +$(VERSION),+test-clj,+test-cljs,+eastwood eastwood \
+	     "{:namespaces [:source-paths] :exclude-namespaces [cider-nrepl.plugin]}"
 
 cljfmt:
 	lein with-profile +$(VERSION),+test-clj,+test-cljs,+cljfmt cljfmt check

--- a/eastwood.clj
+++ b/eastwood.clj
@@ -15,3 +15,9 @@
   :if-inside-macroexpansion-of #{'clojure.core/cond->}
   :within-depth 2
   :reason "The `cond->` macro can legitimately contain always-true predicates."})
+
+(disable-warning
+ {:linter :unused-ret-vals
+  :if-inside-macroexpansion-of #{'boot.core/deftask}
+  :within-depth 7
+  :reason "The `deftask` macro often includes calls to `boot.util/dbug*` whose purpose is solely for side-effects."})

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -348,8 +348,6 @@
                                     :requires {}
                                     :returns  {"status" "Done"}}}})
 
-
-
 (def-wrapper wrap-refresh cider.nrepl.middleware.refresh/handle-refresh
   {:doc "Refresh middleware."
    :requires #{"clone" #'wrap-pprint-fn}

--- a/src/cider/nrepl/middleware/profile.clj
+++ b/src/cider/nrepl/middleware/profile.clj
@@ -128,7 +128,7 @@
 
 (defn handle-profile
   [handler msg]
-  (let [{:keys [op] } msg]
+  (let [{:keys [op]} msg]
     (case op
       "toggle-profile"      (toggle-profile msg)
       "toggle-profile-ns"   (toggle-profile-ns msg)

--- a/test/clj/cider/nrepl/middleware/profile_test.clj
+++ b/test/clj/cider/nrepl/middleware/profile_test.clj
@@ -47,8 +47,8 @@
            (toggle-profile-ns {:ns "my.ns" :transport (test-transport)})))))
 
 (deftest is-var-profiled-test
-  (testing  "is var profiled"
-      (toggle-profile {:ns "clojure.core" :sym "zipmap" :transport (test-transport)})
+  (testing "is var profiled"
+    (toggle-profile {:ns "clojure.core" :sym "zipmap" :transport (test-transport)})
     (is (= [{:value "profiled" :status #{:done}}]
            (is-var-profiled {:ns "clojure.core" :sym "zipmap" :transport (test-transport)})))
     (toggle-profile {:ns "clojure.core" :sym "zipmap" :transport (test-transport)})
@@ -58,4 +58,4 @@
 (deftest set-max-examples-test
   (testing "max examples"
     (is (= [{:value "5000" :status #{:done}}]
-         (set-max-samples {:max-samples 5000 :transport (test-transport)})))))
+           (set-max-samples {:max-samples 5000 :transport (test-transport)})))))


### PR DESCRIPTION
~~Please don't merge yet.~~ I'm trying to locate an inconsistency in builds for the SAME COMMIT failing when they build in my personal Travis CI account versus in the clojure-emacs account.

So the point of this pull request is to get my branch to build as clojure-emacs rather than me... I know, it's a dirty trick but useful in this particular case.



- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [?] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the readme (if adding/changing middleware)
