### PR TITLE
[debugger] Add P command to inspect the currently evaluted value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#605](https://github.com/clojure-emacs/cider-nrepl/pull/605): Added a option for filtering vars to the ns-vars middleware.
 * Added `xref` middleware providing `fn-deps` and `fn-refs` ops.
+* [#613](https://github.com/clojure-emacs/cider-nrepl/pull/613): Inspect the current value by pressing `p` in the debugger. To inspect arbitrary value, press `P`.
 
 ### Bugs fixed
 

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -305,6 +305,7 @@ this map (identified by a key), and will `dissoc` it afterwards."}
    "n" :next
    "o" :out
    "p" :inspect
+   "P" :insPect
    "q" :quit
    "s" :stacktrace
    "t" :trace})
@@ -365,11 +366,14 @@ this map (identified by a key), and will `dissoc` it afterwards."}
         :locals     (->> (debug-inspect page-size (:locals dbg-state))
                          (assoc dbg-state :inspect)
                          (recur value))
-        :inspect    (try-if-let [val (read-eval-expression "Inspect value: " dbg-state code)]
-                      (->> (debug-inspect page-size val)
-                           (assoc dbg-state :inspect)
-                           (recur value))
-                      (recur value dbg-state))
+        :inspect    (->> (debug-inspect page-size value)
+                         (assoc dbg-state :inspect)
+                         (recur value))
+        :insPect    (try-if-let [val (read-eval-expression "Inspect value: " dbg-state code)]
+                                (->> (debug-inspect page-size val)
+                                     (assoc dbg-state :inspect)
+                                     (recur value))
+                                (recur value dbg-state))
         :inject     (try-if-let [val (read-eval-expression "Expression to inject: " dbg-state code)]
                       val
                       (recur value dbg-state))


### PR DESCRIPTION
I can't possibly count how many times I struggled to inspect the value that is right there in the debugger, right next to my cursor, teasing me with its printed representation, but impossible to inspect because I didn't `let` it to anything.

These times are no more. This little fix will make it possible to press `P` while in the debugger to inspect the value of the latest debugging step.