### PR TITLE
Properly extract jar paths in `cider.nrepl.middleware.ns/ns-path`

### DIFF
--- a/src/cider/nrepl/middleware/ns.clj
+++ b/src/cider/nrepl/middleware/ns.clj
@@ -83,7 +83,7 @@
     (:file (info/info* {:dialect :cljs
                         :env cljs-env
                         :sym (symbol ns)}))
-    (.getPath (ns/canonical-source ns))))
+    (str (ns/canonical-source ns))))
 
 (defn ns-list-reply [msg]
   {:ns-list (ns-list msg)})

--- a/test/clj/cider/nrepl/middleware/ns_test.clj
+++ b/test/clj/cider/nrepl/middleware/ns_test.clj
@@ -101,7 +101,8 @@
         core-path (:path (session/message {:op "ns-path"
                                            :ns "clojure.core"}))]
     (is (.endsWith ns-path "cider/nrepl/middleware/ns.clj"))
-    (is (.endsWith core-path "clojure/core.clj"))))
+    (is (.endsWith core-path "clojure/core.clj"))
+    (is (.startsWith core-path "jar:"))))
 
 (deftest ns-load-all-integration-test
   (let [loaded-ns (:loaded-ns (session/message {:op "ns-load-all"}))]


### PR DESCRIPTION
Fixes https://github.com/clojure-emacs/cider/issues/2681#issuecomment-520196771
Allowing cider-find-ns to open files in jars.

- [X] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [X] You've added tests to cover your change(s)
- [X] All tests are passing
- [X] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)
