### PR TITLE
Move leftover code from the info middleware to orchard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ JAVA_VERSION = $(shell lein with-profile +sysutils \
 inline-deps: .inline-deps
 
 test: .inline-deps
-	lein with-profile +$(CLOJURE_VERSION),+plugin.mranderson/config test
+	lein with-profile +$(CLOJURE_VERSION),+test,+plugin.mranderson/config test
 
 eastwood:
 	lein with-profile +$(CLOJURE_VERSION),+eastwood eastwood

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ Let's also acknowledge some of the projects leveraged by cider-nrepl:
 
 * [orchard][] - extracted from `cider-nrepl`, so that non-nREPL clients can leverage the generic tooling functionality (like `inspect`, `apropos`, `var-info`, etc
 * [compliment][] - for Clojure code completion
-* [cljs-tooling][] - for ClojureScript code completion and var info
+* [cljs-tooling][] - for ClojureScript code completion
 * [tools.trace][] - for tracing
 * [tools.namespace][] - for namespace reloading
 * [cljfmt][] - for code formatting

--- a/project.clj
+++ b/project.clj
@@ -62,20 +62,20 @@
                                   [leiningen-core "2.9.0"]]}
 
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]
-                                  [org.clojure/clojurescript "1.8.51" :scope "provided"]
+                                  [org.clojure/clojurescript "1.10.520" :scope "provided"]
                                   [javax.xml.bind/jaxb-api "2.3.1" :scope "provided"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]
-                                  [org.clojure/clojurescript "1.9.946" :scope "provided"]
+                                  [org.clojure/clojurescript "1.10.520" :scope "provided"]
                                   [javax.xml.bind/jaxb-api "2.3.1" :scope "provided"]]
                    ;; TODO: Merge the tests in this dir in to test/clj once we
                    ;; drop support for Clojure 1.8
                    :test-paths ["test/spec"]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.0"]
-                                   [org.clojure/clojurescript "1.10.63" :scope "provided"]]
+                                   [org.clojure/clojurescript "1.10.520" :scope "provided"]]
                     :test-paths ["test/spec"]}
              :master {:repositories [["snapshots" "https://oss.sonatype.org/content/repositories/snapshots"]]
                       :dependencies [[org.clojure/clojure "1.11.0-master-SNAPSHOT"]
-                                     [org.clojure/clojurescript "1.10.516" :scope "provided"]]}
+                                     [org.clojure/clojurescript "1.10.520" :scope "provided"]]}
 
              :test {:source-paths ["test/src"]
                     :java-source-paths ["test/java"]

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/clojure-emacs/cider-nrepl"}
   :dependencies [[nrepl "0.6.0"]
-                 ^:inline-dep [cider/orchard  "0.5.0-beta3"]
+                 ^:inline-dep [cider/orchard  "0.5.0-beta4"]
                  ^:inline-dep [thunknyc/profile "0.5.2"]
                  ^:inline-dep [mvxcvi/puget "1.1.2"]
                  ^:inline-dep [fipp "0.6.18"]; can be removed in unresolved-tree mode

--- a/project.clj
+++ b/project.clj
@@ -59,7 +59,8 @@
 
              :dev {:dependencies [[boot/base "2.8.3"]
                                   [boot/core "2.8.3"]
-                                  [leiningen-core "2.9.0"]]}
+                                  [leiningen-core "2.9.0"]]
+                   :global-vars {*assert* true}}
 
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [org.clojure/clojurescript "1.10.520" :scope "provided"]
@@ -80,7 +81,8 @@
              :test {:source-paths ["test/src"]
                     :java-source-paths ["test/java"]
                     :resource-paths ["test/resources"]
-                    :dependencies [[cider/piggieback "0.4.0"]]}
+                    :dependencies [[pjstadig/humane-test-output "0.9.0"]
+                                   [cider/piggieback "0.4.0"]]}
 
              ;; Need ^:repl because of: https://github.com/technomancy/leiningen/issues/2132
              :repl ^:repl [:test

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -397,7 +397,7 @@ this map (identified by a key), and will `dissoc` it afterwards."}
   (when-not (::instrumented (meta v))
     (when-let [{:keys [ns file form] :as var-meta} (m/var-code v)]
       (let [full-path (misc/transform-value (:file (info/file-info file)))]
-        (binding [*ns*   ns
+        (binding [*ns*   (find-ns ns)
                   *file* file
                   *msg*  (-> *msg*
                              (merge var-meta)

--- a/src/cider/nrepl/middleware/macroexpand.clj
+++ b/src/cider/nrepl/middleware/macroexpand.clj
@@ -4,7 +4,7 @@
   (:require
    [cider.nrepl.middleware.util.cljs :as cljs]
    [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
-   [cljs-tooling.util.analysis :as cljs-ana]
+   [orchard.cljs.analysis :as cljs-ana]
    [clojure.pprint :as pp]
    [clojure.tools.reader :as reader]
    [clojure.walk :as walk]

--- a/src/cider/nrepl/middleware/ns.clj
+++ b/src/cider/nrepl/middleware/ns.clj
@@ -5,8 +5,8 @@
    [cider.nrepl.middleware.util.coerce :as util.coerce]
    [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
    [cider.nrepl.middleware.util.meta :as um]
-   [cljs-tooling.info :as cljs-info]
-   [cljs-tooling.util.analysis :as cljs-analysis]
+   [orchard.info :as info]
+   [orchard.cljs.analysis :as cljs-analysis]
    [orchard.misc :as u]
    [orchard.namespace :as ns]
    [orchard.query :as query]))
@@ -62,11 +62,6 @@
          (u/update-keys name)
          (into (sorted-map)))))
 
-(defn ns-path-cljs [env ns]
-  (->> (symbol ns)
-       (cljs-info/info env)
-       (:file)))
-
 (defn ns-list [{:keys [filter-regexps] :as msg}]
   (if-let [cljs-env (cljs/grab-cljs-env msg)]
     (ns-list-cljs cljs-env)
@@ -84,7 +79,9 @@
 
 (defn ns-path [{:keys [ns] :as msg}]
   (if-let [cljs-env (cljs/grab-cljs-env msg)]
-    (ns-path-cljs cljs-env ns)
+    (:file (info/info* {:dialect :cljs
+                        :env cljs-env
+                        :sym (symbol ns)}))
     (.getPath (ns/canonical-source ns))))
 
 (defn ns-list-reply [msg]

--- a/src/cider/nrepl/middleware/stacktrace.clj
+++ b/src/cider/nrepl/middleware/stacktrace.clj
@@ -74,7 +74,7 @@
              :fn  (str/join "/" (cons fn anons))
              :var (str ns "/" fn)
              ;; Full file path
-             :file-url (or (some-> (info/info 'user (symbol (str ns "/" fn)))
+             :file-url (or (some-> (info/info* {:ns 'user :sym (symbol ns fn)})
                                    :file
                                    path->url
                                    u/transform-value)


### PR DESCRIPTION
This patch copies the leftover "business logic" from the `info` middleware to
the `orchard` `info` function. This will make the `info` function in `orchard`
self-contained, which is easier to test and more portable (one could use
`orchard` without the `nrepl` protocol for instance - say for a Language Server
Protocol implementation).

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [X] You've added tests to cover your change(s)
- [] All tests are passing