### PR TITLE
More images work.

### DIFF
--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -140,7 +140,9 @@
   {:doc "Middleware that handles slurp requests."
    :returns {"content-type" "A MIME type for the response, if one can be detected."
              "content-transfer-encoding" "The encoding (if any) for the content."
-             "body" "The slurped content body."}})
+             "body" "The slurped content body."}
+   :handles {"slurp"
+             {:doc "Slurps a URL from the nREPL server, returning MIME data."}}})
 
 (def-wrapper wrap-apropos cider.nrepl.middleware.apropos/handle-apropos
   {:doc "Middleware that handles apropos requests"

--- a/src/cider/nrepl/middleware/content_type.clj
+++ b/src/cider/nrepl/middleware/content_type.clj
@@ -88,9 +88,9 @@
     (or (and (instance? File value)
              (.exists ^File value))
         (and (instance? URI value)
-             (= (.getScheme ^URI value) "file"))
+             #_(= (.getScheme ^URI value) "file"))
         (and (instance? URL value)
-             (#{"jar" "file"} (.getProtocol ^URL value))))
+             #_(#{"jar" "file"} (.getProtocol ^URL value))))
     (assoc response
            :content-type ["message/external-body"
                           {"access-type" "URL"

--- a/src/cider/nrepl/middleware/content_type.clj
+++ b/src/cider/nrepl/middleware/content_type.clj
@@ -87,10 +87,8 @@
     ;; RFC-2017 external-body responses for UR[IL]s and things which are just wrappers thereof
     (or (and (instance? File value)
              (.exists ^File value))
-        (and (instance? URI value)
-             #_(= (.getScheme ^URI value) "file"))
-        (and (instance? URL value)
-             #_(#{"jar" "file"} (.getProtocol ^URL value))))
+        (instance? URI value)
+        (instance? URL value))
     (assoc response
            :content-type ["message/external-body"
                           {"access-type" "URL"


### PR DESCRIPTION
Follows up from #517.

- Fixes a bug where the `"slurp"` op was not correctly registered with nREPL, leading to the server rejecting otherwise valid `"slurp"` requests.
- Fixes a bug where base64 encoding would produce a byte[] result which nREPL would make a mess of, rather than a string for simple transport.
- Fixes a bug where the `"slurp"` response would include its own `"done"` status, really messing up the REPL logic which expects a separate `"done"` result.
