### PR TITLE
Fix instrumentation of recursive functions

### DIFF
--- a/src/cider/nrepl/middleware/util/instrument.clj
+++ b/src/cider/nrepl/middleware/util/instrument.clj
@@ -161,12 +161,13 @@
        :else form))))
 
 (defn- contains-recur?
-  "Return true if form is not a `loop` and a `recur` is found in it."
+  "Return true if form is not a `loop` or a `fn` and a `recur` is found in it."
   [form]
   (if (seq? form)
     (case (first form)
       recur true
       loop* false
+      fn*   false
       (some contains-recur? (rest form)))))
 
 (defn- dont-break?
@@ -302,7 +303,7 @@
                         (vary-meta f1 assoc :cider/instrumented (name (:name (meta br))))
                         f1))
                     (m/strip-meta f keys))]
-          ;; also strip meta of the meta
+         ;; also strip meta of the meta
          (with-meta f (strip-instrumentation-meta (meta f))))
        f))
    form))

--- a/test/clj/cider/nrepl/middleware/debug_integration_test.clj
+++ b/test/clj/cider/nrepl/middleware/debug_integration_test.clj
@@ -155,6 +155,29 @@
     (<-- {:value "2"})                  ; (let ...)
     (<-- {:status ["done"]})))
 
+(deftest debug-recur-test
+  (--> :eval "(ns user.test.debug)")
+  (<-- {:ns "user.test.debug"})
+  (<-- {:status ["done"]})
+
+  (--> :eval
+       "#dbg
+          (defn foo [a]
+           (if (pos? a)
+             (recur (dec a))
+             :done))")
+  (<-- {:value "#'user.test.debug/foo"})
+  (<-- {:status ["done"]})
+
+  (testing "recur on fn"
+    (--> :eval "(foo 1)")
+    (<-- {:debug-value "1" :coor [3 1 1]}) ; a
+    (--> :continue)
+    (<-- {:debug-value "0" :coor [3 1 1]}) ; a
+    (--> :continue)
+    (<-- {:value ":done"})
+    (<-- {:status ["done"]})))
+
 (deftest debug-ops-test
   (--> :eval "(ns user.test.debug)")
   (<-- {:ns "user.test.debug"})

--- a/test/clj/cider/nrepl/middleware/util/instrument_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/instrument_test.clj
@@ -1,4 +1,4 @@
-(ns cider.nrepl.middleware.util.instrument-test
+(ns ^:debugger cider.nrepl.middleware.util.instrument-test
   (:require
    [cider.nrepl.middleware.util.instrument :as t]
    [clojure.set :as set]
@@ -70,11 +70,13 @@
                                  (if (seq x)
                                    (recur (rest x))
                                    x)))
-         '#{[(rest (bp x {:coor [2 2 1 1]} x)) [2 2 1]]
-            [x [2 2 1 1]]
-            [x [2 1 1]]
-            [x [2 3]]
-            [(seq (bp x {:coor [2 1 1]} x)) [2 1]]})))
+         '#{[x [2 2 1 1]]
+            [(fn* ([x] (if (bp (seq (bp x {:coor [2 1 1]} x)) {:coor [2 1]} (seq x))
+                         (recur (bp (rest (bp x {:coor [2 2 1 1]} x)) {:coor [2 2 1]} (rest x)))
+                         (bp x {:coor [2 3]} x))))
+             []]
+            [x [2 3]] [(seq (bp x {:coor [2 1 1]} x)) [2 1]] [x [2 1 1]]
+            [(rest (bp x {:coor [2 2 1 1]} x)) [2 2 1]]})))
 
 ;; Factor this into a separate variable, otherwise Eastwood fails with
 ;; "method code too large".


### PR DESCRIPTION
There is one side-effect of #552 that I have noticed so far  - functions with recur in them cannot be debugged.  For example instrumenting the following form will throw

```cl

#dbg
(defn foo [a]
  (if (pos? a)
    (recur (dec a))
    :done))
```

The reason for this is that instrumentation doesn't instrument forms containing recur unless in a `loop*` form. I am adding `fn*` to the relevant check because `fn*` is also a target of `recur`. This issue went unnoticed because it could occur only for local let bound functions before, but with localized debugger implementation it occurs with top level defn as well. 

@Malabarba, do you still remember why `contains-recur?` doesn't provision for fn* target? Was there a special reason for that? I have been testing this patch for 2 weeks now and haven't noticed any issues.