### PR TITLE
Test repl setup improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ script:
   - make $TARGET
 env:
   matrix:
-    - VERSION=1.8 TARGET=test-clj
-    - VERSION=1.8 TARGET=test-cljs
-    - VERSION=1.9 TARGET=test-clj
-    - VERSION=1.9 TARGET=test-cljs
+    - CLOJURE_VERSION=1.8 TARGET=test-clj
+    - CLOJURE_VERSION=1.8 TARGET=test-cljs
+    - CLOJURE_VERSION=1.9 TARGET=test-clj
+    - CLOJURE_VERSION=1.9 TARGET=test-cljs
   global:
     - secure: "bCp4gU7XgeqLnqKwEpJarnKPbGljHyLE2rZnub4mEHD8kcvh6LoEkG/2QCtnSETj8zrQJwyMuEDGUwPgjmzQ/aEn6UiIYmv7ka6QnLBxOxhqQTbDtG7HssfkeT5b67LgOyQX7ejK88vnmH+OeWXM7kOOvUwVy5BVgsYyr2f1cGU="
     - secure: "D2Ie7dUZ9nQOIWtkRl2XWZeijSL8expUXP3GziSqQV1scJzwexxnUsRvWOkc2YU8+6IIGz9tcyt9RrEFUVF31VZgRSHh8P5rGGCzI2l99djKhYFfSErElwgoAJZFtOzougZK66/Gtb5uDo5L/wlKHkl4st3miqm+mEvfJITDjRQ="
@@ -32,30 +32,30 @@ stages:
 jobs:
   include:
     # Test OpenJDK against latest Clojure stable
-    - env: VERSION=1.9 TARGET=test-clj
+    - env: CLOJURE_VERSION=1.9 TARGET=test-clj
       jdk: openjdk8
-    - env: VERSION=1.9 TARGET=test-cljs
+    - env: CLOJURE_VERSION=1.9 TARGET=test-cljs
       jdk: openjdk8
 
     # Test Clojure master against a single JDK
-    - env: VERSION=master TARGET=test-clj
+    - env: CLOJURE_VERSION=master TARGET=test-clj
       jdk: oraclejdk8
-    - env: VERSION=master TARGET=test-cljs
+    - env: CLOJURE_VERSION=master TARGET=test-cljs
       jdk: oraclejdk8
 
     # Coverage analysis
-    - env: VERSION=1.9 TARGET=cloverage
+    - env: CLOJURE_VERSION=1.9 TARGET=cloverage
       jdk: oraclejdk8
       after_success: bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json
 
     # Eastwood linter
     - stage: check
-      env: VERSION=1.9 TARGET=eastwood
+      env: CLOJURE_VERSION=1.9 TARGET=eastwood
       jdk: oraclejdk8
 
     # Check cljfmt
     - stage: check
-      env: VERSION=1.9 TARGET=cljfmt
+      env: CLOJURE_VERSION=1.9 TARGET=cljfmt
       jdk: oraclejdk8
 
     # Deployment
@@ -65,6 +65,6 @@ jobs:
 
   fast_finish: true      # don't wait for allowed failures before build finish
   allow_failures:
-    - env: VERSION=master TARGET=test-clj
-    - env: VERSION=master TARGET=test-cljs
-    - env: VERSION=1.9 TARGET=cloverage
+    - env: CLOJURE_VERSION=master TARGET=test-clj
+    - env: CLOJURE_VERSION=master TARGET=test-cljs
+    - env: CLOJURE_VERSION=1.9 TARGET=cloverage

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test-clj test-cljs eastwood cljfmt cloverage install smoketest release deploy clean
+.PHONY: test-clj test-cljs eastwood cljfmt cloverage install smoketest release deploy clean check_node
 
 VERSION ?= 1.9
 export CLOVERAGE_VERSION = 1.0.13
@@ -52,6 +52,9 @@ smoketest: install
 	cd test/smoketest && \
         lein with-profile +$(VERSION) uberjar && \
         java -jar target/smoketest-0.1.0-SNAPSHOT-standalone.jar
+
+check_node:
+	which node
 
 # When releasing, the BUMP variable controls which field in the
 # version string will be incremented in the *next* snapshot

--- a/project.clj
+++ b/project.clj
@@ -30,9 +30,14 @@
   :test-paths ["test/common"] ;; See `test-clj` and `test-cljs` profiles below.
 
   :test-selectors {:default (fn [test-meta]
-                              (if-let [min-version (:min-clj-version test-meta)]
-                                (>= (compare (clojure-version) min-version) 0)
-                                true))
+                              (let [parse-version (fn [v] (mapv #(Integer/parseInt (re-find #"\d+" %)) (clojure.string/split v #"\.")))
+                                    clojure-version (parse-version (clojure-version))]
+                                (and (if-let [min-version (:min-clj-version test-meta)]
+                                       (>= (compare clojure-version (parse-version min-version)) 0)
+                                       true)
+                                     (if-let [max-version (:max-clj-version test-meta)]
+                                       (>= (compare (parse-version max-version) clojure-version) 0)
+                                       true))))
                    :debugger :debugger}
 
   :aliases {"bump-version" ["change" "version" "leiningen.release/bump-version"]}


### PR DESCRIPTION
These are all changes I made in the context of #569 that are not directly related to fixing tests (although some are necessary prerequisites for what follows, e.g. the min/max-clj-version fixes).

I'll make a separate PR with the testing fixes once this is merged.

----

### Explicitly add refactor-nrepl.plugin/middleware to Leiningen config

Before this Leiningen middleware was being added implicitly, but in the latest
Leiningen this causes a warning. Configure it explicitly instead, and disable
Leiningen's support for implicit middleware.

----

### Add a ^:max-clj-version test filter, fix min-clj-version

To be able to account for subtle differences between Clojure versions we have
metadata based filters. The min-clojure-version filter however no longer worked
correctly because Clojure 1.10 would sort before 1.9. Fixed this by adding
explicit version parsing, and also added a max-clj-version filter.

----

### Add REPL helpers: repl-session! / close-session!

Many tests make use of `session-fixture`, which sets up an nREPL session, and
tears it down again. When working on tests this makes it tedious to quickly
evaluate test forms.

These helper functions set up the nREPL session similar to `session-fixture` but
allow you to manage the start/stop lifecycle yourself, so you can start the
session once and get to work.

----

### Add a check to the build logic to see if node is present

The ClojureScript tests rely on node being present, if it's not there then they
will fail in non-obvious ways. To provide quick feedback we do a check first
before starting the tests.

----

### Makefile: rename VERSION to CLOJURE_VERSION

For the sake of clarity and unambiguity, add some namespacing to this env var.