### PR TITLE
Fix last test failing on CI

### DIFF
--- a/test/clj/cider/nrepl/middleware/info_test.clj
+++ b/test/clj/cider/nrepl/middleware/info_test.clj
@@ -158,7 +158,7 @@
         (is (= (:argtypes response) []))
         (is (= (:returns response) "int"))
         (is (= (:modifiers response) "#{:public :bridge :synthetic}"))
-        (is (.startsWith (:javadoc response) "https://docs.oracle.com/javase")))
+        (is (.startsWith (:javadoc response) "https://docs.oracle.com/")))
 
       (if (SystemUtils/IS_JAVA_1_8)
         (testing "JDK 1.8 Javadoc URL style"


### PR DESCRIPTION
Tests response from javadoc. Failing on java 11 expecting
"https://docs.oracle.com/javase" for both java 8 and 11. On 11 have
the following response:

Clearly fine just bad prefix

```
{:javadoc
  "https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java.base/java/lang/StringBuilder.html#capacity()",
  :throws [],
  :file [],
  :arglists-str "[this]",
  :argtypes [],
  :member "capacity",
  :modifiers "#{:public :bridge :synthetic}",
  :status #{"done"},
  :id "5174fd6d-4f65-4524-babb-07bc2ef2dcb3",
  :class "java.lang.StringBuilder",
  :returns "int",
  :session #{"b85884cb-3503-428c-8123-5c970dd08605"}}
```

Before submitting a PR make sure the following things have been done:

- [ ] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [ ] All tests are passing
- [ ] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)

Keep in mind that new cider-nrepl builds are automatically deployed to Clojars
once a PR is merged, but **only** if the CI build is green.

*If you're just starting out to hack on cider-nrepl you might find
this [article](https://juxt.pro/blog/posts/nrepl.html) and the
"Design" section of the README extremely useful.*

Thanks!
