### PR TITLE
Check for cemerick/piggieback and fall back to cider/piggieback

### DIFF
--- a/src/cider/nrepl/middleware/util/cljs.clj
+++ b/src/cider/nrepl/middleware/util/cljs.clj
@@ -41,9 +41,9 @@
   "Returns the path in the session map for the ClojureScript compiler
   environment used by piggieback."
   []
-  [(if cider-piggieback?
-     (resolve 'cider.piggieback/*cljs-compiler-env*)
-     (resolve 'cemerick.piggieback/*cljs-compiler-env*))])
+  [(if cemerick-piggieback?
+     (resolve 'cemerick.piggieback/*cljs-compiler-env*)
+     (resolve 'cider.piggieback/*cljs-compiler-env*))])
 
 (defn- maybe-deref
   [x]


### PR DESCRIPTION
CIDER injects cider/piggieback automatically now while some users are
still on cemerick/piggieback. The result is that this will always
return true since cider/piggieback is on the classpath.

Notably, shadow-cljs fakes a cemerick/piggieback and places the
compiler environment there for cider-nrepl. But we see the injected
cider/piggieback and so look for the cljs compiler environment there
rather than in cemerick.

see https://github.com/clojure-emacs/cider/issues/2305