### PR TITLE
Require cemerick piggieback with correct namespace

### DIFF
--- a/src/cider/nrepl/middleware/util/cljs.clj
+++ b/src/cider/nrepl/middleware/util/cljs.clj
@@ -7,7 +7,7 @@
        (catch Throwable _ false)))
 
 (def cemerick-piggieback?
-  (try (require 'cider.piggieback) true
+  (try (require 'cemerick.piggieback) true
        (catch Throwable _ false)))
 
 (defn try-piggieback


### PR DESCRIPTION
copied code wasn't updated. this fixes the cemerick piggieback check