### PR TITLE
Migrate to nREPL 0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ You can easily boot an nREPL server with the CIDER middleware loaded
 with the following "magic" incantation:
 
 ```
-clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.18.0-SNAPSHOT"} }}' -e '(require (quote cider-nrepl.main)) (cider-nrepl.main/init ["cider.nrepl/cider-middleware"])'
+clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.19.0-SNAPSHOT"} }}' -e '(require (quote cider-nrepl.main)) (cider-nrepl.main/init ["cider.nrepl/cider-middleware"])'
 ```
 
 Note that `clj` was introduced in Clojure 1.9.
@@ -194,7 +194,7 @@ server with CIDER's own nREPL handler.
 
 ```clojure
 (ns my-app
-  (:require [clojure.tools.nrepl.server :as nrepl-server]))
+  (:require [nrepl.server :as nrepl-server]))
 
 (defn nrepl-handler []
   (require 'cider.nrepl)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def VERSION "0.19.0-SNAPSHOT")
+(def VERSION "0.18.0-SNAPSHOT")
 
 (defproject cider/cider-nrepl VERSION
   :description "nREPL middlewares for CIDER"
@@ -6,7 +6,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-  :dependencies [[nrepl "0.4.2"]
+  :dependencies [[nrepl "0.4.4"]
                  ^:source-dep [cider/orchard "0.3.0"]
                  ^:source-dep [thunknyc/profile "0.5.2"]
                  ^:source-dep [mvxcvi/puget "1.0.2"]

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-  :dependencies [[nrepl "0.4.1"]
+  :dependencies [[nrepl "0.4.2"]
                  ^:source-dep [cider/orchard "0.3.0"]
                  ^:source-dep [thunknyc/profile "0.5.2"]
                  ^:source-dep [mvxcvi/puget "1.0.2"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def VERSION "0.18.0-SNAPSHOT")
+(def VERSION "0.19.0-SNAPSHOT")
 
 (defproject cider/cider-nrepl VERSION
   :description "nREPL middlewares for CIDER"
@@ -6,7 +6,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-  :dependencies [[org.clojure/tools.nrepl "0.2.13"]
+  :dependencies [[nrepl "0.4.1"]
                  ^:source-dep [cider/orchard "0.3.0"]
                  ^:source-dep [thunknyc/profile "0.5.2"]
                  ^:source-dep [mvxcvi/puget "1.0.2"]

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -1,8 +1,8 @@
 (ns cider.nrepl
-  (:require [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
-            [clojure.tools.nrepl.middleware.session :refer [session]]
-            [clojure.tools.nrepl.middleware.pr-values :refer [pr-values]]
-            [clojure.tools.nrepl.server :as nrepl-server]
+  (:require [nrepl.middleware :refer [set-descriptor!]]
+            [nrepl.middleware.session :refer [session]]
+            [nrepl.middleware.pr-values :refer [pr-values]]
+            [nrepl.server :as nrepl-server]
             [cider.nrepl.version :as version]
             [cider.nrepl.middleware.util.cljs :as cljs]
             [cider.nrepl.middleware.pprint :as pprint]

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -1,12 +1,23 @@
 (ns cider.nrepl
-  (:require [nrepl.middleware :refer [set-descriptor!]]
-            [nrepl.middleware.session :refer [session]]
-            [nrepl.middleware.pr-values :refer [pr-values]]
-            [nrepl.server :as nrepl-server]
-            [cider.nrepl.version :as version]
+  (:require [cider.nrepl.version :as version]
             [cider.nrepl.middleware.util.cljs :as cljs]
             [cider.nrepl.middleware.pprint :as pprint]
             [cider.nrepl.print-method]))
+
+;; Compatibility with the legacy tools.nrepl and the new nREPL 0.4.x.
+;; The assumption is that if someone is using old lein repl or boot repl
+;; they'll end up using the tools.nrepl, otherwise the modern one.
+(if (find-ns 'clojure.tools.nrepl)
+  (require
+   '[clojure.tools.nrepl.middleware :refer [set-descriptor!]]
+   '[clojure.tools.nrepl.middleware.session :refer [session]]
+   '[clojure.tools.nrepl.middleware.pr-values :refer [pr-values]]
+   '[clojure.tools.nrepl.server :as nrepl-server])
+  (require
+   '[nrepl.middleware :refer [set-descriptor!]]
+   '[nrepl.middleware.session :refer [session]]
+   '[nrepl.middleware.pr-values :refer [pr-values]]
+   '[nrepl.server :as nrepl-server]))
 
 (def delayed-handlers
   "Map of `delay`s holding deferred middleware handlers."

--- a/src/cider/nrepl/middleware/content_type.clj
+++ b/src/cider/nrepl/middleware/content_type.clj
@@ -43,7 +43,7 @@
   [4] https://tools.ietf.org/html/rfc2017"
   {:authors ["Reid 'arrdem' McKenzie <me@arrdem.com>"]}
   (:require [cider.nrepl.middleware.slurp :refer [slurp-reply]])
-  (:import clojure.tools.nrepl.transport.Transport
+  (:import nrepl.transport.Transport
            java.awt.Image
            [java.io ByteArrayOutputStream File OutputStream]
            [java.net URI URL]
@@ -80,7 +80,7 @@
   [{:keys [session value] :as response}]
   (cond
     ;; FIXME (arrdem 2018-04-03):
-    ;; 
+    ;;
     ;;   This could be more generic in terms of tolerating more
     ;;   protocols / schemes
 
@@ -96,7 +96,7 @@
            :body "")
 
     ;; FIXME (arrdem 2018-04-03):
-    ;; 
+    ;;
     ;;   This is super snowflakey in terms of only supporting base64
     ;;   coding this one kind of object.  This could definitely be
     ;;   more generic / open to extension but hey at least it's

--- a/src/cider/nrepl/middleware/content_type.clj
+++ b/src/cider/nrepl/middleware/content_type.clj
@@ -43,12 +43,18 @@
   [4] https://tools.ietf.org/html/rfc2017"
   {:authors ["Reid 'arrdem' McKenzie <me@arrdem.com>"]}
   (:require [cider.nrepl.middleware.slurp :refer [slurp-reply]])
-  (:import nrepl.transport.Transport
-           java.awt.Image
+  (:import java.awt.Image
            [java.io ByteArrayOutputStream File OutputStream]
            [java.net URI URL]
            java.nio.file.Path
            javax.imageio.ImageIO))
+
+;; Compatibility with the legacy tools.nrepl and the new nREPL 0.4.x.
+;; The assumption is that if someone is using old lein repl or boot repl
+;; they'll end up using the tools.nrepl, otherwise the modern one.
+(if (find-ns 'clojure.tools.nrepl)
+  (import 'clojure.tools.nrepl.transport.Transport)
+  (import 'nrepl.transport.Transport))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -10,12 +10,23 @@
             [cider.nrepl.middleware.util.instrument :as ins]
             [orchard.misc :as misc]
             [orchard.meta :as m]
-            [clojure.java.io :as io]
-            [nrepl.middleware.interruptible-eval :refer [*msg*]]
-            [nrepl.misc :refer [response-for]]
-            [nrepl.middleware.session :as session]
-            [nrepl.transport :as transport])
+            [clojure.java.io :as io])
   (:import [clojure.lang Compiler$LocalBinding]))
+
+;; Compatibility with the legacy tools.nrepl and the new nREPL 0.4.x.
+;; The assumption is that if someone is using old lein repl or boot repl
+;; they'll end up using the tools.nrepl, otherwise the modern one.
+(if (find-ns 'clojure.tools.nrepl)
+  (require
+   '[clojure.tools.nrepl.middleware.interruptible-eval :refer [*msg*]]
+   '[clojure.tools.nrepl.middleware.session :as session]
+   '[clojure.tools.nrepl.misc :refer (response-for)]
+   '[clojure.tools.nrepl.transport :as transport])
+  (require
+   '[nrepl.middleware.interruptible-eval :refer [*msg*]]
+   '[nrepl.middleware.session :as session]
+   '[nrepl.misc :refer (response-for)]
+   '[nrepl.transport :as transport]))
 
 ;;;; # The Debugger
 ;;;

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -11,10 +11,10 @@
             [orchard.misc :as misc]
             [orchard.meta :as m]
             [clojure.java.io :as io]
-            [clojure.tools.nrepl.middleware.interruptible-eval :refer [*msg*]]
-            [clojure.tools.nrepl.misc :refer [response-for]]
-            [clojure.tools.nrepl.middleware.session :as session]
-            [clojure.tools.nrepl.transport :as transport])
+            [nrepl.middleware.interruptible-eval :refer [*msg*]]
+            [nrepl.misc :refer [response-for]]
+            [nrepl.middleware.session :as session]
+            [nrepl.transport :as transport])
   (:import [clojure.lang Compiler$LocalBinding]))
 
 ;;;; # The Debugger

--- a/src/cider/nrepl/middleware/inspect.clj
+++ b/src/cider/nrepl/middleware/inspect.clj
@@ -7,6 +7,21 @@
             [nrepl.transport :as transport])
   (:import nrepl.transport.Transport))
 
+;; Compatibility with the legacy tools.nrepl and the new nREPL 0.4.x.
+;; The assumption is that if someone is using old lein repl or boot repl
+;; they'll end up using the tools.nrepl, otherwise the modern one.
+(if (find-ns 'clojure.tools.nrepl)
+  (do
+    (require
+     '[clojure.tools.nrepl.misc :refer [response-for]]
+     '[clojure.tools.nrepl.transport :as transport])
+    (import 'clojure.tools.nrepl.transport.Transport))
+  (do
+    (require
+     '[nrepl.misc :refer [response-for]]
+     '[nrepl.transport :as transport])
+    (import 'nrepl.transport.Transport)))
+
 (def ^:dynamic *inspector* (inspect/fresh))
 
 (defn swap-inspector!

--- a/src/cider/nrepl/middleware/inspect.clj
+++ b/src/cider/nrepl/middleware/inspect.clj
@@ -3,9 +3,9 @@
             [cider.nrepl.middleware.util.error-handling :refer [base-error-response]]
             [orchard.inspect :as inspect]
             [orchard.misc :as u]
-            [clojure.tools.nrepl.misc :refer [response-for]]
-            [clojure.tools.nrepl.transport :as transport])
-  (:import clojure.tools.nrepl.transport.Transport))
+            [nrepl.misc :refer [response-for]]
+            [nrepl.transport :as transport])
+  (:import nrepl.transport.Transport))
 
 (def ^:dynamic *inspector* (inspect/fresh))
 

--- a/src/cider/nrepl/middleware/out.clj
+++ b/src/cider/nrepl/middleware/out.clj
@@ -9,9 +9,14 @@
   We use an eval message, instead of the clone op, because there's no
   guarantee that the channel that sent the clone message will properly
   handle output replies."
-  (:require [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
-            [nrepl.middleware.interruptible-eval :as ie])
+  (:require [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]])
   (:import [java.io PrintWriter Writer PrintStream OutputStream]))
+
+(if (find-ns 'clojure.tools.nrepl)
+  (require
+   '[clojure.tools.nrepl.middleware.interruptible-eval :as ieval])
+  (require
+   '[nrepl.middleware.interruptible-eval :as ieval]))
 
 (declare unsubscribe-session)
 
@@ -29,7 +34,7 @@
                                              (case ~type
                                                :out #'*out*
                                                :err #'*err*))]
-       (try (binding [ie/*msg* ~'msg]
+       (try (binding [ieval/*msg* ~'msg]
               ~@body)
             ;; If a channel is faulty, dissoc it.
             (catch Exception ~'e

--- a/src/cider/nrepl/middleware/out.clj
+++ b/src/cider/nrepl/middleware/out.clj
@@ -10,7 +10,7 @@
   guarantee that the channel that sent the clone message will properly
   handle output replies."
   (:require [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
-            [clojure.tools.nrepl.middleware.interruptible-eval :as ie])
+            [nrepl.middleware.interruptible-eval :as ie])
   (:import [java.io PrintWriter Writer PrintStream OutputStream]))
 
 (declare unsubscribe-session)

--- a/src/cider/nrepl/middleware/pprint.clj
+++ b/src/cider/nrepl/middleware/pprint.clj
@@ -2,12 +2,12 @@
   (:require [cider.nrepl.middleware.util.cljs :as cljs]
             [orchard.misc :as u]
             [clojure.pprint :refer [pprint *print-right-margin*]]
-            [clojure.tools.nrepl.middleware.interruptible-eval :refer [*msg*]]
-            [clojure.tools.nrepl.middleware.pr-values :refer [pr-values]]
-            [clojure.tools.nrepl.middleware.session :as session]
-            [clojure.tools.nrepl.misc :refer [response-for]]
-            [clojure.tools.nrepl.transport :as transport])
-  (:import clojure.tools.nrepl.transport.Transport))
+            [nrepl.middleware.interruptible-eval :refer [*msg*]]
+            [nrepl.middleware.pr-values :refer [pr-values]]
+            [nrepl.middleware.session :as session]
+            [nrepl.misc :refer [response-for]]
+            [nrepl.transport :as transport])
+  (:import nrepl.transport.Transport))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/cider/nrepl/middleware/pprint.clj
+++ b/src/cider/nrepl/middleware/pprint.clj
@@ -1,13 +1,25 @@
 (ns cider.nrepl.middleware.pprint
   (:require [cider.nrepl.middleware.util.cljs :as cljs]
             [orchard.misc :as u]
-            [clojure.pprint :refer [pprint *print-right-margin*]]
-            [nrepl.middleware.interruptible-eval :refer [*msg*]]
-            [nrepl.middleware.pr-values :refer [pr-values]]
-            [nrepl.middleware.session :as session]
-            [nrepl.misc :refer [response-for]]
-            [nrepl.transport :as transport])
-  (:import nrepl.transport.Transport))
+            [clojure.pprint :refer [pprint *print-right-margin*]]))
+
+(if (find-ns 'clojure.tools.nrepl)
+  (do
+    (require
+     '[clojure.tools.nrepl.middleware.interruptible-eval :refer [*msg*]]
+     '[clojure.tools.nrepl.middleware.pr-values :refer [pr-values]]
+     '[clojure.tools.nrepl.middleware.session :as session]
+     '[clojure.tools.nrepl.misc :refer [response-for]]
+     '[clojure.tools.nrepl.transport :as transport])
+    (import 'clojure.tools.nrepl.transport.Transport))
+  (do
+    (require
+     '[nrepl.middleware.interruptible-eval :refer [*msg*]]
+     '[nrepl.middleware.pr-values :refer [pr-values]]
+     '[nrepl.middleware.session :as session]
+     '[nrepl.misc :refer [response-for]]
+     '[nrepl.transport :as transport])
+    (import 'nrepl.transport.Transport)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/cider/nrepl/middleware/profile.clj
+++ b/src/cider/nrepl/middleware/profile.clj
@@ -14,10 +14,15 @@
   Based on older middleware (nrepl-profile) that's not actively
   maintained anymore."
   {:author "Edwin Watkeys"}
-  (:require [clojure.string :as s]
-            [profile.core :as p]
-            [nrepl.transport :as t]
-            [nrepl.misc :refer [response-for]]))
+  (:require [profile.core :as p]))
+
+(if (find-ns 'clojure.tools.nrepl)
+  (require
+   '[clojure.tools.nrepl.misc :refer [response-for]]
+   '[clojure.tools.nrepl.transport :as t])
+  (require
+   '[nrepl.misc :refer [response-for]]
+   '[nrepl.transport :as t]))
 
 (defn send-exception
   [e msg transport]

--- a/src/cider/nrepl/middleware/profile.clj
+++ b/src/cider/nrepl/middleware/profile.clj
@@ -16,8 +16,8 @@
   {:author "Edwin Watkeys"}
   (:require [clojure.string :as s]
             [profile.core :as p]
-            [clojure.tools.nrepl.transport :as t]
-            [clojure.tools.nrepl.misc :refer [response-for]]))
+            [nrepl.transport :as t]
+            [nrepl.misc :refer [response-for]]))
 
 (defn send-exception
   [e msg transport]

--- a/src/cider/nrepl/middleware/refresh.clj
+++ b/src/cider/nrepl/middleware/refresh.clj
@@ -11,10 +11,17 @@
             [clojure.tools.namespace.dir :as dir]
             [clojure.tools.namespace.find :as find]
             [clojure.tools.namespace.reload :as reload]
-            [clojure.tools.namespace.track :as track]
-            [nrepl.middleware.interruptible-eval :refer [*msg*]]
-            [nrepl.misc :refer [response-for]]
-            [nrepl.transport :as transport]))
+            [clojure.tools.namespace.track :as track]))
+
+(if (find-ns 'clojure.tools.nrepl)
+  (require
+   '[clojure.tools.nrepl.middleware.interruptible-eval :refer [*msg*]]
+   '[clojure.tools.nrepl.misc :refer (response-for)]
+   '[clojure.tools.nrepl.transport :as transport])
+  (require
+   '[nrepl.middleware.interruptible-eval :refer [*msg*]]
+   '[nrepl.misc :refer (response-for)]
+   '[nrepl.transport :as transport]))
 
 (defonce ^:private refresh-tracker (agent (track/tracker)))
 

--- a/src/cider/nrepl/middleware/refresh.clj
+++ b/src/cider/nrepl/middleware/refresh.clj
@@ -12,9 +12,9 @@
             [clojure.tools.namespace.find :as find]
             [clojure.tools.namespace.reload :as reload]
             [clojure.tools.namespace.track :as track]
-            [clojure.tools.nrepl.middleware.interruptible-eval :refer [*msg*]]
-            [clojure.tools.nrepl.misc :refer [response-for]]
-            [clojure.tools.nrepl.transport :as transport]))
+            [nrepl.middleware.interruptible-eval :refer [*msg*]]
+            [nrepl.misc :refer [response-for]]
+            [nrepl.transport :as transport]))
 
 (defonce ^:private refresh-tracker (agent (track/tracker)))
 

--- a/src/cider/nrepl/middleware/slurp.clj
+++ b/src/cider/nrepl/middleware/slurp.clj
@@ -6,12 +6,18 @@
   {:authors ["Reid 'arrdem' McKenzie <me@arrdem.com>"]}
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]
-            [clojure.string :as str]
-            [nrepl.transport :as transport]
-            [nrepl.misc :refer [response-for]])
+            [clojure.string :as str])
   (:import [java.net MalformedURLException URL]
            java.io.ByteArrayOutputStream
            [java.nio.file Files Path Paths]))
+
+(if (find-ns 'clojure.tools.nrepl)
+  (require
+   '[clojure.tools.nrepl.misc :refer (response-for)]
+   '[clojure.tools.nrepl.transport :as transport])
+  (require
+   '[nrepl.misc :refer (response-for)]
+   '[nrepl.transport :as transport]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/cider/nrepl/middleware/slurp.clj
+++ b/src/cider/nrepl/middleware/slurp.clj
@@ -1,14 +1,14 @@
 (ns cider.nrepl.middleware.slurp
   "Rich reading & handling for CIDER.
-  
+
   Goes with middleware.content-types, providing the capability to
   convert URLs to values which can be handled nicely."
   {:authors ["Reid 'arrdem' McKenzie <me@arrdem.com>"]}
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.string :as str]
-            [clojure.tools.nrepl.transport :as transport]
-            [clojure.tools.nrepl.misc :refer [response-for]])
+            [nrepl.transport :as transport]
+            [nrepl.misc :refer [response-for]])
   (:import [java.net MalformedURLException URL]
            java.io.ByteArrayOutputStream
            [java.nio.file Files Path Paths]))

--- a/src/cider/nrepl/middleware/stacktrace.clj
+++ b/src/cider/nrepl/middleware/stacktrace.clj
@@ -7,9 +7,9 @@
             [orchard.namespace :as namespace]
             [clojure.repl :as repl]
             [clojure.string :as str]
-            [clojure.tools.nrepl.middleware.session :refer [session]]
-            [clojure.tools.nrepl.misc :refer [response-for]]
-            [clojure.tools.nrepl.transport :as t]
+            [nrepl.middleware.session :refer [session]]
+            [nrepl.misc :refer [response-for]]
+            [nrepl.transport :as t]
             [orchard.misc :as u]
             [orchard.java :as java]
             [clojure.java.io :as io]
@@ -110,7 +110,7 @@
 
 (defn flag-tooling
   "Walk the call stack from top to bottom, flagging frames below the first call
-  to `clojure.lang.Compiler` or `clojure.tools.nrepl.*` as `:tooling` to
+  to `clojure.lang.Compiler` or `nrepl.*` as `:tooling` to
   distinguish compilation and nREPL middleware frames from user code."
   [frames]
   (let [tool-regex #"^clojure\.lang\.Compiler|^clojure\.tools\.nrepl|^cider\."

--- a/src/cider/nrepl/middleware/stacktrace.clj
+++ b/src/cider/nrepl/middleware/stacktrace.clj
@@ -7,15 +7,22 @@
             [orchard.namespace :as namespace]
             [clojure.repl :as repl]
             [clojure.string :as str]
-            [nrepl.middleware.session :refer [session]]
-            [nrepl.misc :refer [response-for]]
-            [nrepl.transport :as t]
             [orchard.misc :as u]
             [orchard.java :as java]
             [clojure.java.io :as io]
             [clojure.set :as set]
             [clojure.tools.namespace.find :as nsfind])
   (:import (clojure.lang Compiler$CompilerException)))
+
+(if (find-ns 'clojure.tools.nrepl)
+  (require
+   '[clojure.tools.nrepl.middleware.session :refer (session)]
+   '[clojure.tools.nrepl.misc :refer (response-for)]
+   '[clojure.tools.nrepl.transport :as t])
+  (require
+   '[nrepl.middleware.session :refer (session)]
+   '[nrepl.misc :refer (response-for)]
+   '[nrepl.transport :as t]))
 
 ;;; ## Stacktraces
 
@@ -110,10 +117,10 @@
 
 (defn flag-tooling
   "Walk the call stack from top to bottom, flagging frames below the first call
-  to `clojure.lang.Compiler` or `nrepl.*` as `:tooling` to
+  to `clojure.lang.Compiler` or `(clojure.tools.)nrepl.*` as `:tooling` to
   distinguish compilation and nREPL middleware frames from user code."
   [frames]
-  (let [tool-regex #"^clojure\.lang\.Compiler|^nrepl\.|^cider\."
+  (let [tool-regex #"^clojure\.lang\.Compiler|^clojure\.tools\.nrepl\.|^nrepl\.|^cider\."
         tool? #(re-find tool-regex (or (:name %) ""))
         flag  #(if (tool? %)
                  (flag-frame % :tooling)

--- a/src/cider/nrepl/middleware/stacktrace.clj
+++ b/src/cider/nrepl/middleware/stacktrace.clj
@@ -113,7 +113,7 @@
   to `clojure.lang.Compiler` or `nrepl.*` as `:tooling` to
   distinguish compilation and nREPL middleware frames from user code."
   [frames]
-  (let [tool-regex #"^clojure\.lang\.Compiler|^clojure\.tools\.nrepl|^cider\."
+  (let [tool-regex #"^clojure\.lang\.Compiler|^nrepl\.|^cider\."
         tool? #(re-find tool-regex (or (:name %) ""))
         flag  #(if (tool? %)
                  (flag-frame % :tooling)

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -9,11 +9,19 @@
             [orchard.namespace :as ns]
             [orchard.query :as query]
             [clojure.pprint :as pp]
-            [clojure.test :as test]
-            [nrepl.middleware.interruptible-eval :as ie]
-            [nrepl.middleware.pr-values :refer [pr-values]]
-            [nrepl.misc :refer [response-for]]
-            [nrepl.transport :as t]))
+            [clojure.test :as test]))
+
+(if (find-ns 'clojure.tools.nrepl)
+  (require
+   '[clojure.tools.nrepl.middleware.interruptible-eval :as ie]
+   '[clojure.tools.nrepl.middleware.pr-values :refer [pr-values]]
+   '[clojure.tools.nrepl.misc :refer (response-for)]
+   '[clojure.tools.nrepl.transport :as t])
+  (require
+   '[nrepl.middleware.interruptible-eval :as ie]
+   '[nrepl.middleware.pr-values :refer [pr-values]]
+   '[nrepl.misc :refer (response-for)]
+   '[nrepl.transport :as t]))
 
 ;;; ## Overview
 ;;

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -10,10 +10,10 @@
             [orchard.query :as query]
             [clojure.pprint :as pp]
             [clojure.test :as test]
-            [clojure.tools.nrepl.middleware.interruptible-eval :as ie]
-            [clojure.tools.nrepl.middleware.pr-values :refer [pr-values]]
-            [clojure.tools.nrepl.misc :refer [response-for]]
-            [clojure.tools.nrepl.transport :as t]))
+            [nrepl.middleware.interruptible-eval :as ie]
+            [nrepl.middleware.pr-values :refer [pr-values]]
+            [nrepl.misc :refer [response-for]]
+            [nrepl.transport :as t]))
 
 ;;; ## Overview
 ;;

--- a/src/cider/nrepl/middleware/track_state.clj
+++ b/src/cider/nrepl/middleware/track_state.clj
@@ -8,12 +8,21 @@
             [orchard.meta :as m]
             [orchard.namespace :as namespace]
             [cljs-tooling.util.analysis :as cljs-ana]
-            [clojure.tools.namespace.find :as ns-find]
-            [nrepl.misc :refer [response-for]]
-            [nrepl.transport :as transport])
+            [clojure.tools.namespace.find :as ns-find])
   (:import (clojure.lang Namespace MultiFn)
-           nrepl.transport.Transport
            java.net.SocketException))
+
+(if (find-ns 'clojure.tools.nrepl)
+  (do
+    (require
+     '[clojure.tools.nrepl.misc :refer [response-for]]
+     '[clojure.tools.nrepl.transport :as transport])
+    (import 'clojure.tools.nrepl.transport.Transport))
+  (do
+    (require
+     '[nrepl.misc :refer [response-for]]
+     '[nrepl.transport :as transport])
+    (import 'nrepl.transport.Transport)))
 
 (def clojure-core (try (find-ns 'clojure.core)
                        (catch Exception e nil)))

--- a/src/cider/nrepl/middleware/track_state.clj
+++ b/src/cider/nrepl/middleware/track_state.clj
@@ -9,10 +9,10 @@
             [orchard.namespace :as namespace]
             [cljs-tooling.util.analysis :as cljs-ana]
             [clojure.tools.namespace.find :as ns-find]
-            [clojure.tools.nrepl.misc :refer [response-for]]
-            [clojure.tools.nrepl.transport :as transport])
+            [nrepl.misc :refer [response-for]]
+            [nrepl.transport :as transport])
   (:import (clojure.lang Namespace MultiFn)
-           clojure.tools.nrepl.transport.Transport
+           nrepl.transport.Transport
            java.net.SocketException))
 
 (def clojure-core (try (find-ns 'clojure.core)

--- a/src/cider/nrepl/middleware/util/error_handling.clj
+++ b/src/cider/nrepl/middleware/util/error_handling.clj
@@ -3,8 +3,8 @@
   errors/exceptions that might arise from doing so."
   (:refer-clojure :exclude [error-handler])
   (:require [clojure.set :as set]
-            [clojure.tools.nrepl.transport :as transport]
-            [clojure.tools.nrepl.misc :refer [response-for]]
+            [nrepl.transport :as transport]
+            [nrepl.misc :refer [response-for]]
             [clojure.walk :as walk])
   (:import java.io.InputStream
            clojure.lang.RT))
@@ -85,7 +85,7 @@
 
 (defn- shallow-bencodable?
   "Returns false if `item`'s type can't be bencoded as defined by the
-  algorithm in `clojure.tools.nrepl.bencode/write-bencode`. Does not
+  algorithm in `nrepl.bencode/write-bencode`. Does not
   examine the elements of a collection to ensure that the enclosed
   elements are also bencodable, and so you probably actually want to
   use `deep-bencodable-or-fail` or write something similar."
@@ -104,7 +104,7 @@
 (defn- deep-bencodable-or-fail
   "Walks through the data structure provided by `item` and returns
   true if it -- and all nested elements -- are bencodable as defined
-  by the algorithm in `clojure.tools.nrepl.bencode/write-bencode`. If
+  by the algorithm in `nrepl.bencode/write-bencode`. If
   any part of `input` is not bencodable, will throw an
   `IllegalArgumentException`. See `cider-nrepl` bug #332 at
   https://github.com/clojure-emacs/cider-nrepl/issues/332 for further

--- a/src/cider/nrepl/middleware/util/error_handling.clj
+++ b/src/cider/nrepl/middleware/util/error_handling.clj
@@ -3,11 +3,17 @@
   errors/exceptions that might arise from doing so."
   (:refer-clojure :exclude [error-handler])
   (:require [clojure.set :as set]
-            [nrepl.transport :as transport]
-            [nrepl.misc :refer [response-for]]
             [clojure.walk :as walk])
   (:import java.io.InputStream
            clojure.lang.RT))
+
+(if (find-ns 'clojure.tools.nrepl)
+  (require
+   '[clojure.tools.nrepl.misc :refer [response-for]]
+   '[clojure.tools.nrepl.transport :as transport])
+  (require
+   '[nrepl.misc :refer [response-for]]
+   '[nrepl.transport :as transport]))
 
 (def ^:private print-cause-trace
   (delay

--- a/src/cider/nrepl/middleware/util/nrepl.clj
+++ b/src/cider/nrepl/middleware/util/nrepl.clj
@@ -1,9 +1,15 @@
 (ns cider.nrepl.middleware.util.nrepl
-  "Common utilities for interaction with the client."
-  (:require
-   [nrepl.middleware.interruptible-eval :refer [*msg*]]
-   [nrepl.misc :refer [response-for]]
-   [nrepl.transport :as transport]))
+  "Common utilities for interaction with the client.")
+
+(if (find-ns 'clojure.tools.nrepl)
+  (require
+   '[clojure.tools.nrepl.middleware.interruptible-eval :refer [*msg*]]
+   '[clojure.tools.nrepl.misc :refer (response-for)]
+   '[clojure.tools.nrepl.transport :as transport])
+  (require
+   '[nrepl.middleware.interruptible-eval :refer [*msg*]]
+   '[nrepl.misc :refer (response-for)]
+   '[nrepl.transport :as transport]))
 
 (defn notify-client
   "Send user level notification to client as a response to request `msg`.

--- a/src/cider/nrepl/middleware/util/nrepl.clj
+++ b/src/cider/nrepl/middleware/util/nrepl.clj
@@ -1,9 +1,9 @@
 (ns cider.nrepl.middleware.util.nrepl
   "Common utilities for interaction with the client."
   (:require
-   [clojure.tools.nrepl.middleware.interruptible-eval :refer [*msg*]]
-   [clojure.tools.nrepl.misc :refer [response-for]]
-   [clojure.tools.nrepl.transport :as transport]))
+   [nrepl.middleware.interruptible-eval :refer [*msg*]]
+   [nrepl.misc :refer [response-for]]
+   [nrepl.transport :as transport]))
 
 (defn notify-client
   "Send user level notification to client as a response to request `msg`.

--- a/src/cider/nrepl/middleware/version.clj
+++ b/src/cider/nrepl/middleware/version.clj
@@ -1,8 +1,14 @@
 (ns cider.nrepl.middleware.version
   "Return version info of the CIDER-nREPL middleware itself."
-  (:require [cider.nrepl.version :as version]
-            [nrepl.misc :refer [response-for]]
-            [nrepl.transport :as transport]))
+  (:require [cider.nrepl.version :as version]))
+
+(if (find-ns 'clojure.tools.nrepl)
+  (require
+   '[clojure.tools.nrepl.misc :refer (response-for)]
+   '[clojure.tools.nrepl.transport :as transport])
+  (require
+   '[nrepl.misc :refer (response-for)]
+   '[nrepl.transport :as transport]))
 
 (defn handle-version [handler msg]
   (if (= (:op msg) "cider-version")

--- a/src/cider/nrepl/middleware/version.clj
+++ b/src/cider/nrepl/middleware/version.clj
@@ -1,8 +1,8 @@
 (ns cider.nrepl.middleware.version
   "Return version info of the CIDER-nREPL middleware itself."
   (:require [cider.nrepl.version :as version]
-            [clojure.tools.nrepl.misc :refer [response-for]]
-            [clojure.tools.nrepl.transport :as transport]))
+            [nrepl.misc :refer [response-for]]
+            [nrepl.transport :as transport]))
 
 (defn handle-version [handler msg]
   (if (= (:op msg) "cider-version")

--- a/src/cider/nrepl/version.clj
+++ b/src/cider/nrepl/version.clj
@@ -6,7 +6,7 @@
 ;; TODO: Figure out how to read the version from project.clj to avoid duplication
 (def version-string
   "The current version for cider-nrepl as a string."
-  "0.19.0-snapshot")
+  "0.18.0-snapshot")
 
 (def version
   "Current version of CIDER nREPL as a map.

--- a/src/cider/nrepl/version.clj
+++ b/src/cider/nrepl/version.clj
@@ -6,7 +6,7 @@
 ;; TODO: Figure out how to read the version from project.clj to avoid duplication
 (def version-string
   "The current version for cider-nrepl as a string."
-  "0.18.0-snapshot")
+  "0.19.0-snapshot")
 
 (def version
   "Current version of CIDER nREPL as a map.

--- a/src/cider_nrepl/main.clj
+++ b/src/cider_nrepl/main.clj
@@ -1,7 +1,7 @@
 (ns cider-nrepl.main
   (:require
    [clojure.java.io :as io]
-   [clojure.tools.nrepl.server :as nrepl.server]))
+   [nrepl.server :as nrepl.server]))
 
 (defn- require-and-resolve
   [thing]
@@ -34,7 +34,7 @@
 
 (defn start-nrepl
   "Starts a socket-based nREPL server. Accepts a map with the following keys:
- 
+
    * :port — defaults to 0, which autoselects an open port
 
    * :bind — bind address, by default \"::\" (falling back to \"localhost\" if

--- a/src/cider_nrepl/main.clj
+++ b/src/cider_nrepl/main.clj
@@ -1,7 +1,12 @@
 (ns cider-nrepl.main
   (:require
-   [clojure.java.io :as io]
-   [nrepl.server :as nrepl.server]))
+   [clojure.java.io :as io]))
+
+(if (find-ns 'clojure.tools.nrepl)
+  (require
+   '[clojure.tools.nrepl.server :as nrepl.server])
+  (require
+   '[nrepl.server]))
 
 (defn- require-and-resolve
   [thing]

--- a/test/clj/cider/nrepl/main_test.clj
+++ b/test/clj/cider/nrepl/main_test.clj
@@ -2,9 +2,9 @@
   (:require [cider.nrepl :refer [wrap-debug cider-middleware]]
             [cider-nrepl.main :as m]
             [clojure.test :refer :all]
-            [clojure.tools.nrepl :as nrepl]
-            [clojure.tools.nrepl.server :as nrepl.server]
-            [clojure.tools.nrepl.transport :as transport]))
+            [nrepl.core :as nrepl]
+            [nrepl.server :as nrepl.server]
+            [nrepl.transport :as transport]))
 
 (defn start-stop-nrepl-session [opts]
   (with-open [server    (#'m/start-nrepl opts)
@@ -40,4 +40,3 @@
                 :port nil
                 :bind nil}]
       (start-stop-nrepl-session opts))))
-

--- a/test/clj/cider/nrepl/middleware/debug_integration_test.clj
+++ b/test/clj/cider/nrepl/middleware/debug_integration_test.clj
@@ -3,15 +3,15 @@
             [cider.nrepl.middleware.debug :as d]
             [cider.nrepl.test.server :refer [start-server]]
             [clojure.test :refer :all]
-            [clojure.tools.nrepl :as nrepl]
-            [clojure.tools.nrepl.server :as nrepl.server]
-            [clojure.tools.nrepl.transport :as transport]
+            [nrepl.core :as nrepl]
+            [nrepl.server :as nrepl.server]
+            [nrepl.transport :as transport]
             [clojure.java.io :as io])
   (:import java.util.UUID
            [java.util.concurrent TimeUnit LinkedBlockingQueue]))
 
 ;;; Helpers for starting an nRepl session
-;;; We do not use clojure.tools.nrepl/client-session here because it
+;;; We do not use nrepl/client-session here because it
 ;;; is built with the expectation that each message sent to the server
 ;;; results in a response message. When that does not happen (as in
 ;;; the case of "init-debugger"), it blocks forever.
@@ -537,13 +537,13 @@
     (<-- {:status ["done"]})))
 
 (deftest step-in-to-function-in-jar-test
-  ;; Step into clojure.tools.nrepl.server/handle*. To do this, we need to find
+  ;; Step into nrepl.server/handle*. To do this, we need to find
   ;; and instrument the source, which is in a jar file. Note that this function
   ;; is used because it is not marked as a :source-dep, so we can rely on the
   ;; namespace remaining unmunged, which is important when these tests run on
   ;; travis CI.
   (--> :eval "(ns user.test.step-in
-                (:require [clojure.tools.nrepl.server :as server]))")
+                (:require [nrepl.server :as server]))")
   (<-- {:ns "user.test.step-in"})
   (<-- {:status ["done"]})
 

--- a/test/clj/cider/nrepl/middleware/debug_integration_test.clj
+++ b/test/clj/cider/nrepl/middleware/debug_integration_test.clj
@@ -562,7 +562,7 @@
                    :coor [3 1 1 1]})
         file (:file msg)]
     (.startsWith file "jar:file:")
-    (.endsWith file "/clojure/tools/nrepl/server.clj"))
+    (.endsWith file "/nrepl/server.clj"))
 
   (--> :continue)
   (<-- {:value "{:transport 23}"})

--- a/test/clj/cider/nrepl/middleware/debug_test.clj
+++ b/test/clj/cider/nrepl/middleware/debug_test.clj
@@ -1,7 +1,7 @@
 (ns cider.nrepl.middleware.debug-test
   (:require [clojure.test :refer :all]
-            [clojure.tools.nrepl.middleware.interruptible-eval :refer [*msg*]]
-            [clojure.tools.nrepl.transport :as t]
+            [nrepl.middleware.interruptible-eval :refer [*msg*]]
+            [nrepl.transport :as t]
             [cider.nrepl.middleware.util.instrument :as ins]
             [cider.nrepl.middleware.debug  :as d]
             [clojure.walk :as walk]))

--- a/test/clj/cider/nrepl/middleware/track_state_test.clj
+++ b/test/clj/cider/nrepl/middleware/track_state_test.clj
@@ -3,7 +3,7 @@
             [cider.nrepl.middleware.util.cljs :as cljs]
             [cider.nrepl.middleware.util.meta :as um]
             [clojure.test :refer :all])
-  (:import clojure.tools.nrepl.transport.Transport))
+  (:import nrepl.transport.Transport))
 
 (def some-ns-map {'cider.nrepl.middleware.track-state-test
                   (st/ns-as-map (find-ns 'cider.nrepl.middleware.track-state-test))})

--- a/test/cljs/cider/nrepl/piggieback_test.clj
+++ b/test/cljs/cider/nrepl/piggieback_test.clj
@@ -3,8 +3,8 @@
             [cider.nrepl.test-session :as session]
             [cider.nrepl :refer [cider-middleware]]
             [clojure.test :refer :all]
-            [clojure.tools.nrepl :as nrepl]
-            [clojure.tools.nrepl.server :as server]))
+            [nrepl.core :as nrepl]
+            [nrepl.server :as server]))
 
 (def piggieback-fixture
   (compose-fixtures

--- a/test/common/cider/nrepl/test/server.clj
+++ b/test/common/cider/nrepl/test/server.clj
@@ -1,6 +1,6 @@
 (ns cider.nrepl.test.server
   (:require
-   [clojure.tools.nrepl.server :as nrepl.server]))
+   [nrepl.server :as nrepl.server]))
 
 ;; This exists to work around https://dev.clojure.org/jira/browse/NREPL-87
 (defn start-server

--- a/test/common/cider/nrepl/test_session.clj
+++ b/test/common/cider/nrepl/test_session.clj
@@ -2,8 +2,8 @@
   (:require [cider.nrepl :refer [cider-nrepl-handler]]
             [cider.nrepl.test.server :refer [start-server]]
             [clojure.test :refer :all]
-            [clojure.tools.nrepl :as nrepl]
-            [clojure.tools.nrepl.transport :as transport]))
+            [nrepl.core :as nrepl]
+            [nrepl.transport :as transport]))
 
 (def ^:dynamic *handler* cider-nrepl-handler)
 (def ^:dynamic *session* nil)

--- a/test/common/cider/nrepl/test_transport.clj
+++ b/test/common/cider/nrepl/test_transport.clj
@@ -1,7 +1,7 @@
 (ns cider.nrepl.test-transport
   "A transport for testing"
   (:use
-   [clojure.tools.nrepl.transport :only [Transport]]))
+   [nrepl.transport :only [Transport]]))
 
 (defrecord TestTransport [msgs]
   Transport

--- a/test/smoketest/project.clj
+++ b/test/smoketest/project.clj
@@ -1,6 +1,6 @@
 (defproject smoketest "0.1.0-SNAPSHOT"
-  :dependencies [[org.clojure/tools.nrepl "0.2.13"]
-                 [cider/cider-nrepl "0.17.0-SNAPSHOT"]]
+  :dependencies [[nrepl "0.4.1"]
+                 [cider/cider-nrepl "0.19.0-SNAPSHOT"]]
   :exclusions [org.clojure/clojure]
   :profiles {:1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}

--- a/test/smoketest/project.clj
+++ b/test/smoketest/project.clj
@@ -1,5 +1,5 @@
 (defproject smoketest "0.1.0-SNAPSHOT"
-  :dependencies [[nrepl "0.4.1"]
+  :dependencies [[nrepl "0.4.2"]
                  [cider/cider-nrepl "0.19.0-SNAPSHOT"]]
   :exclusions [org.clojure/clojure]
   :profiles {:1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}

--- a/test/smoketest/src/smoketest/core.clj
+++ b/test/smoketest/src/smoketest/core.clj
@@ -1,6 +1,6 @@
 (ns smoketest.core
-  (:require [clojure.tools.nrepl :as nrepl]
-            [clojure.tools.nrepl.server :refer [start-server]])
+  (:require [nrepl.core :as nrepl]
+            [nrepl.server :refer [start-server]])
   (:gen-class))
 
 ;; The cider-nrepl "smoke test" replicates a small sampling of the


### PR DESCRIPTION
An initial stab at updating the middleware for nREPL 0.4. 

That's going to be part of the 0.19 release (or at least that's the current plan). 

Any volunteers to test with using https://github.com/nrepl/lein-nrepl? (use `lein install` to build the artefact locally)