### PR TITLE
Fix test.extensions =-body: Only evaluate first argument once

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 [![Build Status](https://travis-ci.org/clojure-emacs/cider-nrepl.png?branch=master)](https://travis-ci.org/clojure-emacs/cider-nrepl)
 [![Dependencies Status](https://versions.deps.co/clojure-emacs/cider-nrepl/status.svg)](https://versions.deps.co/clojure-emacs/cider-nrepl)
 [![Coverage](https://codecov.io/gh/clojure-emacs/cider-nrepl/branch/master/graph/badge.svg)](https://codecov.io/gh/clojure-emacs/cider-nrepl/)

--- a/src/cider/nrepl/middleware/test/extensions.clj
+++ b/src/cider/nrepl/middleware/test/extensions.clj
@@ -13,14 +13,15 @@
   [msg expected more]
   (if (seq more)
     `(let [more# (list ~@more)
-           result# (apply = ~expected more#)]
+           expected# ~expected
+           result# (apply = expected# more#)]
        (->> (if result#
               {:type :pass}
               {:type :fail
-               :diffs (->> (remove #(= ~expected %) more#)
-                           (map #(vector % (data/diff ~expected %))))})
+               :diffs (->> (remove #(= expected# %) more#)
+                           (map #(vector % (data/diff expected# %))))})
             (merge {:message ~msg
-                    :expected ~expected
+                    :expected expected#
                     :actual more#})
             test/do-report)
        result#)

--- a/test/clj/cider/nrepl/middleware/test/extensions_test.clj
+++ b/test/clj/cider/nrepl/middleware/test/extensions_test.clj
@@ -1,0 +1,11 @@
+(ns cider.nrepl.middleware.test.extensions-test
+  (:require [clojure.test :refer :all]
+            [cider.nrepl.middleware.test.extensions :as extensions]))
+
+(deftest =-body-test
+  (testing "Only evalulates expected form once"
+    (let [x (eval
+             `(let [~'x (atom 0)]
+                ~(extensions/=-body "" '(swap! x inc) '(1))
+                (deref ~'x)))]
+      (is (= 1 x)))))


### PR DESCRIPTION
`(is (= ...))` tests executed in cider currently fail if the first
argument to = is not pure as it is evaluated multiple times inside
`=-body`. By caching the value, this can be prevented.

This fixes clojure-emacs/cider/issues/2233

Example:
```
;; before
cider> (let [x (atom 0)]
         (is (= (swap! x inc) 1))
         @x)
;; => 2

;; after
cider> (let [x (atom 0)]
         (is (= (swap! x inc) 1))
         @x)
;; => 1
```

----

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [ ] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)
