### PR TITLE
Fix inspector silently doing nothing if eval errored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 * [#550](https://github.com/clojure-emacs/cider-nrepl/pull/550): Always return test documentation messages as strings.
 * [#563](https://github.com/clojure-emacs/cider-nrepl/pull/563): Add :root-ex key to error summary that contains the classname of the root cause.
 
+### Bugs fixed
+
+* [#573](https://github.com/clojure-emacs/cider-nrepl/pull/573): Fix inspector silently doing nothing if eval errored
+
 ## 0.18.0 (2018-08-06)
 
 ### New features

--- a/test/clj/cider/nrepl/middleware/inspect_test.clj
+++ b/test/clj/cider/nrepl/middleware/inspect_test.clj
@@ -76,13 +76,8 @@
                                                :code "(first 1)"})]
 
       (testing "exprs that throw exceptions return an `ex` slot"
-        (is (= "class java.lang.IllegalArgumentException"
-               (:ex exception-response))))
-
-      ;;TODO: The :err slot is missing when running this through the Cider test-runner
-      (testing "exprs that throw exceptions return an `err` slot"
-        (is (.startsWith (:err exception-response)
-                         "IllegalArgumentException")))))
+        (is (= "class java.lang.Exception"
+               (:ex exception-response))))))
 
   (testing "inspect-pop error handling"
     (with-redefs [i/swap-inspector! (fn [& _] (throw (Exception. "pop exception")))]


### PR DESCRIPTION
**The problem**
If you inspect an expression that throws an exception (e.g. `(/ 1 0)`), the inspector silently discards the exception as if nothing has happened. This is annoying.

**Why?**
Cider already has machinery for things like that, e.g. if macroexpansion throws an error, it will be displayed in a special cider middleware error buffer. That is implemented by macroexpansion middleware using `with-safe-transport` which, in the case of error, returns a message with status `[:done :macroexpansion-error]`. On the Emacs side, Cider's `cider-nrepl-send-sync-request` listens to `:done` events, and if there's an error status after it the error buffer will be raised.
Why doesn't it work for inspector? Because at some point (#164) the inspector has been changed from having its own middleware command to riding upon `eval` command. `eval` command is asynchronous and can return many results; and if the exception is thrown, it will send the exception as separate message and finish up with `:done` message. And `cider-nrepl-send-sync-request` ignores everything except `:done`.

**What is this fix?**
A hack to make `eval :inspect true` interceptor to short-circuit the failed eval with `[:done :inspect-eval-error]` message. Also, some refactoring to make the inspector middleware more like other middlewares.

**Does it have to be like this?**
I have no idea. I don't know if CLJS implementation will work after this, why it must use `eval` command, and what can be safely refactored. Need someone's help with CLJS side, this is too complicated for me.

BTW, it might be a good idea to hold this until 0.19 release.