### PR TITLE
Fix print-length bug and fix integration tests

### DIFF
--- a/src/cider/nrepl/middleware/inspect.clj
+++ b/src/cider/nrepl/middleware/inspect.clj
@@ -21,9 +21,12 @@
         page-size (or page-size 32)
         inspector (swap-inspector! msg #(-> (assoc % :page-size page-size)
                                             (inspect/start value)))]
-    (transport/send
-     transport
-     (response-for msg :value (:rendered inspector)))))
+    (binding [*print-length* nil]
+      ;; Remove print-length limit because it breaks the output in the middle of
+      ;; the page when inspecting long sequences.
+      (transport/send
+       transport
+       (response-for msg :value (:rendered inspector))))))
 
 (defn inspector-transport
   [{:keys [^Transport transport] :as msg}]

--- a/test/clj/cider/nrepl/middleware/inspect_test.clj
+++ b/test/clj/cider/nrepl/middleware/inspect_test.clj
@@ -11,9 +11,9 @@
 
 (def eval-result (eval (read-string code)))
 
-(def inspect-result ["(\"Class\" \": \" (:value \"clojure.lang.PersistentTreeMap\" 0) (:newline) \"Contents: \" (:newline) \"  \" \"0\" \". \" (:value \"[ :a { :b 1 } ]\" 1) (:newline) \"  \" \"1\" \". \" (:value \"[ :c \\\"a\\\" ]\" 2) (:newline) \"  \" \"2\" \". \" (:value \"[ :d e ]\" 3) (:newline) \"  \" \"3\" \". \" (:value \"[ :f [ 2 3 ] ]\" 4) (:newline))"])
+(def inspect-result ["(\"Class\" \": \" (:value \"clojure.lang.PersistentTreeMap\" 0) (:newline) \"Contents: \" (:newline) \"  \" (:value \":a\" 1) \" = \" (:value \"{ :b 1 }\" 2) (:newline) \"  \" (:value \":c\" 3) \" = \" (:value \"\\\"a\\\"\" 4) (:newline) \"  \" (:value \":d\" 5) \" = \" (:value \"e\" 6) (:newline) \"  \" (:value \":f\" 7) \" = \" (:value \"[ 2 3 ]\" 8) (:newline))"])
 
-(def push-result ["(\"Class\" \": \" (:value \"clojure.lang.PersistentTreeMap$BlackVal\" 0) (:newline) \"Contents: \" (:newline) \"  \" \"0\" \". \" (:value \":a\" 1) (:newline) \"  \" \"1\" \". \" (:value \"{ :b 1 }\" 2) (:newline) (:newline) \"  Path: (find :a)\")"])
+(def push-result ["(\"Class\" \": \" (:value \"clojure.lang.PersistentArrayMap\" 0) (:newline) \"Contents: \" (:newline) \"  \" (:value \":b\" 1) \" = \" (:value \"1\" 2) (:newline) (:newline) \"  Path: :a\")"])
 
 (def next-page-result ["(\"Class\" \": \" (:value \"clojure.lang.LazySeq\" 0) (:newline) \"Contents: \" (:newline) \"  ...\" (:newline) \"  \" \"32\" \". \" (:value \"32\" 1) (:newline) \"  \" \"33\" \". \" (:value \"33\" 2) (:newline) \"  \" \"34\" \". \" (:value \"34\" 3) (:newline) (:newline) \"  Page size: 32, showing page: 2 of 2\")"])
 (def first-page-result ["(\"Class\" \": \" (:value \"clojure.lang.LazySeq\" 0) (:newline) \"Contents: \" (:newline) \"  \" \"0\" \". \" (:value \"0\" 1) (:newline) \"  \" \"1\" \". \" (:value \"1\" 2) (:newline) \"  \" \"2\" \". \" (:value \"2\" 3) (:newline) \"  \" \"3\" \". \" (:value \"3\" 4) (:newline) \"  \" \"4\" \". \" (:value \"4\" 5) (:newline) \"  ...\" (:newline) \"  Page size: 5, showing page: 1 of ?\")"])
@@ -153,7 +153,7 @@
                                        :inspect "true"
                                        :code code})
                      (session/message {:op "inspect-push"
-                                       :idx 1})))))))
+                                       :idx 2})))))))
 
 (deftest next-page-integration-test
   (testing "jumping to next page in a rendered expr inspector"
@@ -214,7 +214,7 @@
                                        :inspect "true"
                                        :code code})
                      (session/message {:op "inspect-push"
-                                       :idx 1})
+                                       :idx 2})
                      (session/message {:op "inspect-refresh"})))))))
 
 (deftest session-binding-integration-test

--- a/test/clj/cider/nrepl/middleware/inspect_test.clj
+++ b/test/clj/cider/nrepl/middleware/inspect_test.clj
@@ -272,3 +272,11 @@
                    (extract-text normal-page-2)))
       (is (re-find #"Page size: 5, showing page: 2 of 20"
                    (extract-text small-page-2))))))
+
+(deftest print-length-independence-test
+  (testing "*print-length* doesn't break rendering of long collections"
+    (is (re-find #"showing page: \d+ of \d+"
+                 (binding [*print-length* 10]
+                   (first (:value (session/message {:op "eval"
+                                                    :inspect "true"
+                                                    :code "(range 100)"}))))))))

--- a/test/cljs/cider/nrepl/middleware/cljs_inspect_test.clj
+++ b/test/cljs/cider/nrepl/middleware/cljs_inspect_test.clj
@@ -12,9 +12,9 @@
 
 (def eval-result (eval (read-string code)))
 
-(def inspect-result  ["(\"Class\" \": \" (:value \"clojure.lang.PersistentArrayMap\" 0) (:newline) \"Contents: \" (:newline) \"  \" \"0\" \". \" (:value \"[ :a { :b 1 } ]\" 1) (:newline) \"  \" \"1\" \". \" (:value \"[ :c \\\"a\\\" ]\" 2) (:newline) \"  \" \"2\" \". \" (:value \"[ :d e ]\" 3) (:newline) \"  \" \"3\" \". \" (:value \"[ :f [ 2 3 ] ]\" 4) (:newline))"])
+(def inspect-result ["(\"Class\" \": \" (:value \"clojure.lang.PersistentArrayMap\" 0) (:newline) \"Contents: \" (:newline) \"  \" (:value \":a\" 1) \" = \" (:value \"{ :b 1 }\" 2) (:newline) \"  \" (:value \":c\" 3) \" = \" (:value \"\\\"a\\\"\" 4) (:newline) \"  \" (:value \":d\" 5) \" = \" (:value \"e\" 6) (:newline) \"  \" (:value \":f\" 7) \" = \" (:value \"[ 2 3 ]\" 8) (:newline))"])
 
-(def push-result ["(\"Class\" \": \" (:value \"clojure.lang.MapEntry\" 0) (:newline) \"Contents: \" (:newline) \"  \" \"0\" \". \" (:value \":a\" 1) (:newline) \"  \" \"1\" \". \" (:value \"{ :b 1 }\" 2) (:newline) (:newline) \"  Path: (find :a)\")"])
+(def push-result ["(\"Class\" \": \" (:value \"clojure.lang.PersistentArrayMap\" 0) (:newline) \"Contents: \" (:newline) \"  \" (:value \":b\" 1) \" = \" (:value \"1\" 2) (:newline) (:newline) \"  Path: :a\")"])
 
 (def next-page-result ["(\"Class\" \": \" (:value \"clojure.lang.PersistentList\" 0) (:newline) \"Contents: \" (:newline) \"  ...\" (:newline) \"  \" \"32\" \". \" (:value \"32\" 1) (:newline) \"  \" \"33\" \". \" (:value \"33\" 2) (:newline) \"  \" \"34\" \". \" (:value \"34\" 3) (:newline) (:newline) \"  Page size: 32, showing page: 2 of 2\")"])
 (def first-page-result
@@ -47,16 +47,16 @@
   (testing "pushing an empty inspector index renders nil"
     (is (= nil-result
            (:value (session/message {:op "inspect-push"
-                                     :idx 1}))))))
+                                     :idx 2}))))))
 
 (deftest push-empty-idempotent-integration-test
   (testing "pushing an empty inspector index is idempotent"
     (is (= nil-result
            (:value (do
                      (session/message {:op "inspect-push"
-                                       :idx 1})
+                                       :idx 2})
                      (session/message {:op "inspect-push"
-                                       :idx 1})))))))
+                                       :idx 2})))))))
 
 (deftest refresh-empty-integration-test
   (testing "refreshing an empty inspector renders nil"
@@ -94,7 +94,7 @@
 
   (testing "inspect-push error handling"
     (with-redefs [i/swap-inspector! (fn [& _] (throw (Exception. "push exception")))]
-      (let [response (session/message {:op "inspect-push" :idx 1})]
+      (let [response (session/message {:op "inspect-push" :idx 2})]
         (is (= (:status response) #{"inspect-push-error" "done"}))
         (is (= (:ex response) "class java.lang.Exception"))
         (is (.startsWith (:err response) "java.lang.Exception: push exception"))
@@ -154,7 +154,7 @@
                                        :inspect "true"
                                        :code code})
                      (session/message {:op "inspect-push"
-                                       :idx 1})))))))
+                                       :idx 2})))))))
 
 (deftest next-page-integration-test
   (testing "jumping to next page in a rendered expr inspector"
@@ -185,7 +185,7 @@
                                        :inspect "true"
                                        :code code})
                      (session/message {:op "inspect-push"
-                                       :idx 1})
+                                       :idx 2})
                      (session/message {:op "inspect-pop"})))))))
 
 (deftest refresh-integration-test
@@ -215,7 +215,7 @@
                                        :inspect "true"
                                        :code code})
                      (session/message {:op "inspect-push"
-                                       :idx 1})
+                                       :idx 2})
                      (session/message {:op "inspect-refresh"})))))))
 
 (deftest session-binding-integration-test


### PR DESCRIPTION
All of the useful work was done in clojure-emacs/orchard#24.

Not editing CHANGELOG here since nothing useful happened in cider-nrepl. I can, however, edit the CHANGELOG in cider if you like, since changes in Orchard are user-facing.