### PR TITLE
Increase timeout in debug-integration-test, fail loudly upon timeout

### DIFF
--- a/test/clj/cider/nrepl/middleware/debug_integration_test.clj
+++ b/test/clj/cider/nrepl/middleware/debug_integration_test.clj
@@ -42,7 +42,7 @@
     (transport/send *transport* msg)))
 
 (defn nrepl-recv []
-  (let [msg (transport/recv *transport* 200)]
+  (let [msg (transport/recv *transport* 500)]
     (dbg "<==" msg)
     msg))
 
@@ -113,6 +113,10 @@
         assertions (for [[k v] expected]
                      `(is (= ~v (get ~msg-sym ~k)) (str "Message: " ~msg-sym)))]
     `(let [~msg-sym (nrepl-recv)]
+       (when (nil? ~msg-sym)
+         (throw (ex-info (str "Unexpected timeout waiting for nREPL response. "
+                              "Expected message: " (prn-str ~expected))
+                         {})))
        ~@assertions
        (when-let [k# (:key ~msg-sym)]
          (.put *debugger-key* k#))


### PR DESCRIPTION
These tests use special `--->` and `<---` macros to sketch out an interaction
with the debugger, but the `<---` macro (nrepl-recv) did not account for the
possibility of a timeout. A timeout would result in receiving a `nil` message,
which was then treated as an empty map as far as assertions are concerned.

When this happened the actual and expected messages would get out of sync,
causing all future assertions in the same test var to also fail.

This commit increases the timeout from 200 to 500 ms, and throws an exception
when a timeout does occur.
