### PR TITLE
Move resource implementation to orchard

### DIFF
--- a/src/cider/nrepl/middleware/resource.clj
+++ b/src/cider/nrepl/middleware/resource.clj
@@ -1,58 +1,10 @@
 (ns cider.nrepl.middleware.resource
   (:require
    [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
-   [clojure.java.io :as io]
-   [clojure.string :as str]
-   [orchard.classpath :as cp]
-   [orchard.misc :as u]))
-
-(defn- trim-leading-separator
-  [s]
-  (if (.startsWith s java.io.File/separator)
-    (subs s 1)
-    s))
-
-(defn- get-project-resources
-  []
-  (mapcat
-   (fn [directory]
-     (->> directory
-          (file-seq)
-          (filter (memfn isFile))
-          (map (fn [file]
-                 (let [relpath (-> file
-                                   (.getPath)
-                                   (.replaceFirst
-                                    (.getPath directory)
-                                    "")
-                                   (trim-leading-separator))]
-                   {:root directory
-                    :file file
-                    :relpath relpath
-                    :url (io/resource relpath)})))
-          (remove #(.startsWith (:relpath %) "META-INF/"))
-          (remove #(re-matches #".*\.(clj[cs]?|java|class)" (:relpath %)))))
-   (filter (memfn isDirectory) (map io/as-file (cp/classpath (cp/boot-aware-classloader))))))
-
-(defn resource-path [name]
-  (when-let [resource (io/resource name (cp/boot-aware-classloader))]
-    (.getPath resource)))
-
-(defn resources-list
-  "Return a list of dictionaries containing file and relpath: file is the
-  absolute path to the resource, relpath is the path of the resource relative
-  to the classpath."
-  [_]
-  (map #(select-keys % [:file :relpath])
-       (get-project-resources)))
-
-(defn resource-reply [{:keys [name] :as msg}]
-  {:resource-path (resource-path name)})
-
-(defn resources-list-reply [msg]
-  {:resources-list (u/transform-value (resources-list msg))})
+   [orchard.misc :as u]
+   [orchard.resource :as resource]))
 
 (defn handle-resource [handler msg]
   (with-safe-transport handler msg
-    "resource" resource-reply
-    "resources-list" resources-list-reply))
+    "resource" {:resource-path (resource/resource-path (:name msg))}
+    "resources-list" {:resources-list (u/transform-value (resource/resource-maps))}))

--- a/src/cider/nrepl/middleware/stacktrace.clj
+++ b/src/cider/nrepl/middleware/stacktrace.clj
@@ -10,10 +10,10 @@
    [nrepl.misc :refer [response-for]]
    [nrepl.transport :as t]
    [orchard.info :as info]
-   [orchard.resource :as resource]
    [orchard.java :as java]
    [orchard.misc :as u]
-   [orchard.namespace :as namespace])
+   [orchard.namespace :as namespace]
+   [orchard.resource :as resource])
   (:import
    (clojure.lang Compiler$CompilerException)
    (java.io StringWriter)))

--- a/test/clj/cider/nrepl/middleware/resource_test.clj
+++ b/test/clj/cider/nrepl/middleware/resource_test.clj
@@ -1,7 +1,6 @@
 (ns cider.nrepl.middleware.resource-test
   (:require
    [cider.nrepl.test-session :as session]
-   [cider.nrepl.middleware.resource :as r]
    [clojure.test :refer :all]))
 
 (use-fixtures :once session/session-fixture)
@@ -19,17 +18,3 @@
                        (:resources-list response))))
       (is (seq (filter #(re-matches #".*test/resources/test\.txt" (:file %))
                        (:resources-list response)))))))
-
-(deftest resource-op-error-handling-test
-  (with-redefs [r/resource-path (fn [& _] (throw (Exception. "resource")))]
-    (let [response (session/message {:op "resource" :name "test.txt"})]
-      (is (= "class java.lang.Exception" (:ex response)))
-      (is (= #{"done" "resource-error"} (:status response)))
-      (is (:pp-stacktrace response)))))
-
-(deftest resources-list-op-error-handling-test
-  (with-redefs [r/resources-list (fn [& _] (throw (Exception. "resources list")))]
-    (let [response (session/message {:op "resources-list"})]
-      (is (= "class java.lang.Exception" (:ex response)))
-      (is (= #{"done" "resources-list-error"} (:status response)))
-      (is (:pp-stacktrace response)))))


### PR DESCRIPTION
This patch moves the code for the resource op down into the orchard.


Before submitting a PR make sure the following things have been done:

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [X] All tests are passing