### PR TITLE
Add test selector support

### DIFF
--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -199,14 +199,16 @@
 
 (defn test-vars
   "Call `test-var` on each var, with the fixtures defined for namespace
-  object `ns`."
-  [ns vars]
+  object `ns`. Filter vars with `selector` metadata marker when `selector` is present."
+  [ns selector vars]
   (let [once-fixture-fn (test/join-fixtures (::test/once-fixtures (meta ns)))
         each-fixture-fn (test/join-fixtures (::test/each-fixtures (meta ns)))]
     (try (once-fixture-fn
           (fn []
             (doseq [v vars]
-              (when (:test (meta v))
+              (when (and (:test (meta v))
+                         (or (not selector)
+                             ((keyword selector) (meta v))))
                 (each-fixture-fn (fn [] (test-var v)))))))
          (catch Throwable e
            (report-fixture-error ns e)))))
@@ -214,27 +216,29 @@
 (defn test-ns
   "If the namespace object defines a function named `test-ns-hook`, call that.
   Otherwise, test the specified vars. If no vars are specified, test all vars
-  in the namespace. On completion, return a map of test results."
-  [ns vars]
+  in the namespace. On completion, return a map of test results. If `selector`
+  is present filter vars that have the `selector` metadata marker."
+  [ns selector vars]
   (binding [test/report report]
     (test/do-report {:type :begin-test-ns, :ns ns})
     (if-let [test-hook (ns-resolve ns 'test-ns-hook)]
       (test-hook)
-      (test-vars ns (or (seq vars)
-                        (vals (ns-interns ns)))))
+      (test-vars ns selector (or (seq vars)
+                                 (vals (ns-interns ns)))))
     (test/do-report {:type :end-test-ns, :ns ns})
     @current-report))
 
 (defn test-nss
   "Call `test-ns` for each entry in map `m`, in which keys are namespace symbols
   and values are var symbols to be tested in that namespace (or `nil` to test
-  all vars). Symbols are first resolved to their corresponding objects."
-  [m]
+  all vars). Symbols are first resolved to their corresponding objects. If `selector`
+  is present filter vars that have the `selector` metadata marker."
+  [m selector]
   (report-reset!)
   (doseq [[ns vars] m]
     (->> (map (partial ns-resolve ns) vars)
          (filter identity)
-         (test-ns (the-ns ns))))
+         (test-ns (the-ns ns) selector)))
   @current-report)
 
 ;;; ## Metadata Utils
@@ -274,25 +278,25 @@
                            (alter-meta! session# dissoc :thread :eval-msg))))))
 
 (defn handle-test-op
-  [{:keys [ns tests session transport] :as msg}]
+  [{:keys [ns tests session transport selector] :as msg}]
   (with-interruptible-eval msg
     (if-let [ns (ns/ensure-namespace ns)]
       (let [nss {ns (map u/as-sym tests)}
-            report (test-nss nss)]
+            report (test-nss nss selector)]
         (reset! results (:results report))
         (t/send transport (response-for msg (u/transform-value report))))
       (t/send transport (response-for msg :status :namespace-not-found)))
     (t/send transport (response-for msg :status :done))))
 
 (defn handle-test-all-op
-  [{:keys [load? session transport] :as msg}]
+  [{:keys [load? session transport selector] :as msg}]
   (with-interruptible-eval msg
     (let [nss (zipmap (->> (if load?
                              (ns/load-project-namespaces)
                              (ns/loaded-project-namespaces))
                            (filter has-tests?))
                       (repeat nil))
-          report (test-nss nss)]
+          report (test-nss nss selector)]
       (reset! results (:results report))
       (t/send transport (response-for msg (u/transform-value report))))
     (t/send transport (response-for msg :status :done))))
@@ -306,7 +310,7 @@
                               vars (distinct (map :var problems))]
                           (if (seq vars) (assoc ret ns vars) ret)))
                       {} @results)
-          report (test-nss nss)]
+          report (test-nss nss nil)]
       (reset! results (:results report))
       (t/send transport (response-for msg (u/transform-value report))))
     (t/send transport (response-for msg :status :done))))
@@ -330,8 +334,8 @@
 (defn handle-test [handler msg & configuration]
   (let [executor (:executor configuration @default-executor)]
     (case (:op msg)
-      "test"            (handle-test-op (assoc msg :executor executor))
-      "test-all"        (handle-test-all-op (assoc msg :executor executor))
+      "test"            (handle-test-op (update (assoc msg :executor executor) :selector u/transform-value))
+      "test-all"        (handle-test-all-op (update (assoc msg :executor executor) :selector u/transform-value))
       "test-stacktrace" (handle-stacktrace-op (assoc msg :executor executor))
       "retest"          (handle-retest-op (assoc msg :executor executor))
       (handler msg))))

--- a/test/clj/cider/nrepl/middleware/test_selector_tests.clj
+++ b/test/clj/cider/nrepl/middleware/test_selector_tests.clj
@@ -1,0 +1,13 @@
+(ns cider.nrepl.middleware.test-selector-tests
+  "empty tests for tests testing the selector feature
+  in `cider.nrepl.middleware.test-test` namespace"
+  (:require [clojure.test :refer :all]))
+
+(deftest ^:smoke a-puff-of-smoke-test
+  (is true "puff"))
+
+(deftest some-other-test
+  (is true "other"))
+
+(deftest yet-an-other-test
+  (is true "yet an other"))

--- a/test/clj/cider/nrepl/middleware/test_test.clj
+++ b/test/clj/cider/nrepl/middleware/test_test.clj
@@ -1,6 +1,9 @@
 (ns cider.nrepl.middleware.test-test
-  (:require [clojure.test :refer :all]
-            [cider.nrepl.middleware.test :as test]))
+  (:require [cider.nrepl.middleware.test :as test]
+            [cider.nrepl.test-session :as session]
+            [clojure.test :refer :all]))
+
+(use-fixtures :each session/session-fixture)
 
 (deftest basic-sanity-test
   ;; Just make sure that the namespace loads properly and the macro
@@ -10,7 +13,31 @@
   (is (= (class @test/default-executor)
          java.util.concurrent.ThreadPoolExecutor)))
 
-(deftest has-tests-errors []
+(deftest has-tests-errors
   (is (test/has-tests? 'cider.nrepl.middleware.test-test))
   ;; clojure-emacs/cider#1940
   (is (not (test/has-tests? 'this.namespace.does.not.have.tests.or.error))))
+
+(deftest only-smoke-test-run-test
+  (testing "only test marked as smoke is run when test-all is used"
+    (let [{:keys [results] :as test-result} (session/message {:op            "test-all"
+                                                              :selector "smoke"})
+          tests (keys (:cider.nrepl.middleware.test-selector-tests results))]
+      (is ((set (keys results)) :cider.nrepl.middleware.test-selector-tests) "ns that contains smoke is present")
+      (is (= 1 (count tests)) "only one test was run")
+      (is (= :a-puff-of-smoke-test (first tests)) "only the test marked 'smoke' was run")))
+  (testing "only test marke as smoke is run when test-ns is used"
+    (let [{:keys [results] :as test-result} (session/message {:op            "test"
+                                                              :ns            "cider.nrepl.middleware.test-selector-tests"
+                                                              :selector "smoke"})
+          tests (keys (:cider.nrepl.middleware.test-selector-tests results))]
+      (is ((set (keys results)) :cider.nrepl.middleware.test-selector-tests) "ns that contains smoke is present")
+      (is (= 1 (count tests)) "only one test was run")
+      (is (= :a-puff-of-smoke-test (first tests)) "only the test marked 'smoke' was run")))
+  (testing "marked test is still run if selector is not used"
+    (let [{:keys [results] :as test-result} (session/message {:op            "test"
+                                                              :ns            "cider.nrepl.middleware.test-selector-tests"})
+          tests (keys (:cider.nrepl.middleware.test-selector-tests results))]
+      (is ((set (keys results)) :cider.nrepl.middleware.test-selector-tests) "ns that contains smoke is present")
+      (is (< 1 (count tests)) "more tests were run")
+      (is ((set tests) :a-puff-of-smoke-test) "smoke test is still present without a selector"))))


### PR DESCRIPTION
Test all and test ns understand `leiningen` style test selectors, eg
metadata markers on `deftest`s. No support for namespace level metada
markers for now.

If test selector is specified only the test(s) run that have that
selector in their metadata.

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)

