### PR TITLE
Dynamically font lock multifns as fns in CljS

### DIFF
--- a/src/cider/nrepl/middleware/track_state.clj
+++ b/src/cider/nrepl/middleware/track_state.clj
@@ -45,7 +45,7 @@
   [m]
   (cond-> (:meta m)
     (or (:fn-var m)
-        (= (:tag m) 'function)
+        ('#{function cljs.core/MultiFn} (:tag m))
         (not (contains? m :tag)))
     (assoc :fn true)))
 

--- a/test/clj/cider/nrepl/middleware/track_state_test.clj
+++ b/test/clj/cider/nrepl/middleware/track_state_test.clj
@@ -123,7 +123,8 @@
                  :uses {'sym-1 #'ns-as-map-cljs-test}
                  :defs {'a-fn {:fn-var true}
                         'b-fn {:tag 'function}
-                        'c-fn {}
+                        'c-fn {:tag 'cljs.core/MultiFn}
+                        'd-fn {}
                         'a-var {:tag 'something}}
                  :require-macros {'sym-2 'some-namespace}
                  :requires {'sym-3 'some-namespace}}
@@ -134,7 +135,8 @@
              a-var {}
              a-fn {:fn "true"}
              b-fn {:fn "true"}
-             c-fn {:fn "true"}}
+             c-fn {:fn "true"}
+             d-fn {:fn "true"}}
            interns))))
 
 (deftest calculate-used-aliases-test


### PR DESCRIPTION
I discovered that multifns have a tag I didn't account for earlier, in #622