### PR TITLE
Proposed fix for #537

### DIFF
--- a/src/cider/tasks.clj
+++ b/src/cider/tasks.clj
@@ -30,6 +30,6 @@
     (util/dbug* "nREPL middleware: %s\n" (vec default-mws))
     (boot.core/with-pass-thru [_]
       (require 'cider-nrepl.main)
-      ((resolve 'cider-nrepl.main/init) {:middleware default-mws
-                                         :port port
-                                         :bind bind}))))
+      ((resolve 'cider-nrepl.main/start-nrepl) {:middleware default-mws
+                                                :port port
+                                                :bind bind}))))

--- a/src/cider_nrepl/main.clj
+++ b/src/cider_nrepl/main.clj
@@ -30,7 +30,7 @@
 
 (defn start-nrepl
   [opts]
-  (let [{:keys [handler middleware bind port]} opts
+  (let [{:keys [handler middleware bind port] :or {port 0 bind "::"}} opts
 
         handler (cond-> (or handler nrepl.server/default-handler)
                   middleware (apply (->mw-list middleware)))
@@ -51,7 +51,7 @@
 (defn init
   ([]
    (init nil))
-  ([opts]
-   (start-nrepl opts)
+  ([handlers]
+   (start-nrepl {:handler handlers})
    ;; Return nil so the value doesn't print
    nil))


### PR DESCRIPTION
- revert `cider.nrepl/init` such that it takes a vector of middlewares
- have `cider.nrepl/init` pass a map of arguments to `start-nrepl`
- tweak cider nrepl boot task to pass a map to `start-nrepl` directly
- set defaults for `port` and `bind` to keep `nrepl-server` happy
