### PR TITLE
Use Nashorn for CLJS tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,10 @@
 /checkouts
 pom.xml
 pom.xml.asc
+nashorn_code_cache
 *.jar
 *.class
-.cljs_node_repl
+.cljs_nashorn_repl
 .lein-deps-sum
 .lein-failures
 .lein-plugins

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test-clj test-cljs eastwood cljfmt cloverage install smoketest release deploy clean check_node detect_timeout
+.PHONY: test-clj test-cljs eastwood cljfmt cloverage install smoketest release deploy clean detect_timeout
 
 CLOJURE_VERSION ?= 1.9
 export CLOVERAGE_VERSION = 1.0.13
@@ -16,7 +16,7 @@ source-deps: .source-deps
 test-clj: .source-deps smoketest
 	lein with-profile +$(CLOJURE_VERSION),+plugin.mranderson/config,+test-clj test
 
-test-cljs: .source-deps check_node detect_timeout
+test-cljs: .source-deps
 	lein with-profile +$(CLOJURE_VERSION),+plugin.mranderson/config,+test-cljs test
 
 eastwood:
@@ -47,8 +47,6 @@ smoketest: install
         lein with-profile +$(CLOJURE_VERSION) uberjar && \
         java -jar target/smoketest-0.1.0-SNAPSHOT-standalone.jar
 
-check_node:
-	which node
 
 # Run a background process that prints all JVM stacktraces after five minutes,
 # then kills all JVMs, to help diagnose issues with ClojureScript tests getting

--- a/test/cljs/cider/nrepl/piggieback_test.clj
+++ b/test/cljs/cider/nrepl/piggieback_test.clj
@@ -16,8 +16,8 @@
                                               #'piggieback/wrap-cljs-repl))]
        (session/message {:op :eval
                          :code (nrepl/code (require '[cider.piggieback :as piggieback])
-                                           (require '[cljs.repl.node :as node])
-                                           (piggieback/cljs-repl (node/repl-env)))})
+                                           (require '[cljs.repl.nashorn :as nashorn])
+                                           (piggieback/cljs-repl (nashorn/repl-env)))})
        (session/message {:op :eval
                          :code (nrepl/code (require 'clojure.data))})
        (f)


### PR DESCRIPTION
Fixes #578.

When I added the CLJS tests, Nashorn was unavailable on JDK 7 – but we no longer support that. Nashorn is now deprecated as of JDK 11, the suggested alternative being Graal, but that is unavailable on JDK 8 which we do still support. Additionally `cljs.repl.graaljs` was only added in ClojureScript 1.10.439.

For now: just use Nashorn; if it's removed in some future JDK version then what we do will depend on which JDKs/CLJS versions we still support at that time.