### PR TITLE
[Fix #570] Use base class of different writers

### DIFF
--- a/src/cider/nrepl/middleware/out.clj
+++ b/src/cider/nrepl/middleware/out.clj
@@ -81,7 +81,7 @@
         print-timer (Timer.)
         print-flusher (proxy [TimerTask] []
                         (run []
-                          (.flush ^PrintWriter @printer)))]
+                          (.flush ^Writer @printer)))]
     (.scheduleAtFixedRate print-timer print-flusher delay delay)
     (PrintStream.
      (proxy [OutputStream] []
@@ -92,13 +92,13 @@
        (write
          ([int-or-bytes]
           (if (instance? Integer int-or-bytes)
-            (.write ^PrintWriter @printer ^Integer int-or-bytes)
-            (.write ^PrintWriter @printer (String. ^"[B" int-or-bytes))))
+            (.write ^Writer @printer ^Integer int-or-bytes)
+            (.write ^Writer @printer (String. ^"[B" int-or-bytes))))
          ([^"[B" bytes ^Integer off ^Integer len]
           (let [byte-range (byte-array (take len (drop off bytes)))]
-            (.write ^PrintWriter @printer (String. byte-range)))))
+            (.write ^Writer @printer (String. byte-range)))))
        (flush []
-         (.flush ^PrintWriter @printer))))))
+         (.flush ^Writer @printer))))))
 
 ;;; Known eval sessions
 (def tracked-sessions-map


### PR DESCRIPTION
Although the `forking-writer` *should be* a `PrintWriter`, in practice we've
seen that a `BufferedWriter` can be returned. This led to the error:

>java.lang.ClassCastException: java.io.BufferedWriter cannot be cast to
java.io.PrintWriter

These types of errors are avoided by using the base class `Writer` of the
`BufferedWriter` and `PrintWriter`, just as is done in the rest of this file.