### PR TITLE
Upgrade mranderson to 0.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: xenial
 language: clojure
-lein: 2.8.3
+lein: 2.9.1
 cache:
   directories:
     - $HOME/.m2

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,13 @@ export CLOVERAGE_VERSION = 1.0.13
 JAVA_VERSION = $(shell lein with-profile +sysutils \
                        sysutils :java-version-simple | cut -d " " -f 2)
 
-.source-deps:
-	lein source-deps
-	touch .source-deps
+.inline-deps:
+	lein inline-deps
+	touch .inline-deps
 
-source-deps: .source-deps
+inline-deps: .inline-deps
 
-test: .source-deps
+test: .inline-deps
 	lein with-profile +$(CLOJURE_VERSION),+plugin.mranderson/config test
 
 eastwood:
@@ -24,7 +24,7 @@ cljfmt:
 cloverage:
 	lein with-profile +$(CLOJURE_VERSION),+cloverage cloverage
 
-install: .source-deps
+install: .inline-deps
 	lein with-profile +$(CLOJURE_VERSION),+plugin.mranderson/config install
 
 smoketest: install
@@ -52,10 +52,10 @@ release:
 # specified in project.clj to provide a login and password to the
 # artifact repository.
 
-deploy: .source-deps
+deploy: .inline-deps
 	lein with-profile +$(CLOJURE_VERSION),+plugin.mranderson/config deploy clojars
 
 clean:
 	lein clean
 	cd test/smoketest && lein clean
-	rm -f .source-deps
+	rm -f .inline-deps

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ avoid classpath collisions.
 To work with `mranderson` the first thing to do is:
 
 ```
-lein do clean, source-deps :project-prefix cider.inlined-deps
+lein do clean, inline-deps
 ```
 
 This creates the munged local dependencies in `target/srcdeps` directory.

--- a/project.clj
+++ b/project.clj
@@ -9,18 +9,19 @@
                  ^:source-dep [cider/orchard "0.4.0"]
                  ^:source-dep [thunknyc/profile "0.5.2"]
                  ^:source-dep [mvxcvi/puget "1.1.0"]
-                 ^:source-dep [fipp "0.6.15"]
+                 ^:source-dep [fipp "0.6.15"]; can be removed in unresolved-tree mode
                  ^:source-dep [compliment "0.3.8"]
                  ^:source-dep [cljs-tooling "0.3.1"]
                  ^:source-dep [cljfmt "0.6.4" :exclusions [org.clojure/clojurescript]]
-                 ;; Not used directly in cider-nrepl, but needed because of tools.namespace
-                 ;; and the way MrAnderson processes dependencies
-                 ;; See https://github.com/clojure-emacs/cider/issues/2176 for details
-                 ^:source-dep [org.clojure/java.classpath "0.3.0"]
                  ^:source-dep [org.clojure/tools.namespace "0.3.0-alpha4"]
                  ^:source-dep [org.clojure/tools.trace "0.7.10"]
                  ^:source-dep [org.clojure/tools.reader "1.2.2"]]
-  :plugins [[thomasa/mranderson "0.4.9"]]
+  :plugins [[thomasa/mranderson "0.5.0"]]
+  :mranderson {:project-prefix "cider.nrepl.inlined-deps"
+               :overrides       {[mvxcvi/puget fipp] [fipp "0.6.15"]}; only takes effect in unresolved-tree mode
+               :expositions     [[mvxcvi/puget fipp]]; only takes effect unresolved-tree mode
+               :unresolved-tree false}
+
   :exclusions [org.clojure/clojure]
 
   :filespecs [{:type :bytes :path "cider/cider-nrepl/project.clj" :bytes ~(slurp "project.clj")}]


### PR DESCRIPTION
mranderson 0.5.x specific config added to the project file as
well. **Resolved tree** mode is used. This means that
mranderson works with a resolved dependency tree and does not create a
deeply nested directory structure, only adds prefixes to all
dependencies. Handles all depedendencies as first level ones and
processes them in a topological order.

Add project prefix in the project file for mranderson, also some
config for **unresolved tree** if that would get used in the near
future.

Breaking changes in mranderson are followed up in Makefile and README

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the README (if adding/changing middleware)
