### PR TITLE
Update format-code op to call cljfmt with option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#546](https://github.com/clojure-emacs/cider-nrepl/pull/546): Added support for matcher-combinators to the test middleware.
+* [#556](https://github.com/clojure-emacs/cider-nrepl/pull/556): Added configuration option for cljfmt to the format middleware.
 
 ### Changes
 

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -226,6 +226,7 @@
    :handles {"format-code"
              {:doc "Reformats the given Clojure code, returning the result as a string."
               :requires {"code" "The code to format."}
+              :optional {"options" "Configuration map for cljfmt."}
               :returns {"formatted-code" "The formatted code."}}
              "format-edn"
              {:doc "Reformats the given EDN data, returning the result as a string."


### PR DESCRIPTION
Update `format-code` op to call `cljfmt.core/reformat-string` with config option.
* https://github.com/weavejester/cljfmt#configuration

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [ ] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)

