### PR TITLE
Fix compilation exception

### DIFF
--- a/src/cider/nrepl/middleware/stacktrace.clj
+++ b/src/cider/nrepl/middleware/stacktrace.clj
@@ -10,6 +10,7 @@
    [nrepl.misc :refer [response-for]]
    [nrepl.transport :as t]
    [orchard.info :as info]
+   [orchard.resource :as resource]
    [orchard.java :as java]
    [orchard.misc :as u]
    [orchard.namespace :as namespace])
@@ -43,7 +44,7 @@
 (defn- path->url
   "Return a url for the path, either relative to classpath, or absolute."
   [path]
-  (or (info/file-path path) (second (info/resource-path path))))
+  (or (info/file-path path) (second (resource/resource-path path))))
 
 (defn- frame->url
   "Return a java.net.URL to the file referenced in the frame, if possible.

--- a/src/cider/nrepl/middleware/stacktrace.clj
+++ b/src/cider/nrepl/middleware/stacktrace.clj
@@ -44,7 +44,7 @@
 (defn- path->url
   "Return a url for the path, either relative to classpath, or absolute."
   [path]
-  (or (info/file-path path) (second (resource/resource-path path))))
+  (or (info/file-path path) (second (resource/resource-path-tuple path))))
 
 (defn- frame->url
   "Return a java.net.URL to the file referenced in the frame, if possible.


### PR DESCRIPTION
Due to refactoring done in orchard `resource-path` function moved to
dedicated namespace `orchard.resource`

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the README (if adding/changing middleware)

Keep in mind that new cider-nrepl builds are automatically deployed to Clojars
once a PR is merged, but **only** if the CI build is green.

*If you're just starting out to hack on cider-nrepl you might find
this [article](https://juxt.pro/blog/posts/nrepl.html) and the
"Design" section of the README extremely useful.*

Thanks!
