### PR TITLE
[Fix #225] Add :root-ex to error summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Changes
 
 * [#550](https://github.com/clojure-emacs/cider-nrepl/pull/550): Always return test documentation messages as strings.
+* [#563](https://github.com/clojure-emacs/cider-nrepl/pull/563): Add :root-ex key to error summary that contains the classname of the root cause.
 
 ## 0.18.0 (2018-08-06)
 

--- a/src/cider/nrepl/middleware/util/error_handling.clj
+++ b/src/cider/nrepl/middleware/util/error_handling.clj
@@ -37,7 +37,8 @@
   used as the value for the :status key."
   [ex & statuses]
   (merge {:ex (str (class ex))
-          :err (with-out-str (@print-cause-trace ex))}
+          :err (with-out-str (@print-cause-trace ex))
+          :root-ex (-> (#'clojure.main/root-cause ex) class str)}
          (when statuses {:status (set statuses)})))
 
 (defn pp-stacktrace

--- a/test/clj/cider/nrepl/middleware/util/error_handling_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/error_handling_test.clj
@@ -58,3 +58,11 @@
       (is (deep-bencodable? [:a :vector 1 {:a :map} 2 '(:a {:bad-map *ns*} :list) 3])
           "Should pass since *ns* is inside a quoted list and doesn't get evaluated")
       (is (thrown? IllegalArgumentException (deep-bencodable? [:a :vector 1 {:a :map} 2 [:sub :vec :bad *ns*] '(:a :list) 3]))))))
+
+(deftest error-handler-root-ex
+  (let [e (Exception. "testing" (Throwable. "root-cause"))
+        e2 (Exception. "testing2")]
+    (is (= "class java.lang.Throwable"
+           (:root-ex (err/error-handler :done {:id 1} e))))
+    (is (= "class java.lang.Exception"
+           (:root-ex (err/error-handler :done {:id 2} e2))))))


### PR DESCRIPTION
- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [ ] The new code is not generating reflection warnings
- [x] You've updated the README (if adding/changing middleware)

This PR adds a `:root-ex` key to the error summary that contains the classname of the root cause.