### PR TITLE
Use a multimethod for content-type dispatching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#548](https://github.com/clojure-emacs/cider-nrepl/pull/548): Make the content-type middleware extensible via multimethod
+
 ## 0.27.4 (2021-12-15)
 
 ### Bugs fixed

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -158,7 +158,9 @@ Returns::
 
 === `content-type-middleware`
 
-Enhances the ``eval`` op by adding ``content-type`` and friends to some responses. Not an op in itself.
+Enhances the ``eval`` op by adding ``content-type`` and ``body`` to certain ``eval`` responses. Not an op in itself.
+
+Depending on the type of the return value of the evaluation this middleware may kick in and include a representation of the result in the response, together with a MIME/Media type to indicate how it should be handled by the client. Comes with implementations for ``URI``, ``URL``, ``File``, and ``java.awt.Image``. More type handlers can be provided by the user by extending the ``cider.nrepl.middleware.content-type/content-type-response`` multimethod. This dispatches using ``clojure.core/type``, so ``:type`` metadata on plain Clojure values can be used to provide custom handling.
 
 Required parameters::
 {blank}
@@ -168,7 +170,9 @@ Optional parameters::
 
 
 Returns::
-{blank}
+* `:body` The rich response document, if applicable.
+* `:content-type` The Media type (MIME type) of the reponse, structured as a pair, `[type {:as attrs}]`
+* `:content-transfer-encoding` The encoding of the response body (Optional, currently only one possible value `"base64"`)
 
 
 === `debug-input`

--- a/doc/modules/ROOT/pages/nrepl-api/supplied_middleware.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/supplied_middleware.adoc
@@ -27,6 +27,12 @@
 | `complete`
 | Code completion.
 
+| `wrap-content-type`
+| -
+| No
+| `eval`
+| Rich content handling, return multimedia results beyond plain text from `eval`.
+
 | `wrap-debug`
 | -
 | No


### PR DESCRIPTION
Make the content-type middleware that handles inlining of File/URL/Image
extensible through a multimethod. This makes it possible for developers to add
handling of custom types.

Regular Clojure values can be given a `:type` metadata to make them
distinguishable. Other types can dispatch on the class.

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the README (if adding/changing middleware)
