### PR TITLE
Ensure ns-query map is built correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bugs fixed
 
+* [#618](https://github.com/clojure-emacs/cider-nrepl/pull/618): Fix apropos to honor exclude-regexps to filter out namespaces by regex
 * [#605](https://github.com/clojure-emacs/cider-nrepl/pull/605): Fix `ns-vars-with-meta` to return public vars.
 
 ### Changes


### PR DESCRIPTION
The required structure for the 'query/var' function is `{:var-query
{:ns-query {...}}`. The older implementation did not grab those
keywords from the cider message and put them at the correct
level. they were left top level and then missed by the
`query/namespace` function.

In addition to this, there was a bug in orchard which had the wrong
prefix for inlined deps so these were not omitted in _2_ places: both
in the client-side specification of which namespaces to ignore and
orchard's own mechanism to elide cider's internal namespaces.

See related:
- orchard https://github.com/clojure-emacs/orchard/pull/59/
- CIDER

Before submitting a PR make sure the following things have been done:

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [ ] All tests are passing
- [ ] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)

Keep in mind that new cider-nrepl builds are automatically deployed to Clojars
once a PR is merged, but **only** if the CI build is green.

*If you're just starting out to hack on cider-nrepl you might find
this [article](https://juxt.pro/blog/posts/nrepl.html) and the
"Design" section of the README extremely useful.*

Thanks!
