### PR TITLE
Add ns-aliases op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#546](https://github.com/clojure-emacs/cider-nrepl/pull/546): Added support for matcher-combinators to the test middleware.
 * [#556](https://github.com/clojure-emacs/cider-nrepl/pull/556): Added configuration option for cljfmt to the format middleware.
+* [#558](https://github.com/clojure-emacs/cider-nrepl/pull/558): Added the `ns-aliases` op to the ns middleware.
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Middleware        | Op(s)      | Description
 `wrap-info`       | `info/eldoc` | File/line, arglists, docstrings and other metadata for vars.
 `wrap-inspect`    |`inspect-(start/refresh/pop/push/reset/get-path)` | Inspect a Clojure expression.
 `wrap-macroexpand`| `macroexpand/macroexpand-1/macroexpand-all/macroexpand-step` | Macroexpand a Clojure form.
-`wrap-ns`         | `ns-list/ns-vars/ns-path/ns-load-all` | Namespace browsing & loading.
+`wrap-ns`         | `ns-list/ns-vars/ns-path/ns-load-all/ns-aliases` | Namespace browsing & loading.
 `wrap-spec`         | `spec-list/spec-form/spec-example` | Spec browsing.
 `wrap-pprint`     | | Adds pretty-printing support to code evaluation. It also installs a dummy `pprint-middleware` op. Thus `wrap-pprint` is discoverable through the `describe` op.
 `wrap-pprint-fn`  | | Provides a common pretty-printing interface for other middlewares that need to perform customisable pretty-printing.

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -333,7 +333,11 @@
                :return {"status" "done" "path" "The path to the file containing ns."}}
               "ns-load-all"
               {:doc "Loads all project namespaces."
-               :return {"status" "done" "loaded-ns" "The list of ns that were loaded."}}}}))
+               :return {"status" "done" "loaded-ns" "The list of ns that were loaded."}}
+              "ns-aliases"
+              {:doc "Returns a map of [ns-alias] to [ns-name] in a namespace."
+               :requires {"ns" "The namespace to use."}
+               :return {"status" "done" "ns-aliases" "The map of [ns-alias] to [ns-name] in a namespace."}}}}))
 
 (def-wrapper wrap-out cider.nrepl.middleware.out/handle-out
   (cljs/expects-piggieback

--- a/test/clj/cider/nrepl/middleware/ns_test.clj
+++ b/test/clj/cider/nrepl/middleware/ns_test.clj
@@ -81,6 +81,12 @@
   (is (= (count (ns-list-vars-by-name 'ns-list-vars-by-name-test)) 1))
   (is (not (seq (ns-list-vars-by-name 'all-your-base-are-belong-to-us)))))
 
+(deftest ns-aliases-integration-test
+  (let [aliases (:ns-aliases (session/message {:op "ns-aliases"
+                                               :ns "cider.nrepl.middleware.ns-test"}))]
+    (is (map? aliases))
+    (is (= (:cider-ns aliases) "cider.nrepl.middleware.ns"))))
+
 (deftest error-handling-test
   (testing "ns-list op error handling"
     (with-redefs [cider-ns/ns-list (fn [& _] (throw (Exception. "ns-list error")))]
@@ -115,4 +121,12 @@
         (is (.startsWith (:err response) "java.lang.Exception: ns-path error"))
         (is (= (:ex response) "class java.lang.Exception"))
         (is (= (:status response) #{"ns-path-error" "done"}))
+        (is (:pp-stacktrace response)))))
+
+  (testing "ns-aliases op error handling"
+    (with-redefs [cider-ns/ns-aliases (fn [& _] (throw (Exception. "ns-aliases error")))]
+      (let [response (session/message {:op "ns-aliases" :name "testing-function"})]
+        (is (.startsWith (:err response) "java.lang.Exception: ns-aliases error"))
+        (is (= (:ex response) "class java.lang.Exception"))
+        (is (= (:status response) #{"ns-aliases-error" "done"}))
         (is (:pp-stacktrace response))))))


### PR DESCRIPTION
Add `ns-aliases` op to the ns middleware.

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [ ] The new code is not generating reflection warnings
- [x] You've updated the README (if adding/changing middleware)