### PR TITLE
Move transform-value from the orchard to cider-nrepl

### DIFF
--- a/src/cider/nrepl/middleware/clojuredocs.clj
+++ b/src/cider/nrepl/middleware/clojuredocs.clj
@@ -1,14 +1,14 @@
 (ns cider.nrepl.middleware.clojuredocs
   (:require
+   [cider.nrepl.middleware.util :as util]
    [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
-   [orchard.clojuredocs :as docs]
-   [orchard.misc :as misc]))
+   [orchard.clojuredocs :as docs]))
 
 (defn- clojuredocs-lookup-reply [{:keys [export-edn-url ns symbol]}]
   (if-let [doc (if export-edn-url
                  (docs/find-doc ns symbol export-edn-url)
                  (docs/find-doc ns symbol))]
-    {:clojuredocs (misc/transform-value doc)}
+    {:clojuredocs (util/transform-value doc)}
     {:status :no-document}))
 
 (defn clojuredocs-refresh-cache-reply [{:keys [export-edn-url]}]

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -4,6 +4,7 @@
   (:require
    [cider.nrepl.middleware.inspect :refer [swap-inspector!]]
    [cider.nrepl.middleware.stacktrace :as stacktrace]
+   [cider.nrepl.middleware.util :as util]
    [cider.nrepl.middleware.util.cljs :as cljs]
    [cider.nrepl.middleware.util.instrument :as ins]
    [cider.nrepl.middleware.util.nrepl :refer [notify-client]]
@@ -14,8 +15,7 @@
    [nrepl.transport :as transport]
    [orchard.info :as info]
    [orchard.inspect :as inspect]
-   [orchard.meta :as m]
-   [orchard.misc :as misc])
+   [orchard.meta :as m])
   (:import
    [clojure.lang Compiler$LocalBinding]))
 
@@ -396,7 +396,7 @@ this map (identified by a key), and will `dissoc` it afterwards."}
   [v]
   (when-not (::instrumented (meta v))
     (when-let [{:keys [ns file form] :as var-meta} (m/var-code v)]
-      (let [full-path (misc/transform-value (:file (info/file-info file)))]
+      (let [full-path (util/transform-value (:file (info/file-info file)))]
         (binding [*ns*   (find-ns ns)
                   *file* file
                   *msg*  (-> *msg*
@@ -634,7 +634,7 @@ this map (identified by a key), and will `dissoc` it afterwards."}
   (->> (all-ns)
        (map #(cons (ns-name %) (ins/list-instrumented-defs %)))
        (filter second)
-       misc/transform-value
+       (util/transform-value)
        (response-for msg :status :done :list)
        (transport/send (:transport msg))))
 

--- a/src/cider/nrepl/middleware/info.clj
+++ b/src/cider/nrepl/middleware/info.clj
@@ -1,5 +1,6 @@
 (ns cider.nrepl.middleware.info
   (:require
+   [cider.nrepl.middleware.util :as util]
    [cider.nrepl.middleware.util.cljs :as cljs]
    [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
    [clojure.java.io :as io]
@@ -44,7 +45,7 @@
                    (info/javadoc-info path)))
           format-nested
           blacklist
-          u/transform-value))))
+          util/transform-value))))
 
 (defn info
   [{:keys [ns symbol class member] :as msg}]

--- a/src/cider/nrepl/middleware/ns.clj
+++ b/src/cider/nrepl/middleware/ns.clj
@@ -1,12 +1,13 @@
 (ns cider.nrepl.middleware.ns
   (:refer-clojure :exclude [ns-aliases])
   (:require
+   [cider.nrepl.middleware.util :as util]
    [cider.nrepl.middleware.util.cljs :as cljs]
    [cider.nrepl.middleware.util.coerce :as util.coerce]
    [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
    [cider.nrepl.middleware.util.meta :as um]
-   [orchard.info :as info]
    [orchard.cljs.analysis :as cljs-analysis]
+   [orchard.info :as info]
    [orchard.misc :as u]
    [orchard.namespace :as ns]
    [orchard.query :as query]))
@@ -107,15 +108,15 @@
 
 (defn- ns-aliases-clj [ns]
   (->> (symbol ns)
-       clojure.core/ns-aliases
+       (clojure.core/ns-aliases)
        (u/update-vals ns-name)
-       u/transform-value))
+       (util/transform-value)))
 
 (defn- ns-aliases-cljs [env ns]
   (->> (cljs-analysis/ns-aliases env ns)
        (remove (fn [[k v]] (= k v)))
        (into {})
-       u/transform-value))
+       (util/transform-value)))
 
 (defn ns-aliases [{:keys [ns] :as msg}]
   (if-let [cljs-env (cljs/grab-cljs-env msg)]

--- a/src/cider/nrepl/middleware/resource.clj
+++ b/src/cider/nrepl/middleware/resource.clj
@@ -1,10 +1,10 @@
 (ns cider.nrepl.middleware.resource
   (:require
+   [cider.nrepl.middleware.util :as util]
    [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
-   [orchard.misc :as u]
    [orchard.resource :as resource]))
 
 (defn handle-resource [handler msg]
   (with-safe-transport handler msg
     "resource" {:resource-path (resource/resource-path (:name msg))}
-    "resources-list" {:resources-list (u/transform-value (resource/resource-maps))}))
+    "resources-list" {:resources-list (util/transform-value (resource/resource-maps))}))

--- a/src/cider/nrepl/middleware/stacktrace.clj
+++ b/src/cider/nrepl/middleware/stacktrace.clj
@@ -2,6 +2,7 @@
   "Cause and stacktrace analysis for exceptions"
   {:author "Jeff Valk"}
   (:require
+   [cider.nrepl.middleware.util :as util]
    [clojure.repl :as repl]
    [clojure.set :as set]
    [clojure.string :as str]
@@ -58,7 +59,7 @@
           (str "." (last (.split ^String (:file frame)
                                  "\\.")))
           path->url
-          u/transform-value))
+          util/transform-value))
 
 (defn analyze-fn
   "Add namespace, fn, and var to the frame map when the source is a Clojure
@@ -78,14 +79,14 @@
              :file-url (or (some-> (info/info* {:ns 'user :sym (symbol ns fn)})
                                    :file
                                    path->url
-                                   u/transform-value)
-                           (u/transform-value (frame->url frame)))))
+                                   util/transform-value)
+                           (util/transform-value (frame->url frame)))))
     (assoc frame :file-url (some->
                             (java/resolve-symbol 'user
                                                  (symbol (:name frame)))
                             :file
                             path->url
-                            u/transform-value))))
+                            util/transform-value))))
 
 (defn analyze-file
   "Associate the file type (extension) of the source file to the frame map, and
@@ -207,7 +208,7 @@
              :file (:clojure.error/source location)
              :file-url (some-> (:clojure.error/source location)
                                path->url
-                               u/transform-value)
+                               util/transform-value)
              :path (relative-path (:clojure.error/source location))
              :line (:clojure.error/line location)
              :column (:clojure.error/column location))
@@ -218,7 +219,7 @@
                :file file
                :file-url (some-> file
                                  path->url
-                                 u/transform-value)
+                                 util/transform-value)
                :path (relative-path file)
                :line (Integer/parseInt line)
                :column (Integer/parseInt column))))

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -4,6 +4,7 @@
   (:require
    [cider.nrepl.middleware.stacktrace :as st]
    [cider.nrepl.middleware.test.extensions :as extensions]
+   [cider.nrepl.middleware.util :as util]
    [cider.nrepl.middleware.util.coerce :as util.coerce]
    [clojure.pprint :as pp]
    [clojure.test :as test]
@@ -283,7 +284,7 @@
                                  test-var-query
                                  stringify-msg)]
                   (reset! results (:results report))
-                  (t/send transport (response-for msg (u/transform-value report))))
+                  (t/send transport (response-for msg (util/transform-value report))))
                 (catch clojure.lang.ExceptionInfo e
                   (let [d (ex-data e)]
                     (if (::util.coerce/id d)
@@ -323,7 +324,7 @@
                                 {} @results)
                     report (test-nss nss)]
                 (reset! results (:results report))
-                (t/send transport (response-for msg (u/transform-value report))))))
+                (t/send transport (response-for msg (util/transform-value report))))))
           (fn []
             (t/send transport (response-for msg :status :done))))))
 

--- a/src/cider/nrepl/middleware/track_state.clj
+++ b/src/cider/nrepl/middleware/track_state.clj
@@ -2,6 +2,7 @@
   "State tracker for client sessions."
   {:author "Artur Malabarba"}
   (:require
+   [cider.nrepl.middleware.util :as util]
    [cider.nrepl.middleware.util.cljs :as cljs]
    [cider.nrepl.middleware.util.meta :as um]
    [cljs-tooling.util.analysis :as cljs-ana]
@@ -209,7 +210,7 @@
      (try (->> (response-for
                 msg :status :state
                 :repl-type (if cljs :cljs :clj)
-                :changed-namespaces (u/transform-value changed-ns-map))
+                :changed-namespaces (util/transform-value changed-ns-map))
                (transport-send-fn (:transport msg)))
           ;; We run async, so the connection might have been closed in
           ;; the mean time.

--- a/src/cider/nrepl/middleware/util.clj
+++ b/src/cider/nrepl/middleware/util.clj
@@ -1,0 +1,40 @@
+(ns cider.nrepl.middleware.util
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]))
+
+(defmulti transform-value "Transform a value for output" type)
+
+(defmethod transform-value :default [v] (str v))
+
+(defmethod transform-value Number [v] v)
+
+(defmethod transform-value nil [v] nil)
+
+(defmethod transform-value java.io.File
+  [v]
+  (.getAbsolutePath ^java.io.File v))
+
+(defmethod transform-value clojure.lang.Sequential
+  [v]
+  (list* (map transform-value v)))
+
+(defmethod transform-value clojure.lang.Symbol
+  [v]
+  (let [[the-ns the-name] [(namespace v) (name v)]]
+    (if the-ns
+      (str the-ns "/" the-name)
+      the-name)))
+
+(defmethod transform-value clojure.lang.Keyword
+  [v]
+  (transform-value (.sym ^clojure.lang.Keyword v)))
+
+(defmethod transform-value clojure.lang.Associative
+  [m]
+  (->> (for [[k v] m] ; bencode keys must be strings
+         [(str (transform-value k)) (transform-value v)])
+       (into {})))
+
+;; handles vectors
+(prefer-method transform-value clojure.lang.Sequential clojure.lang.Associative)


### PR DESCRIPTION
The transform-value function is moved here to cider-nrepl, where it belongs, as
it seems to be mainly related to presentation only.

PR friend of https://github.com/clojure-emacs/orchard/pull/66 

Before submitting a PR make sure the following things have been done:

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [X] All tests are passing
- [X] The new code is not generating reflection warnings
