### PR TITLE
Accept non-namespaced tests in backwards compat

### DIFF
--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -298,7 +298,7 @@
    (merge msg {:var-query {:ns-query {:exactly [ns]}
                            :include-meta-key include
                            :exclude-meta-key exclude
-                           :exactly tests}})))
+                           :exactly (map #(str ns "/" %) tests)}})))
 
 (defn handle-test-all-op
   [{:keys [load? include exclude] :as msg}]

--- a/test/clj/cider/nrepl/middleware/test_test.clj
+++ b/test/clj/cider/nrepl/middleware/test_test.clj
@@ -15,6 +15,19 @@
   (is (= (class @test/default-executor)
          java.util.concurrent.ThreadPoolExecutor)))
 
+(deftest only-selected-tests
+  (testing "only single test is run with test"
+    (are [tests] (let [{:keys [results] :as test-result}
+                       (session/message
+                        {:op "test"
+                         :ns "cider.nrepl.middleware.test-filter-tests"
+                         :tests (map name tests)})]
+                   (is (= tests (keys (:cider.nrepl.middleware.test-filter-tests results)))))
+      [:a-puff-of-smoke-test]
+      [:a-smokey-test]
+      [:a-puff-of-smoke-test :a-smokey-test]
+      [:a-puff-of-smoke-test :a-smokey-test :yet-an-other-test])))
+
 (deftest only-smoke-test-run-test-deprecated
   (testing "only test marked as smoke is run when test-all is used"
     (let [{:keys [results] :as test-result} (session/message {:op            "test-all"


### PR DESCRIPTION
This is the original API before the API was deprecated.