### PR TITLE
added org.clojure/tools.nrepl {:mvn/version "0.2.12"} to clj dependen…

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ You can easily boot an nREPL server with the CIDER middleware loaded
 with the following "magic" incantation:
 
 ```
-clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.17.0-SNAPSHOT"} }}' -e '(require (quote cider-nrepl.main)) (cider-nrepl.main/init ["cider.nrepl/cider-middleware"])'
+clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.17.0-SNAPSHOT"}  org.clojure/tools.nrepl {:mvn/version "0.2.12"}}}' -e '(require (quote cider-nrepl.main)) (cider-nrepl.main/init ["cider.nrepl/cider-middleware"])'
 ```
 
 Note that `clj` was introduced in Clojure 1.9.


### PR DESCRIPTION
…cies

Is needed to avoid exception on starting nRepl
``` 
Could not locate cider_nrepl/main__init.class or cider_nrepl/main.clj on classpath. Please check that namespaces with dashes use underscores in the Clojure file name.
```

Before submitting a PR make sure the following things have been done:

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [ ] All tests are passing
- [ ] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)

Keep in mind that new cider-nrepl builds are automatically deployed to Clojars
once a PR is merged, but **only** if the CI build is green.

*If you're just starting out to hack on cider-nrepl you might find
this [article](https://juxt.pro/blog/posts/nrepl.html) and the
"Design" section of the README extremely useful.*

Thanks!
