### PR TITLE
There is a lot of reflection warnings

### DIFF
--- a/src/cider/nrepl/middleware/content_type.clj
+++ b/src/cider/nrepl/middleware/content_type.clj
@@ -46,6 +46,7 @@
    [cider.nrepl.middleware.slurp :refer [slurp-reply]])
   (:import
    java.awt.Image
+   [java.awt.image RenderedImage]
    [java.io ByteArrayOutputStream File OutputStream]
    [java.net URI URL]
    java.nio.file.Path
@@ -94,7 +95,7 @@
     (assoc response
            :content-type ["message/external-body"
                           {"access-type" "URL"
-                           "URL" (.toString (as-url value))}]
+                           "URL" (.toString ^URL (as-url value))}]
            :body "")
 
     ;; FIXME (arrdem 2018-04-03):
@@ -107,7 +108,7 @@
     (instance? java.awt.Image value)
     (with-open [bos (ByteArrayOutputStream.)]
       (merge response
-             (when (ImageIO/write ^Image value "png" ^OutputStream bos)
+             (when (ImageIO/write ^RenderedImage value "png" ^OutputStream bos)
                (slurp-reply "" ["image/png" {}] (.toByteArray bos)))))
 
     :else response))

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -66,7 +66,7 @@
   []
   (letfn [(hex [] (format "%x" (rand-int 15)))
           (nhex [n] (apply str (repeatedly n hex)))]
-    (let [rhex (format "%x" (bit-or 0x8 (bit-and 0x3 (rand-int 14))))]
+    (let [rhex (format "%x" (bit-or 0x8 (bit-and 0x3 ^int (rand-int 14))))]
       (str (nhex 8) "-" (nhex 4) "-4" (nhex 3)
            "-" rhex (nhex 3) "-" (nhex 12)))))
 
@@ -139,7 +139,7 @@
   (if (map? *msg*)
     (do
       (transport/send (:transport *msg*) (response-for *msg* :value 'QUIT))
-      (.stop (:thread (meta (:session *msg*)))))
+      (.stop ^Thread (:thread (meta (:session *msg*)))))
     ;; We can't really abort if there's no *msg*, so we do our best
     ;; impression of that. This is only used in some panic situations,
     ;; the user won't be offered the :quit option if there's no *msg*.
@@ -380,7 +380,7 @@ this map (identified by a key), and will `dissoc` it afterwards."}
             (throw (ex-info "Invalid input from `read-debug-input`."
                             {:response-raw response-raw})))))))
 
-(defn print-step-indented [depth form value]
+(defn print-step-indented [^long depth form value]
   (print (apply str (repeat (dec depth) "| ")))
   (binding [*print-length* 4
             *print-level*  2]

--- a/src/cider/nrepl/middleware/util/instrument.clj
+++ b/src/cider/nrepl/middleware/util/instrument.clj
@@ -252,8 +252,8 @@
   [x y]
   (if (seq x)
     (if (seq y)
-      (let [fa (first x)
-            fb (first y)]
+      (let [^int fa (first x)
+            ^int fb (first y)]
         (if (= fa fb)
           (recur (rest x) (rest y))
           (< fa fb)))

--- a/src/cider/nrepl/print_method.clj
+++ b/src/cider/nrepl/print_method.clj
@@ -74,7 +74,7 @@
 ;;; Agents, futures, delays, promises, etc
 (defn- deref-name [c]
   (let [class-name (translate-class-name c)]
-    (if-let [[_ short-name] (re-find #"^clojure\.lang\.([^.]+)" class-name)]
+    (if-let [[_ ^String short-name] (re-find #"^clojure\.lang\.([^.]+)" class-name)]
       (.toLowerCase short-name)
       (case (second (re-find #"^clojure\.core/(.+)/reify" class-name))
         "future-call" "future"


### PR DESCRIPTION
I have fixed the easy ones. There is some more left.

the remaining ones, 
```
Reflection warning, cider/nrepl/middleware/out.clj:53:22 - call to method write can't be resolved (target class is unknown).
Reflection warning, cider/nrepl/middleware/out.clj:55:24 - call to method write on java.lang.Object can't be resolved (no such method).
Reflection warning, cider/nrepl/middleware/out.clj:55:24 - call to method write on java.lang.Object can't be resolved (no such method).
Reflection warning, cider/nrepl/middleware/out.clj:57:22 - call to method write can't be resolved (target class is unknown).
Reflection warning, cider/nrepl/middleware/out.clj:59:24 - call to method write on java.lang.Object can't be resolved (no such method).
Boxed math warning, byte_streams/graph.clj:130:77 - call: public static double clojure.lang.Numbers.unchecked_add(java.lang.Object,double).
Reflection warning, cider/nrepl/middleware/out.clj:59:24 - call to method write on java.lang.Object can't be resolved (no such method).
Reflection warning, cider/nrepl/middleware/out.clj:61:21 - reference to field flush can't be resolved.
Reflection warning, cider/nrepl/middleware/out.clj:63:23 - reference to field flush on java.lang.Object can't be resolved.
Reflection warning, cider/nrepl/middleware/out.clj:63:23 - reference to field flush on java.lang.Object can't be resolved.

Reflection warning, cider/nrepl/middleware/inspect.clj:47:25 - call to java.lang.Exception ctor can't be resolved.

Reflection warning, cider/nrepl/middleware/debug.clj:159:29 - reference to field sym on java.lang.Object can't be resolved.
Reflection warning, cider/nrepl/middleware/debug.clj:159:29 - reference to field sym on java.lang.Object can't be resolved.
```

Not completly sure how to fix the remaining ones. 