### PR TITLE
Allow for multiple Clojures when checking Clojure version

### DIFF
--- a/test/common/cider_nrepl/plugin_test.clj
+++ b/test/common/cider_nrepl/plugin_test.clj
@@ -15,7 +15,7 @@
 (deftest plugin-test
   ;; Suppress output of leiningen.core.main/warn
   (binding [lein/*info* false]
-    (with-redefs [lein/leiningen-version (constantly plugin/min-lein-version)]
+    (with-redefs [lein/leiningen-version (constantly (plugin/minimum-versions :lein))]
       (testing "Valid Lein version; valid Clojure version"
         (let [project (plugin/middleware '{:dependencies [[org.clojure/clojure "1.8.0"]]})]
           (is (contains-cider-nrepl-dep? project))
@@ -23,6 +23,12 @@
 
       (testing "Valid Lein version; no Clojure version specified"
         (let [project (plugin/middleware '{})]
+          (is (contains-cider-nrepl-dep? project))
+          (is (contains-cider-nrepl-middleware? project))))
+
+      (testing "Valid Lein version; multiple Clojure versions specified"
+        (let [project (plugin/middleware `{:dependencies [[org.clojure/clojure "1.5.1"]
+                                                          [org.clojure/clojure ~(plugin/minimum-versions :clojure)]]})]
           (is (contains-cider-nrepl-dep? project))
           (is (contains-cider-nrepl-middleware? project))))
 


### PR DESCRIPTION
## Problem:

Check out [nippy](https://github.com/ptaoussanis/nippy) and jack in. You are greeted with:

```shell
;; Clojure 1.10.0, Java 1.8.0_201                ;; <----------------- note 1.10.0
;;     Docs: (doc function-name)
;;           (find-doc part-of-name)
;;   Source: (source function-name)
;;  Javadoc: (javadoc java-object-or-class)
;;     Exit: <C-c C-q>
;;  Results: Stored in vars *1, *2, *3, an exception in *e;
WARNING: CIDER requires cider-nrepl to be fully functional. Many things will not work without it!
         More information.
user> 
```

If you run the start up command on the shell you are greeted with:

```bash
[dan@fedora nippy]$ /home/dan/bin/lein update-in :dependencies conj \[nrepl\ \"0.6.0\"\] -- update-in :plugins conj \[cider/cider-nrepl\ \.21.2-SNAPSHOT\"\] -- repl :headless :host localhost
Warning: cider-nrepl requires Clojure 1.8 or greater.    < ----------- startup thinks 1.5.1
Warning: cider-nrepl will not be included in your project.
```

## The reason

A common pattern is an old clojure in the deps and a modern clojure in
a profile

```clj
(defproject project
  :dependencies [[org.clojure/clojure "1.5.1"]]
  :profiles {:1.10 {:dependencies [[org.clojure/clojure "1.10.0"]]})
```
When checking for the clojure version allow for the presence of multiple clojure versions rather than just taking the first one.

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)

Keep in mind that new cider-nrepl builds are automatically deployed to Clojars
once a PR is merged, but **only** if the CI build is green.

*If you're just starting out to hack on cider-nrepl you might find
this [article](https://juxt.pro/blog/posts/nrepl.html) and the
"Design" section of the README extremely useful.*

Thanks!
