### PR TITLE
Always return test documentation messages as strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#546](https://github.com/clojure-emacs/cider-nrepl/pull/546): Added support for matcher-combinators to the test middleware.
 
+### Changes
+
+* [#550](https://github.com/clojure-emacs/cider-nrepl/pull/550): Always return test documentation messages as strings.
+
 ## 0.18.0 (2018-08-06)
 
 ### New features

--- a/test/clj/cider/nrepl/middleware/test_filter_tests.clj
+++ b/test/clj/cider/nrepl/middleware/test_filter_tests.clj
@@ -11,3 +11,6 @@
 
 (deftest yet-an-other-test
   (is true "yet an other"))
+
+(deftest test-with-map-as-message
+  (is true {:key "val"}))

--- a/test/clj/cider/nrepl/middleware/test_test.clj
+++ b/test/clj/cider/nrepl/middleware/test_test.clj
@@ -52,8 +52,8 @@
                                                               :exclude       ["integration"]})
           tests (keys (:cider.nrepl.middleware.test-filter-tests results))]
       (is ((set (keys results)) :cider.nrepl.middleware.test-filter-tests) "ns that contains smoke is present")
-      (is (= 2 (count tests)) "only one test was run")
-      (is (= #{:a-puff-of-smoke-test :yet-an-other-test} (set tests)) "only the test marked 'smoke' was run")))
+      (is (= 3 (count tests)) "only one test was run")
+      (is (= #{:a-puff-of-smoke-test :yet-an-other-test :test-with-map-as-message} (set tests)) "only the test marked 'smoke' was run")))
   (testing "marked test is still run if filter is not used"
     (let [{:keys [results] :as test-result} (session/message {:op            "test"
                                                               :ns            "cider.nrepl.middleware.test-filter-tests"})
@@ -86,8 +86,8 @@
                                                                           :exclude-meta-key ["integration"]}})
           tests (keys (:cider.nrepl.middleware.test-filter-tests results))]
       (is ((set (keys results)) :cider.nrepl.middleware.test-filter-tests) "ns that contains smoke is present")
-      (is (= 2 (count tests)) "only one test was run")
-      (is (= #{:a-puff-of-smoke-test :yet-an-other-test} (set tests)) "only the test marked 'smoke' was run")))
+      (is (= 3 (count tests)) "only one test was run")
+      (is (= #{:a-puff-of-smoke-test :yet-an-other-test :test-with-map-as-message} (set tests)) "only the test marked 'smoke' was run")))
   (testing "marked test is still run if filter is not used"
     (let [{:keys [results] :as test-result} (session/message {:op "test-var-query"
                                                               :var-query {:ns-query {:exactly ["cider.nrepl.middleware.test-filter-tests"]}}})
@@ -95,3 +95,14 @@
       (is ((set (keys results)) :cider.nrepl.middleware.test-filter-tests) "ns that contains smoke is present")
       (is (< 1 (count tests)) "more tests were run")
       (is ((set tests) :a-puff-of-smoke-test) "smoke test is still present without a filter"))))
+
+(deftest run-test-with-map-as-documentation-message
+  (testing "documentation message map is returned as string"
+    (let [{:keys [results] :as test-result} (session/message {:op "test"
+                                                              :ns "cider.nrepl.middleware.test-filter-tests"
+                                                              :tests ["test-with-map-as-message"]})]
+      (is (= (str {:key "val"}) (-> results
+                                    :cider.nrepl.middleware.test-filter-tests
+                                    :test-with-map-as-message
+                                    first
+                                    :message))))))


### PR DESCRIPTION
- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [ ] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)

This PR fixes [cider issue 2449](https://github.com/clojure-emacs/cider/issues/2449) by making sure test documentation messages are always returned as strings.