### PR TITLE
Document embedded-nREPL workaround for #447 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,13 +193,17 @@ server with CIDER's own nREPL handler.
 
 ```clojure
 (ns my-app
-  (:require [clojure.tools.nrepl.server :as nrepl-server]
-            [cider.nrepl :refer (cider-nrepl-handler)]))
+  (:require [clojure.tools.nrepl.server :as nrepl-server]))
 
-(defn -main
-  []
-  (nrepl-server/start-server :port 7888 :handler cider-nrepl-handler))
+(defn nrepl-handler []
+  (require 'cider.nrepl)
+  (ns-resolve 'cider.nrepl 'cider-nrepl-handler))
+
+(defn -main []
+  (nrepl-server/start-server :port 7888 :handler (nrepl-handler)))
 ```
+
+(See [issue #447](https://github.com/clojure-emacs/cider-nrepl/issues/447) for why the manual namespace resolution of `cider-nrepl-handler` is currently necessary.)
 
 ### With JBoss AS/JBoss EAP/WildFly
 


### PR DESCRIPTION
Per Bozhidar in https://github.com/clojure-emacs/cider-nrepl/issues/447#issuecomment-364812922 we are documenting the necessity of manual namespace resolution until #464 is resolved.

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our contribution guidelines—which, contrary to the PR template, are at https://github.com/clojure-emacs/cider-nrepl#contributing not CONTRIBUTING.md 😃 
- [n/a] You've added tests to cover your change(s)
- [n/a ] All tests are passing
- [n/a] The new code is not generating reflection warnings
- [x] You've updated the README (if adding/changing middleware)

Keep in mind that new cider-nrepl builds are automatically deployed to Clojars
once a PR is merged, but **only** if the CI build is green.

*If you're just starting out to hack on cider-nrepl you might find
this [article](https://juxt.pro/blog/posts/nrepl.html) and the
"Design" section of the README extremely useful.*

Thanks!
