### PR TITLE
Remove :provided profile mapping in project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -54,9 +54,7 @@
                                     :password :env/clojars_password
                                     :sign-releases false}]]
 
-  :profiles {:provided [:1.8]
-
-             :dev {:dependencies [[boot/base "2.8.2"]
+  :profiles {:dev {:dependencies [[boot/base "2.8.2"]
                                   [boot/core "2.8.2"]
                                   [leiningen-core "2.8.3"]]}
 


### PR DESCRIPTION
This patch removes the :provided key as it seems not necessary for correctly
packaging and testing cider-nrepl. It actually gets kind of in the way when
testing where the :1.8 was always loaded regardless of the env var version.

It is more here for myself to know more but the doc says:

> The :provided profile is used to specify dependencies that should be
> available during jar creation, but not propagated to other code that depends
> on your project. These are dependencies that the project assumes will be
> provided by whatever environment the jar is used in, but are needed during
> the development of the project. This is often used for frameworks like Hadoop
> that provide their own copies of certain libraries.

