### PR TITLE
Fix dynamic font locking for fns defined with def in cljs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bugs fixed
 
+* Fix some functions defined with `def` not being properly font locked when using dynamic font locking for ClojureScript.
 * [#618](https://github.com/clojure-emacs/cider-nrepl/pull/618): Fix apropos to honor exclude-regexps to filter out namespaces by regex
 * [#605](https://github.com/clojure-emacs/cider-nrepl/pull/605): Fix `ns-vars-with-meta` to return public vars.
 

--- a/src/cider/nrepl/middleware/track_state.clj
+++ b/src/cider/nrepl/middleware/track_state.clj
@@ -40,10 +40,14 @@
                               [sym (um/relevant-meta the-meta)]))))))))
 
 (defn- cljs-meta-with-fn
-  "Like (:meta m) but adds {:fn true} if (:fn-var m) is true."
+  "Like (:meta m) but adds {:fn true} if (:fn-var m) is true, (:tag m) is
+  'function, or if m does not have a :tag key."
   [m]
   (cond-> (:meta m)
-    (:fn-var m) (assoc :fn true)))
+    (or (:fn-var m)
+        (= (:tag m) 'function)
+        (not (contains? m :tag)))
+    (assoc :fn true)))
 
 ;;; Namespaces
 

--- a/test/clj/cider/nrepl/middleware/track_state_test.clj
+++ b/test/clj/cider/nrepl/middleware/track_state_test.clj
@@ -121,18 +121,20 @@
 (deftest ns-as-map-cljs-test
   (let [cljs-ns {:use-macros {'sym-0 #'test-fn}
                  :uses {'sym-1 #'ns-as-map-cljs-test}
-                 :defs {'sym-2 #'ns-as-map-cljs-test
-                        'a-fn {:fn-var true}
-                        'a-var {}}
-                 :require-macros {'sym-3 'some-namespace}
-                 :requires {'sym-4 'some-namespace}}
+                 :defs {'a-fn {:fn-var true}
+                        'b-fn {:tag 'function}
+                        'c-fn {}
+                        'a-var {:tag 'something}}
+                 :require-macros {'sym-2 'some-namespace}
+                 :requires {'sym-3 'some-namespace}}
         {:keys [aliases interns]} (st/ns-as-map cljs-ns)]
-    (is (= '{sym-3 some-namespace sym-4 some-namespace} aliases))
+    (is (= '{sym-2 some-namespace sym-3 some-namespace} aliases))
     (is (= '{sym-0 {:arglists ([]) :macro true}
              sym-1 {:arglists ([])}
-             sym-2 {}
              a-var {}
-             a-fn {:fn "true"}}
+             a-fn {:fn "true"}
+             b-fn {:fn "true"}
+             c-fn {:fn "true"}}
            interns))))
 
 (deftest calculate-used-aliases-test


### PR DESCRIPTION
I have tried to fix an issue with some functions not being properly dynamically font-locked in ClojureScript.

As you can see in the diff, I have used the tags generated by, as far as I understand, `cljs.analyzer`. The following screen shot shows the result, as well as the tags given to the various definitions. You can see in the bottom vector the result, where of course functions are colored with green, and other values with orange.

![Results](https://i.imgur.com/CmrVZ0t.png)

Previously, only `fn1` and `fn5` would have been recognized as functions (and of course `comp`). As you can see, `fn7`, `fn8` and `fn8` are not recognized, but that is not something we can fix in CIDER, I guess.

I wrote made this pull request to get feedback---what do you think about this? Also, is there anything else I should do, such as adding a line in `CHANGELOG.md`? If so, should I add to cider's chanelog, cider-nrepl's changelog, or both? I was a bit unsure about that, which is why I haven't done it.