### PR TITLE
Actually fix #537

### DIFF
--- a/src/cider/tasks.clj
+++ b/src/cider/tasks.clj
@@ -30,6 +30,6 @@
     (util/dbug* "nREPL middleware: %s\n" (vec default-mws))
     (boot.core/with-pass-thru [_]
       (require 'cider-nrepl.main)
-      ((resolve 'cider-nrepl.main/init) {:middleware default-mws
-                                         :port port
-                                         :bind bind}))))
+      ((resolve 'cider-nrepl.main/start-nrepl) {:middleware default-mws
+                                                :port port
+                                                :bind bind}))))

--- a/src/cider_nrepl/main.clj
+++ b/src/cider_nrepl/main.clj
@@ -56,7 +56,7 @@
 
         {:keys [server-socket port] :as server}
         (nrepl.server/start-server :handler handler
-                                   :bind (or bind "::")
+                                   :bind (or bind "localhost")
                                    :port (or port 0))
 
         bind

--- a/src/cider_nrepl/main.clj
+++ b/src/cider_nrepl/main.clj
@@ -53,7 +53,7 @@
   [{:keys [bind port] :as opts}]
   (let [handler
         (build-handler opts)
-        
+
         {:keys [server-socket port] :as server}
         (nrepl.server/start-server :handler handler
                                    :bind (or bind "::")

--- a/src/cider_nrepl/main.clj
+++ b/src/cider_nrepl/main.clj
@@ -29,11 +29,8 @@
   (into [] mw-xf middleware-var-strs))
 
 (defn- build-handler
-  [{:keys [handler middleware]}]
-  (let [handler (or handler nrepl.server/default-handler)]
-    (if middleware
-      (apply handler (->mw-list middleware))
-      (handler))))
+  [middleware]
+  (apply nrepl.server/default-handler (->mw-list middleware)))
 
 (defn start-nrepl
   "Starts a socket-based nREPL server. Accepts a map with the following keys:
@@ -50,9 +47,11 @@
      representing middleware you wish to mix in to the nREPL handler. Vars can
      resolve to a sequence of vars, in which case they'll be flattened into the
      list of middleware."
-  [{:keys [bind port] :as opts}]
+  [{:keys [handler middleware bind port] :as opts}]
   (let [handler
-        (build-handler opts)
+        (if handler
+          (handler)
+          (build-handler middleware))
 
         {:keys [server-socket port] :as server}
         (nrepl.server/start-server :handler handler

--- a/src/cider_nrepl/main.clj
+++ b/src/cider_nrepl/main.clj
@@ -28,17 +28,36 @@
   [middleware-var-strs]
   (into [] mw-xf middleware-var-strs))
 
+(defn- build-handler
+  [{:keys [handler middleware]}]
+  (let [handler (or handler nrepl.server/default-handler)]
+    (if middleware
+      (apply handler (->mw-list middleware))
+      (handler))))
+
 (defn start-nrepl
-  [opts]
-  (let [{:keys [handler middleware bind port] :or {port 0 bind "::"}} opts
+  "Starts a socket-based nREPL server. Accepts a map with the following keys:
+ 
+   * :port — defaults to 0, which autoselects an open port
 
-        handler (cond-> (or handler nrepl.server/default-handler)
-                  middleware (apply (->mw-list middleware)))
+   * :bind — bind address, by default \"::\" (falling back to \"localhost\" if
+     \"::\" isn't resolved by the underlying network stack)
 
+   * :handler — the nREPL message handler to use for each incoming connection;
+     defaults to the result of `(nrepl.server/default-handler)`
+
+   * :middleware - a sequence of vars or string which can be resolved to vars,
+     representing middleware you wish to mix in to the nREPL handler. Vars can
+     resolve to a sequence of vars, in which case they'll be flattened into the
+     list of middleware."
+  [{:keys [bind port] :as opts}]
+  (let [handler
+        (build-handler opts)
+        
         {:keys [server-socket port] :as server}
         (nrepl.server/start-server :handler handler
-                                   :bind bind
-                                   :port port)
+                                   :bind (or bind "::")
+                                   :port (or port 0))
 
         bind
         (-> server-socket (.getInetAddress) (.getHostName))]
@@ -50,8 +69,8 @@
 
 (defn init
   ([]
-   (init nil))
-  ([handlers]
-   (start-nrepl {:handler handlers})
+   (start-nrepl {}))
+  ([middleware]
+   (start-nrepl {:middleware middleware})
    ;; Return nil so the value doesn't print
    nil))

--- a/src/cider_nrepl/main.clj
+++ b/src/cider_nrepl/main.clj
@@ -30,7 +30,7 @@
 
 (defn start-nrepl
   [opts]
-  (let [{:keys [handler middleware bind port]} opts
+  (let [{:keys [handler middleware bind port] :or {port 0 bind "::"}} opts
 
         handler (cond-> (or handler nrepl.server/default-handler)
                   middleware (apply (->mw-list middleware)))
@@ -51,7 +51,7 @@
 (defn init
   ([]
    (init nil))
-  ([opts]
-   (start-nrepl opts)
+  ([handlers]
+   (start-nrepl {:handler handlers})
    ;; Return nil so the value doesn't print
    nil))

--- a/test/clj/cider/nrepl/main_test.clj
+++ b/test/clj/cider/nrepl/main_test.clj
@@ -1,0 +1,45 @@
+(ns cider.nrepl.main-test 
+  (:require [cider.nrepl :refer [wrap-debug cider-middleware]]
+            [cider-nrepl.main :as m]
+            [clojure.test :refer :all]
+            [clojure.tools.nrepl :as nrepl]
+            [clojure.tools.nrepl.server :as nrepl.server]
+            [clojure.tools.nrepl.transport :as transport]))
+
+(defn start-stop-nrepl-session
+  [opts]
+  (with-open [server    (#'m/start-nrepl opts)
+              transport (nrepl/connect :port (:port server))]
+    (transport/send transport {:op "clone" :id 1})
+    (let [session-id (:new-session (transport/recv transport 1000))]
+      (assert session-id)
+      (transport/send transport {:session session-id
+                                 :id      2
+                                 :op      "clone"})
+      (is (= (:status (transport/recv transport 1000)) ["done"])))))
+
+(deftest start-nrepl-test
+  (testing "passing a specific handler should work"
+    (let [opts {:handler nrepl.server/default-handler}]
+      (start-stop-nrepl-session opts)))
+  
+  (testing "passing a sequence instead of a map shouldn't crash"
+    (let [opts ["cider.nrepl/cider-middleware"]]
+      (start-stop-nrepl-session opts)))
+
+  (testing "passing nil shouldn't crash"
+    (let [opts nil]
+      (start-stop-nrepl-session opts)))
+
+  (testing "passing valid middleware should work"
+    (let [opts {:middleware ["cider.nrepl/cider-middleware"]}]
+      (start-stop-nrepl-session opts)))
+
+  (testing "passing options as given by boot task middleware should work"
+    (let [opts {:middleware '(cider.nrepl.middleware.version/wrap-version
+                              cider.nrepl.middleware.apropos/wrap-apropos)
+                :port nil
+                :bind nil}]
+      (start-stop-nrepl-session opts))))
+
+

--- a/test/clj/cider/nrepl/main_test.clj
+++ b/test/clj/cider/nrepl/main_test.clj
@@ -1,4 +1,4 @@
-(ns cider.nrepl.main-test 
+(ns cider.nrepl.main-test
   (:require [cider.nrepl :refer [wrap-debug cider-middleware]]
             [cider-nrepl.main :as m]
             [clojure.test :refer :all]
@@ -6,8 +6,7 @@
             [clojure.tools.nrepl.server :as nrepl.server]
             [clojure.tools.nrepl.transport :as transport]))
 
-(defn start-stop-nrepl-session
-  [opts]
+(defn start-stop-nrepl-session [opts]
   (with-open [server    (#'m/start-nrepl opts)
               transport (nrepl/connect :port (:port server))]
     (transport/send transport {:op "clone" :id 1})
@@ -22,7 +21,7 @@
   (testing "passing a specific handler should work"
     (let [opts {:handler nrepl.server/default-handler}]
       (start-stop-nrepl-session opts)))
-  
+
   (testing "passing a sequence instead of a map shouldn't crash"
     (let [opts ["cider.nrepl/cider-middleware"]]
       (start-stop-nrepl-session opts)))
@@ -41,5 +40,4 @@
                 :port nil
                 :bind nil}]
       (start-stop-nrepl-session opts))))
-
 


### PR DESCRIPTION
My fix yesterday was not properly tested - I started nREPL from the command line, but I didn't attempt to exercise it with messages. As a result, I missed the fact I was setting passing the middleware as the handler, which kept things just as broken.

This PR contains a fix for that problem, plus a new test ns `cider.nrepl.main-test` that exercises the `start-nrepl` function by passing it a variety of valid and invalid option maps. The tests go as far as checking that two `:op "clone"` messages can be exchanged before declaring success.

On my local machine I saw a test failure in a totally unrelated part of the code, `test-sum-types-is-base64`, which I'm assuming is an artifact of my local environment and not something that will come up in the PR tests.