### PR TITLE
Fix cider.tasks/nrepl-server

### DIFF
--- a/src/cider/tasks.clj
+++ b/src/cider/tasks.clj
@@ -30,7 +30,7 @@
   (let [default-mws @@(resolve 'boot.repl/*default-middleware*)]
     (util/dbug* "nREPL middleware: %s\n" (vec default-mws))
     (boot.core/with-pass-thru [_]
-      (require 'cider-nrepl.main)
-      ((resolve 'cider-nrepl.main/start-nrepl) {:middleware default-mws
-                                                :port port
-                                                :bind bind}))))
+      (require 'nrepl.cmdline)
+      ((resolve 'nrepl.cmdline/dispatch-commands) {:middleware default-mws
+                                                   :port port
+                                                   :bind bind}))))


### PR DESCRIPTION
It had been broken after the removal of `cider-nrepl.main`. The functionality is
now restored by delegating to `nrepl.cmdline/dispatch-commands`. Probably some
renaming and/or refactoring is necessary in nrepl for programmatic use.


Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)
