### PR TITLE
Debugger fixes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,8 @@
   :test-selectors {:default (fn [test-meta]
                               (if-let [min-version (:min-clj-version test-meta)]
                                 (>= (compare (clojure-version) min-version) 0)
-                                true))}
+                                true))
+                   :debugger :debugger}
 
   :aliases {"bump-version" ["change" "version" "leiningen.release/bump-version"]}
 

--- a/test/clj/cider/nrepl/middleware/debug_integration_test.clj
+++ b/test/clj/cider/nrepl/middleware/debug_integration_test.clj
@@ -1,4 +1,4 @@
-(ns cider.nrepl.middleware.debug-integration-test
+(ns ^:debugger cider.nrepl.middleware.debug-integration-test
   (:require
    [cider.nrepl :refer [wrap-debug]]
    [cider.nrepl.middleware.debug :as d]

--- a/test/clj/cider/nrepl/middleware/debug_test.clj
+++ b/test/clj/cider/nrepl/middleware/debug_test.clj
@@ -1,4 +1,4 @@
-(ns cider.nrepl.middleware.debug-test
+(ns ^:debugger cider.nrepl.middleware.debug-test
   (:require
    [cider.nrepl.middleware.util.instrument :as ins]
    [cider.nrepl.middleware.debug  :as d]
@@ -202,7 +202,7 @@
                      :line    :line
                      :column  :column}]
       (let [m (eval `(d/with-initial-debug-bindings
-                       (d/breakpoint-if-interesting (inc 10) {:coor [6]} ~'(inc 10))))]
+                         (d/breakpoint-if-interesting (inc 10) {:coor [6]} ~'(inc 10))))]
         (are [k v] (= (k m) v)
           :value       11
           :debug-value "11"
@@ -215,14 +215,14 @@
       (reset! d/debugger-message [:fake])
       ;; Locals capturing
       (is (= (:value (eval `(d/with-initial-debug-bindings
-                              (let [~'x 10] (d/breakpoint-if-interesting
-                                             (locals)
-                                             {:coor [1]} nil)))))
+                                (let [~'x 10] (d/breakpoint-if-interesting
+                                               (locals)
+                                               {:coor [1]} nil)))))
              '{x 10}))
       ;; Top-level sexps are not debugged, just returned.
       (is (= (eval `(d/with-initial-debug-bindings
-                      (let [~'x 10] (d/breakpoint-if-interesting
-                                     (locals)
-                                     {:coor []}
-                                     nil))))
+                        (let [~'x 10] (d/breakpoint-if-interesting
+                                       (locals)
+                                       {:coor []}
+                                       nil))))
              '{x 10})))))


### PR DESCRIPTION
Two changes:

   - debugger forms are now localized in the sense that STATE__ is inserted where the reader form is located and not around the entire defun. Besides fixing non-closure situations as in #544 it is' likely to be useful in core-async contexts (macros with &env) for which there are a few issues open. Still have to check those.

  - implement a notion of a debugger session and build on top of it to fix a range of "continue" issues 

There are now two `continue` commands, one local which stops on next `#dbg` or `#break` readers, and one global which behaves like the old `continue`. First one is now on `c` and the global on is on `C`. 

I want to fix a few more debugger related issues but it seems wise to push these changes first so that people could start testing immediately. 