### PR TITLE
[Fix #575] Upgrade to Eastwood 0.3.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -110,4 +110,4 @@
                                          if-class [[:block 1]]}}}
 
              :eastwood {:plugins [[jonase/eastwood "0.3.4"]]
-                        :eastwood {:config-files ["eastwood.clj"] :exclude-namespaces [cider-nrepl.plugin cider.tasks cider.nrepl.test-session]}}})
+                        :eastwood {:config-files ["eastwood.clj"] :exclude-namespaces [cider-nrepl.plugin cider.tasks cider.nrepl.test-session] :exclude-linters [:implicit-dependencies]}}})

--- a/project.clj
+++ b/project.clj
@@ -109,5 +109,5 @@
                                          try-if-let [[:block 1]]
                                          if-class [[:block 1]]}}}
 
-             :eastwood {:plugins [[jonase/eastwood "0.2.5"]]
-                        :eastwood {:config-files ["eastwood.clj"]}}})
+             :eastwood {:plugins [[jonase/eastwood "0.3.4"]]
+                        :eastwood {:config-files ["eastwood.clj"] :exclude-namespaces [cider-nrepl.plugin cider.tasks cider.nrepl.test-session]}}})


### PR DESCRIPTION
-  add excluded namespaces

This is not done yet, but with three excluded ns's, linting passes without exceptions, but with errors.
One of the exceptions (thrown from `test-sessions` is a bug in eastwood (https://github.com/jonase/eastwood/issues/306)
The two others might be bugs in eastwood, I don't know.

I'll leave this here for now, and work a bit more on it, so please don't merge yet.