### PR TITLE
[#508] Bump compliment so that namespaces aliased as user autocomplete

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                  ^:source-dep [thunknyc/profile "0.5.2"]
                  ^:source-dep [mvxcvi/puget "1.0.2"]
                  ^:source-dep [fipp "0.6.12"]
-                 ^:source-dep [compliment "0.3.5"]
+                 ^:source-dep [compliment "0.3.6"]
                  ^:source-dep [cljs-tooling "0.2.0"]
                  ^:source-dep [cljfmt "0.5.7" :exclusions [org.clojure/clojurescript]]
                  ;; Not used directly in cider-nrepl, but needed because of tool.namespace


### PR DESCRIPTION
just a simple dependency bump. have checked and works for me.

Steps to recreate:

```
(ns fizzbuzz.user)

(defn baz [] 1)

(ns fizzbuzz.core
  (:require [fizzbuzz.user :as user]))
```

then at a repl `fizzbuzz.core> (user/)` would not see any auto complete.

This does not depend on the name of the namespace (`fizzbuzz.user`) but on the alias, `user`. If you rename to `usern` autocomplete works again.