### PR TITLE
Remove support for piggieback 0.1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
 ### Changes
 
 * Remove support for cljx.
+* Remove support for piggieback 0.1.x.

--- a/src/cider/nrepl/middleware/util/cljs.clj
+++ b/src/cider/nrepl/middleware/util/cljs.clj
@@ -9,16 +9,6 @@
     (resolve 'cemerick.piggieback/wrap-cljs-repl)
     (catch Exception _)))
 
-;; TODO: warn on usage of piggieback 0.1.x?
-(defn piggieback-0-2+?
-  "Returns true if piggieback 0.2.x is loaded, or false otherwise."
-  []
-  (boolean
-   (try
-     (require 'cemerick.piggieback)
-     (resolve 'cemerick.piggieback/*cljs-compiler-env*)
-     (catch Exception _))))
-
 (defn- maybe-piggieback
   [descriptor descriptor-key]
   (if-let [piggieback (try-piggieback)]
@@ -41,9 +31,7 @@
   "Returns the path in the session map for the ClojureScript compiler
   environment used by piggieback."
   []
-  (if (piggieback-0-2+?)
-    [(resolve 'cemerick.piggieback/*cljs-compiler-env*)]
-    [(resolve 'cemerick.piggieback/*cljs-repl-env*) :cljs.env/compiler]))
+  [(resolve 'cemerick.piggieback/*cljs-compiler-env*)])
 
 (defn- maybe-deref
   [x]
@@ -67,16 +55,11 @@
   "Returns the :value slot of an eval response from piggieback as a Clojure
   value."
   [response]
-  ;; Older versions of piggieback would attempt to read-string the result of
-  ;; `cljs.repl/evaluate-form` and return that as the value, but newer versions
-  ;; just return the output printed by `cljs.repl/repl*`.
   (let [value (:value response)]
-    (if (and (string? value) (piggieback-0-2+?))
-      (try
-        (read-string value)
-        (catch Exception _
-          value))
-      value)))
+    (try
+      (read-string value)
+      (catch Exception _
+        value))))
 
 (defn response-value
   "Returns the :value slot of an eval response as a Clojure value, reading the


### PR DESCRIPTION
I noticed we're still carting around some legacy code for compatibility with piggieback 0.1 and I think it's time to remove it. 