### PR TITLE
Add deps.edn for convenient command line launchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,29 @@ with the following "magic" incantation:
 clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.18.0"} }}' -e '(require (quote cider-nrepl.main)) (cider-nrepl.main/init ["cider.nrepl/cider-middleware"])'
 ```
 
+There are also two convenient aliases you can employ (see this project's `deps.edn`):
+
+```clojure
+{...
+ :aliases
+ {:cider-clj {:extra-deps {org.clojure/clojure {:mvn/version "1.9.0"}
+                           cider/cider-nrepl {:mvn/version "0.18.0"}}
+              :main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"]}
+
+  :cider-cljs {:extra-deps {org.clojure/clojure {:mvn/version "1.9.0"}
+                            org.clojure/clojurescript {:mvn/version "1.10.339"}
+                            cider/cider-nrepl {:mvn/version "0.18.0"}
+                            cider/piggieback {:mvn/version "0.3.9"}}
+               :main-opts ["-m" "nrepl.cmdline" "--middleware"
+                           "[cider.nrepl/cider-middleware,cider.piggieback/wrap-cljs-repl]"]}}}
+```
+
+Which then allow you to simply run:
+
+```
+clj -A:cider-clj
+```
+
 Note that `clj` was introduced in Clojure 1.9.
 
 ### Via embedding nREPL in your app

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,18 @@
+{:paths ["src" "resources"]
+ :deps {nrepl {:mvn/version "0.4.5"}
+        cider/orchard {:mvn/version "0.3.1"}
+        thunknyc/profile {:mvn/version "0.5.2"}
+        mvxcvi/puget {:mvn/version "1.0.2"}
+        fipp {:mvn/version "0.6.12"}
+        compliment {:mvn/version "0.3.6"}
+        cljs-tooling {:mvn/version "0.3.0"}
+        cljfmt {:mvn/version "0.5.7" :exclusions [org.clojure/clojurescript]}}
+ :aliases
+ {:cider-clj {:extra-deps {org.clojure/clojure {:mvn/version "1.9.0"}}
+              :main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"]}
+
+  :cider-cljs {:extra-deps {org.clojure/clojure {:mvn/version "1.9.0"}
+                            org.clojure/clojurescript {:mvn/version "1.10.339"}
+                            cider/piggieback {:mvn/version "0.3.9"}}
+               :main-opts ["-m" "nrepl.cmdline" "--middleware"
+                           "[cider.nrepl/cider-middleware,cider.piggieback/wrap-cljs-repl]"]}}}


### PR DESCRIPTION
Specifically this will enable: "clojure -A:cider-clj" and its ClojureScript
cousin.

---

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [X] You've updated the README (if adding/changing middleware)

Keep in mind that new cider-nrepl builds are automatically deployed to Clojars
once a PR is merged, but **only** if the CI build is green.