### PR TITLE
Bumping fipp deps for JDK11 support

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
         cider/orchard {:mvn/version "0.3.1"}
         thunknyc/profile {:mvn/version "0.5.2"}
         mvxcvi/puget {:mvn/version "1.0.2"}
-        fipp {:mvn/version "0.6.12"}
+        fipp {:mvn/version "0.6.14"}
         compliment {:mvn/version "0.3.6"}
         cljs-tooling {:mvn/version "0.3.0"}
         cljfmt {:mvn/version "0.5.7" :exclusions [org.clojure/clojurescript]}}


### PR DESCRIPTION
Just a simple PR to bump the fipp version regarding [this PR](https://github.com/brandonbloom/fipp/commit/1d5b74a3cd384b2673c9f45c204838bab20ac7b3).

The latest fipp version includes updates to rrb-vector, which now works nicely with JDK11 rather than throwing weird errors.