### PR TITLE
Use deep-diff for diffing expected vs actual in test failures

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,7 +6,7 @@
         fipp {:mvn/version "0.6.12"}
         compliment {:mvn/version "0.3.6"}
         cljs-tooling {:mvn/version "0.3.0"}
-        lambdaisland/deep-diff {:mvn/version "0.0-15"}
+        lambdaisland/deep-diff {:mvn/version "0.0-25"}
         cljfmt {:mvn/version "0.5.7" :exclusions [org.clojure/clojurescript]}}
  :aliases
  {:cider-clj {:extra-deps {org.clojure/clojure {:mvn/version "1.9.0"}}

--- a/deps.edn
+++ b/deps.edn
@@ -6,6 +6,7 @@
         fipp {:mvn/version "0.6.12"}
         compliment {:mvn/version "0.3.6"}
         cljs-tooling {:mvn/version "0.3.0"}
+        lambdaisland/deep-diff {:mvn/version "0.0-15"}
         cljfmt {:mvn/version "0.5.7" :exclusions [org.clojure/clojurescript]}}
  :aliases
  {:cider-clj {:extra-deps {org.clojure/clojure {:mvn/version "1.9.0"}}

--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
                  ^:source-dep [org.clojure/tools.namespace "0.3.0-alpha4"]
                  ^:source-dep [org.clojure/tools.trace "0.7.10"]
                  ^:source-dep [org.clojure/tools.reader "1.2.2"]
-                 ^:source-dep [lambdaisland/deep-diff "0.0-15"]]
+                 ^:source-dep [lambdaisland/deep-diff "0.0-25"]]
   :plugins [[thomasa/mranderson "0.4.9"]]
   :exclusions [org.clojure/clojure]
 

--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,8 @@
                  ^:source-dep [org.clojure/java.classpath "0.3.0"]
                  ^:source-dep [org.clojure/tools.namespace "0.3.0-alpha4"]
                  ^:source-dep [org.clojure/tools.trace "0.7.10"]
-                 ^:source-dep [org.clojure/tools.reader "1.2.2"]]
+                 ^:source-dep [org.clojure/tools.reader "1.2.2"]
+                 ^:source-dep [lambdaisland/deep-diff "0.0-15"]]
   :plugins [[thomasa/mranderson "0.4.9"]]
   :exclusions [org.clojure/clojure]
 

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -98,6 +98,12 @@
    "print-meta" "Value to bind to `*print-meta*` when pretty-printing. Defaults to the value bound in the current REPL session."
    "print-right-margin" "Value to bind to `clojure.pprint/*print-right-margin*` when pretty-printing. Defaults to the value bound in the current REPL session."})
 
+(def-wrapper wrap-diff-backend cider.nrepl.middleware.test/handle-diff-backend
+  (fn [msg] true)
+  {:doc "Middleware that adds the diff backend to be used for producing the diff of expected vs actual in tests.
+Valid options are `:data-diff` to use `clojure.data/diff` and :deep-diff to use `lambdaisland.deep-diff/diff."
+   :requires #{#'session}})
+
 (def-wrapper wrap-pprint-fn cider.nrepl.middleware.pprint/handle-pprint-fn
   (fn [msg] true)
   {:doc "Middleware that provides a common interface for other middlewares that
@@ -451,7 +457,7 @@
 
 (def-wrapper wrap-test cider.nrepl.middleware.test/handle-test
   {:doc "Middleware that handles testing requests."
-   :requires #{#'session #'wrap-pprint-fn}
+   :requires #{#'session #'wrap-pprint-fn #'wrap-diff-backend}
    :expects #{#'pr-values}
    :handles {"test-var-query"
              {:doc "Run tests specified by the `var-query` and return results. Results are cached for exception retrieval and to enable re-running of failed/erring tests."
@@ -534,6 +540,7 @@
     wrap-content-type
     wrap-slurp
     wrap-pprint
+    wrap-diff-backend
     wrap-pprint-fn
     wrap-profile
     wrap-refresh

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -98,12 +98,6 @@
    "print-meta" "Value to bind to `*print-meta*` when pretty-printing. Defaults to the value bound in the current REPL session."
    "print-right-margin" "Value to bind to `clojure.pprint/*print-right-margin*` when pretty-printing. Defaults to the value bound in the current REPL session."})
 
-(def-wrapper wrap-diff-backend cider.nrepl.middleware.test/handle-diff-backend
-  (fn [msg] true)
-  {:doc "Middleware that adds the diff backend to be used for producing the diff of expected vs actual in tests.
-Valid options are `:data-diff` to use `clojure.data/diff` and :deep-diff to use `lambdaisland.deep-diff/diff."
-   :requires #{#'session}})
-
 (def-wrapper wrap-pprint-fn cider.nrepl.middleware.pprint/handle-pprint-fn
   (fn [msg] true)
   {:doc "Middleware that provides a common interface for other middlewares that
@@ -457,7 +451,7 @@ Valid options are `:data-diff` to use `clojure.data/diff` and :deep-diff to use 
 
 (def-wrapper wrap-test cider.nrepl.middleware.test/handle-test
   {:doc "Middleware that handles testing requests."
-   :requires #{#'session #'wrap-pprint-fn #'wrap-diff-backend}
+   :requires #{#'session #'wrap-pprint-fn}
    :expects #{#'pr-values}
    :handles {"test-var-query"
              {:doc "Run tests specified by the `var-query` and return results. Results are cached for exception retrieval and to enable re-running of failed/erring tests."
@@ -540,7 +534,6 @@ Valid options are `:data-diff` to use `clojure.data/diff` and :deep-diff to use 
     wrap-content-type
     wrap-slurp
     wrap-pprint
-    wrap-diff-backend
     wrap-pprint-fn
     wrap-profile
     wrap-refresh

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -355,11 +355,6 @@
         (t/send transport (response-for msg :status :no-error)))
       (t/send transport (response-for msg :status :done)))))
 
-(defn handle-diff-backend [handler {:keys [diff-backend]
-                                    :or   {diff-backend :deep-diff}
-                                    :as   msg}]
-  (handler (assoc msg :diff-backend diff-backend)))
-
 ;; Before tools.nrepl-0.2.10, `default-executor` was private and
 ;; before 0.2.9 it didn't even exist.
 (def default-executor (delay (if-let [def (resolve 'ie/default-executor)]

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -9,6 +9,7 @@
    [clojure.walk :as walk]
    [orchard.misc :as u]
    [orchard.query :as query]
+   [lambdaisland.deep-diff :as dd]
    [cider.nrepl.middleware.stacktrace :as st]))
 
 (if (find-ns 'clojure.tools.nrepl)
@@ -79,17 +80,18 @@
         c (when (seq test/*testing-contexts*) (test/testing-contexts-str))
         i (count (get-in (@current-report :results) [ns (:name (meta v))]))
         gen-input (:gen-input @current-report)
+        dd-pprint-str  #(with-out-str (dd/pretty-print %))
         pprint-str #(with-out-str (pp/pprint %))]
     ;; Errors outside assertions (faults) do not return an :expected value.
     ;; Type :fail returns :actual value. Type :error returns :error and :line.
     (merge (dissoc m :expected :actual)
            {:ns ns, :var (:name (meta v)), :index i, :context c}
            (when (and (#{:fail :error} t) (not fault))
-             {:expected (pprint-str expected)})
+             {:expected (dd-pprint-str expected)})
            (when (and (#{:fail} t) gen-input)
-             {:gen-input (pprint-str gen-input)})
+             {:gen-input (dd-pprint-str gen-input)})
            (when (#{:fail} t)
-             {:actual (pprint-str actual)})
+             {:actual (dd-pprint-str actual)})
            (when diffs
              {:diffs (extensions/diffs-result diffs)})
            (when (#{:error} t)

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -355,6 +355,11 @@
         (t/send transport (response-for msg :status :no-error)))
       (t/send transport (response-for msg :status :done)))))
 
+(defn handle-diff-backend [handler {:keys [diff-backend]
+                                    :or   {diff-backend :deep-diff}
+                                    :as   msg}]
+  (handler (assoc msg :diff-backend diff-backend)))
+
 ;; Before tools.nrepl-0.2.10, `default-executor` was private and
 ;; before 0.2.9 it didn't even exist.
 (def default-executor (delay (if-let [def (resolve 'ie/default-executor)]

--- a/src/cider/nrepl/middleware/test/diff.clj
+++ b/src/cider/nrepl/middleware/test/diff.clj
@@ -8,6 +8,12 @@
 
 (defmulti pprint (fn [m _actual _diff] (:diff-backend m)))
 
+(defmethod diff :default [m a b]
+  (diff (assoc m :diff-backend :data-diff) a b))
+
+(defmethod pprint :default [m actual diff]
+  (pprint (assoc m :diff-backend :data-diff) actual diff))
+
 (defmethod diff :deep-diff [_ a b]
   (deep-diff/diff a b))
 

--- a/src/cider/nrepl/middleware/test/diff.clj
+++ b/src/cider/nrepl/middleware/test/diff.clj
@@ -1,0 +1,23 @@
+(ns cider.nrepl.middleware.test.diff
+  (:require
+   [clojure.data :as data]
+   [clojure.pprint :as pprint]
+   [lambdaisland.deep-diff :as deep-diff]))
+
+(defmulti diff (fn [m _a _b] (:diff-backend m)))
+
+(defmulti pprint (fn [m _actual _diff] (:diff-backend m)))
+
+(defmethod diff :deep-diff [_ a b]
+  (deep-diff/diff a b))
+
+(defmethod pprint :deep-diff [_ actual diff]
+  (let [pprint #(with-out-str (deep-diff/pretty-print %))]
+    [(pprint actual) (pprint diff)]))
+
+(defmethod diff :data-diff [_ a b]
+  (data/diff a b))
+
+(defmethod pprint :data-diff [_ actual [removed added]]
+  (let [pprint #(with-out-str (pprint/pprint %))]
+    [(pprint actual) [(pprint removed) (pprint added)]]))

--- a/src/cider/nrepl/middleware/test/diff.clj
+++ b/src/cider/nrepl/middleware/test/diff.clj
@@ -6,24 +6,23 @@
 
 (defmulti diff (fn [m _a _b] (:diff-backend m)))
 
-(defmulti pprint (fn [m _actual _diff] (:diff-backend m)))
+(defmulti pprint (fn [m v] (:diff-backend m)))
 
 (defmethod diff :default [m a b]
   (diff (assoc m :diff-backend :data-diff) a b))
 
-(defmethod pprint :default [m actual diff]
-  (pprint (assoc m :diff-backend :data-diff) actual diff))
+(defmethod pprint :default [m v]
+  (pprint (assoc m :diff-backend :data-diff) v))
 
 (defmethod diff :deep-diff [_ a b]
   (deep-diff/diff a b))
 
-(defmethod pprint :deep-diff [_ actual diff]
-  (let [pprint #(with-out-str (deep-diff/pretty-print %))]
-    [(pprint actual) (pprint diff)]))
+(defmethod pprint :deep-diff [_ v]
+  (with-out-str (deep-diff/pretty-print v)))
 
 (defmethod diff :data-diff [_ a b]
-  (data/diff a b))
+  (let [[removed added] (data/diff a b)]
+    [removed added]))
 
-(defmethod pprint :data-diff [_ actual [removed added]]
-  (let [pprint #(with-out-str (pprint/pprint %))]
-    [(pprint actual) [(pprint removed) (pprint added)]]))
+(defmethod pprint :data-diff [_ v]
+  (with-out-str (pprint/pprint v)))

--- a/src/cider/nrepl/middleware/test/extensions.clj
+++ b/src/cider/nrepl/middleware/test/extensions.clj
@@ -6,6 +6,7 @@
   (:require
    [clojure.data :as data]
    [clojure.pprint :as pp]
+   [lambdaisland.deep-diff :as dd]
    [clojure.test :as test :refer [assert-expr]]))
 
 ;; From pjstadig/humane-test-output
@@ -20,7 +21,7 @@
               {:type :pass}
               {:type :fail
                :diffs (->> (remove #(= expected# %) more#)
-                           (map #(vector % (data/diff expected# %))))})
+                           (map #(vector % (dd/diff expected# %))))})
             (merge {:message ~msg
                     :expected expected#
                     :actual more#})
@@ -40,8 +41,7 @@
 (defn diffs-result
   "Convert diffs data to form appropriate for transport."
   [diffs]
-  (let [pprint-str #(with-out-str (pp/pprint %))]
-    (map (fn [[a [removed added]]]
-           [(pprint-str a)
-            [(pprint-str removed) (pprint-str added)]])
+  (let [dd-pprint-str #(with-out-str (dd/pretty-print %))]
+    (map (fn [[a diff]]
+           [(dd-pprint-str a) (dd-pprint-str diff)])
          diffs)))

--- a/src/cider/nrepl/middleware/test/extensions.clj
+++ b/src/cider/nrepl/middleware/test/extensions.clj
@@ -48,5 +48,8 @@
   "Convert diffs data to form appropriate for transport."
   [diffs]
   (map (fn [[actual diff]]
-         (diff/pprint ie/*msg* actual diff))
+         [(diff/pprint ie/*msg* actual)
+          (if (map? diff)
+            (diff/pprint ie/*msg* diff)
+            (mapv (partial diff/pprint ie/*msg*) diff))])
        diffs))

--- a/test/clj/cider/nrepl/middleware/test/extensions_test.clj
+++ b/test/clj/cider/nrepl/middleware/test/extensions_test.clj
@@ -12,15 +12,10 @@
                                                     (reset! ~'r r#))]
                        ~(extensions/=-body "" {:foo :bar} [{:foo :baz} {:baz :nat}])
                        (deref ~'r))))]
-      (is (= {:expected {:foo :bar}
-              :actual   [{:foo :baz} {:baz :nat}]
-              :message  ""
-              :type     :fail
-              :diffs
-              [[{:foo :baz} {:foo #lambdaisland.deep_diff.diff.Mismatch{:- :bar, :+ :baz}}]
-               [{:baz :nat} {#lambdaisland.deep_diff.diff.Insertion{:+ :baz} :nat
-                             #lambdaisland.deep_diff.diff.Deletion{:- :foo} :bar}]]}
-             report))))
+      (is (= [[{:foo :baz} {:foo #lambdaisland.deep_diff.diff.Mismatch{:- :bar, :+ :baz}}]
+              [{:baz :nat} {#lambdaisland.deep_diff.diff.Insertion{:+ :baz} :nat
+                            #lambdaisland.deep_diff.diff.Deletion{:- :foo} :bar}]]
+             (:diffs report)))))
   (testing "Only evalulates expected form once"
     (let [x (eval
              `(let [~'x (atom 0)]

--- a/test/clj/cider/nrepl/middleware/test/extensions_test.clj
+++ b/test/clj/cider/nrepl/middleware/test/extensions_test.clj
@@ -1,7 +1,6 @@
 (ns cider.nrepl.middleware.test.extensions-test
   (:require
    [cider.nrepl.middleware.test.extensions :as extensions]
-   [lambdaisland.deep-diff :as dd]
    [clojure.test :as test :refer :all]))
 
 (deftest =-body-test

--- a/test/clj/cider/nrepl/middleware/test/extensions_test.clj
+++ b/test/clj/cider/nrepl/middleware/test/extensions_test.clj
@@ -10,12 +10,9 @@
                   `(let [~'r (atom nil)]
                      (with-redefs [test/do-report (fn [r#]
                                                     (reset! ~'r r#))]
-                       ~(extensions/=-body "" {:foo :bar} [{:foo :baz} {:baz :nat}])
+                       ~(extensions/=-body "" {:foo :bar} [{:foo :baz}])
                        (deref ~'r))))]
-      (is (= [[{:foo :baz} {:foo #lambdaisland.deep_diff.diff.Mismatch{:- :bar, :+ :baz}}]
-              [{:baz :nat} {#lambdaisland.deep_diff.diff.Insertion{:+ :baz} :nat
-                            #lambdaisland.deep_diff.diff.Deletion{:- :foo} :bar}]]
-             (:diffs report)))))
+      (is (= 1 (count (:diffs report))))))
   (testing "Only evalulates expected form once"
     (let [x (eval
              `(let [~'x (atom 0)]

--- a/test/clj/cider/nrepl/middleware/test/extensions_test.clj
+++ b/test/clj/cider/nrepl/middleware/test/extensions_test.clj
@@ -1,9 +1,26 @@
 (ns cider.nrepl.middleware.test.extensions-test
   (:require
    [cider.nrepl.middleware.test.extensions :as extensions]
-   [clojure.test :refer :all]))
+   [lambdaisland.deep-diff :as dd]
+   [clojure.test :as test :refer :all]))
 
 (deftest =-body-test
+  (testing "Adds diff output"
+    (let [report (eval
+                  `(let [~'r (atom nil)]
+                     (with-redefs [test/do-report (fn [r#]
+                                                    (reset! ~'r r#))]
+                       ~(extensions/=-body "" {:foo :bar} [{:foo :baz} {:baz :nat}])
+                       (deref ~'r))))]
+      (is (= {:expected {:foo :bar}
+              :actual   [{:foo :baz} {:baz :nat}]
+              :message  ""
+              :type     :fail
+              :diffs
+              [[{:foo :baz} {:foo #lambdaisland.deep_diff.diff.Mismatch{:- :bar, :+ :baz}}]
+               [{:baz :nat} {#lambdaisland.deep_diff.diff.Insertion{:+ :baz} :nat
+                             #lambdaisland.deep_diff.diff.Deletion{:- :foo} :bar}]]}
+             report))))
   (testing "Only evalulates expected form once"
     (let [x (eval
              `(let [~'x (atom 0)]


### PR DESCRIPTION
This changes the existing diff library used by the test middleware `clojure.data/diff` for [lambdaisland.deep-diff](https://github.com/lambdaisland/deep-diff) with the purpose of getting nicer diffs to make it easier to spot the differences of expected vs actual in tests. The advantages of deep-diff is that it recursively compares data structures and produces colorised output. 

This is the current output by `clojure.data/diff`:
<img width="717" alt="screenshot 2018-11-08 23 47 22" src="https://user-images.githubusercontent.com/517965/48234257-c8f44100-e3b0-11e8-982f-b451e2353207.png">
<img width="707" alt="screenshot 2018-11-08 23 46 42" src="https://user-images.githubusercontent.com/517965/48234260-cb569b00-e3b0-11e8-9b8c-3e7bd533608a.png">
<img width="706" alt="screenshot 2018-11-08 23 47 45" src="https://user-images.githubusercontent.com/517965/48234264-ce518b80-e3b0-11e8-991a-4dedceb87b9f.png">


This is the kind of output that you get with `deep-diff`:
<img width="714" alt="screenshot 2018-11-07 23 34 01" src="https://user-images.githubusercontent.com/517965/48232885-081f9380-e3ab-11e8-8e8f-1519c785ee9c.png">
<img width="710" alt="screenshot 2018-11-08 23 10 57" src="https://user-images.githubusercontent.com/517965/48233022-93008e00-e3ab-11e8-8566-881dae503c97.png">
<img width="706" alt="screenshot 2018-11-08 23 28" src="https://user-images.githubusercontent.com/517965/48233663-0f946c00-e3ae-11e8-82b4-f359514c42f0.png">

I am also raising another PR to make `cider` understand this new format, just want to get your thoughts on this first. On the cider side, I understand there's also `cider-test-ediff`, which might not make sense anymore as the diff Is more explicit about the actual differences.

Let me know what you think.