### PR TITLE
plugin: ensure there is a version to check to begin with

### DIFF
--- a/src/cider_nrepl/plugin.clj
+++ b/src/cider_nrepl/plugin.clj
@@ -22,7 +22,8 @@
         clojure-versions    (when-not clojure-excluded?
                               (->> dependencies
                                    (keep (fn [[id version & _]]
-                                           (when (= id 'org.clojure/clojure)
+                                           (when (and (= id 'org.clojure/clojure)
+                                                      (string? version))
                                              version)))))
         clojure-version-ok? (cond clojure-excluded?
                                   ;; In this case the onus is on the user. A warning will be emitted

--- a/src/cider_nrepl/plugin.clj
+++ b/src/cider_nrepl/plugin.clj
@@ -23,6 +23,10 @@
                               (->> dependencies
                                    (keep (fn [[id version & _]]
                                            (when (and (= id 'org.clojure/clojure)
+                                                      ;; We do an additional check here to ensure
+                                                      ;; a version is present. Some lein extensions
+                                                      ;; such as lein modules or managed dependencies
+                                                      ;; do not require versions in the dependency list
                                                       (string? version))
                                              version)))))
         clojure-version-ok? (cond clojure-excluded?

--- a/test/clj/cider/nrepl/plugin_test.clj
+++ b/test/clj/cider/nrepl/plugin_test.clj
@@ -1,0 +1,42 @@
+(ns cider.nrepl.plugin-test
+  (:require [cider-nrepl.plugin :refer :all]
+            [cider.nrepl.version :refer [version-string]]
+            [clojure.test :refer :all]))
+
+
+(def expected-output
+  {:dependencies
+   [['org.clojure/clojure]
+    ['cider/cider-nrepl version-string]],
+   :repl-options
+   {:nrepl-middleware
+    '[cider.nrepl/wrap-apropos
+      cider.nrepl/wrap-classpath
+      cider.nrepl/wrap-complete
+      cider.nrepl/wrap-debug
+      cider.nrepl/wrap-enlighten
+      cider.nrepl/wrap-format
+      cider.nrepl/wrap-info
+      cider.nrepl/wrap-inspect
+      cider.nrepl/wrap-macroexpand
+      cider.nrepl/wrap-slurp
+      cider.nrepl/wrap-ns
+      cider.nrepl/wrap-out
+      cider.nrepl/wrap-content-type
+      cider.nrepl/wrap-slurp
+      cider.nrepl/wrap-profile
+      cider.nrepl/wrap-refresh
+      cider.nrepl/wrap-resource
+      cider.nrepl/wrap-spec
+      cider.nrepl/wrap-stacktrace
+      cider.nrepl/wrap-test
+      cider.nrepl/wrap-trace
+      cider.nrepl/wrap-tracker
+      cider.nrepl/wrap-undef
+      cider.nrepl/wrap-version
+      cider.nrepl/wrap-xref]}})
+
+(deftest version-checks
+  (testing "undefined versions work"
+    (is (= expected-output
+           (middleware {:dependencies [['org.clojure/clojure]]})))))

--- a/test/clj/cider/nrepl/plugin_test.clj
+++ b/test/clj/cider/nrepl/plugin_test.clj
@@ -40,3 +40,8 @@
   (testing "undefined versions work"
     (is (= expected-output
            (middleware {:dependencies [['org.clojure/clojure]]})))))
+
+(deftest version-checks
+  (testing "defined versions also work"
+    (is (= (update-in expected-output [:dependencies 0 0] conj "1.10.0")
+           (middleware {:dependencies [['org.clojure/clojure "1.10.0"]]})))))


### PR DESCRIPTION
When using dependency supplying modules such as `lein-modules`,
by the time cider-nrepl does its version check it has no indication
of version.

In this case, the code throws leaving no chance to the REPL to
be spun up.

When versions are unavailable, assume the project knows what it
is doing instead and discard it from the version check altogether.

