### PR TITLE
Bump compliment to 0.3.7-SNAPSHOT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - secure: "D2Ie7dUZ9nQOIWtkRl2XWZeijSL8expUXP3GziSqQV1scJzwexxnUsRvWOkc2YU8+6IIGz9tcyt9RrEFUVF31VZgRSHh8P5rGGCzI2l99djKhYFfSErElwgoAJZFtOzougZK66/Gtb5uDo5L/wlKHkl4st3miqm+mEvfJITDjRQ="
 jdk:
   - oraclejdk8
-  - oraclejdk9
+  - openjdk11
 stages:
   - name: check
   - name: test

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  ^:source-dep [thunknyc/profile "0.5.2"]
                  ^:source-dep [mvxcvi/puget "1.0.2"]
                  ^:source-dep [fipp "0.6.13"]
-                 ^:source-dep [compliment "0.3.6"]
+                 ^:source-dep [compliment "0.3.7-SNAPSHOT"]
                  ^:source-dep [cljs-tooling "0.3.0"]
                  ^:source-dep [cljfmt "0.6.1" :exclusions [org.clojure/clojurescript]]
                  ;; Not used directly in cider-nrepl, but needed because of tool.namespace


### PR DESCRIPTION
This version of Compliment fixes the class name completion on JDK9+.