### PR TITLE
Bump fipp so that we silent Clojure 1.10 warnings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                  ^:source-dep [cider/orchard "0.3.3"]
                  ^:source-dep [thunknyc/profile "0.5.2"]
                  ^:source-dep [mvxcvi/puget "1.0.2"]
-                 ^:source-dep [fipp "0.6.13"]
+                 ^:source-dep [fipp "0.6.14"]
                  ^:source-dep [compliment "0.3.7-SNAPSHOT"]
                  ^:source-dep [cljs-tooling "0.3.0"]
                  ^:source-dep [cljfmt "0.6.1" :exclusions [org.clojure/clojurescript]]


### PR DESCRIPTION
This is necessary in new Clojure 1.10 releases, see
https://github.com/brandonbloom/fipp/issues/52.

Before submitting a PR make sure the following things have been done:

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)