### PR TITLE
Integrate the new suitable ClojureScript completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 * [#664](https://github.com/clojure-emacs/cider-nrepl/pull/664): Fix continue-all in conditional break.
 * [#665](https://github.com/clojure-emacs/cider-nrepl/pull/665): Fix form location in map literals.
 
+### Changes
+
+* [#641](https://github.com/clojure-emacs/cider-nrepl/pull/641): Integrate the new suitable ClojureScript completion.
+
 ## 0.23.0 (2019-01-18)
 
 ### New Features

--- a/project.clj
+++ b/project.clj
@@ -4,15 +4,13 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/clojure-emacs/cider-nrepl"}
-
   :dependencies [[nrepl "0.6.0"]
                  ^:inline-dep [cider/orchard "0.5.5"]
                  ^:inline-dep [thunknyc/profile "0.5.2"]
                  ^:inline-dep [mvxcvi/puget "1.2.0"]
                  ^:inline-dep [fipp "0.6.22"] ; can be removed in unresolved-tree mode
                  ^:inline-dep [compliment "0.3.10"]
-                 ^:inline-dep [cljs-tooling "0.3.1"]
-                 ^:inline-dep [org.rksm/suitable "0.2.14" :exclusions [org.clojure/clojurescript]]
+                 ^:inline-dep [org.rksm/suitable "0.3.5" :exclusions [org.clojure/clojurescript]]
                  ^:inline-dep [cljfmt "0.6.6" :exclusions [org.clojure/clojurescript]]
                  ^:inline-dep [org.clojure/tools.namespace "0.3.1"]
                  ^:inline-dep [org.clojure/tools.trace "0.7.10"]

--- a/src/cider/nrepl/middleware/complete.clj
+++ b/src/cider/nrepl/middleware/complete.clj
@@ -2,33 +2,46 @@
   (:require
    [cider.nrepl.middleware.util.cljs :as cljs]
    [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
-   [cljs-tooling.complete :as cljs-complete]
-   [compliment.core :as jvm-complete]
-   [compliment.utils :as jvm-complete-utils]
+   [compliment.core :as complete]
+   [compliment.utils :as complete-utils]
    [orchard.misc :as misc]
-   [suitable.complete-for-nrepl :as suitable]))
+   [suitable.complete-for-nrepl :as suitable]
+   [suitable.compliment.sources.cljs :as suitable-sources]))
 
-(defn- cljs-complete
-  [{:keys [enhanced-cljs-completion?] :as msg} cljs-env ns prefix extra-metadata]
-  (concat (cljs-complete/completions cljs-env prefix {:context-ns ns
-                                                      :extra-metadata extra-metadata})
-          (when enhanced-cljs-completion? (suitable/complete-for-nrepl msg))))
+(def clj-sources
+  "Source keywords for Clojure completions."
+  [:compliment.sources.special-forms/literals
+   :compliment.sources.class-members/static-members
+   :compliment.sources.ns-mappings/ns-mappings
+   :compliment.sources.resources/resources
+   :compliment.sources.keywords/keywords
+   :compliment.sources.local-bindings/local-bindings
+   :compliment.sources.class-members/members
+   :compliment.sources.namespaces-and-classes/namespaces-and-classes
+   :compliment.sources.special-forms/special-forms])
+
+(def cljs-sources
+  "Source keywords for ClojureScript completions."
+  [::suitable-sources/cljs-source])
 
 (defn complete
-  [{:keys [ns symbol context extra-metadata] :as msg}]
-  (let [ns (misc/as-sym ns)
-        prefix (str symbol)
-        extra-metadata (set (map keyword extra-metadata))]
+  [{:keys [ns symbol context extra-metadata enhanced-cljs-completion?] :as msg}]
+  (let [prefix (str symbol)
+        completion-opts {:ns (misc/as-sym ns)
+                         :context context
+                         :extra-metadata (set (map keyword extra-metadata))}]
     (if-let [cljs-env (cljs/grab-cljs-env msg)]
-      (cljs-complete msg cljs-env ns prefix extra-metadata)
-      (jvm-complete/completions prefix {:ns ns
-                                        :context context
-                                        :extra-metadata extra-metadata}))))
+      (binding [suitable-sources/*compiler-env* cljs-env]
+        (concat (complete/completions prefix (merge completion-opts {:sources cljs-sources}))
+                (when enhanced-cljs-completion? (suitable/complete-for-nrepl msg))))
+      (complete/completions prefix (merge completion-opts {:sources clj-sources})))))
 
 (defn completion-doc
   [{:keys [ns symbol] :as msg}]
-  (when-not (cljs/grab-cljs-env msg)
-    (jvm-complete/documentation (str symbol) (misc/as-sym ns))))
+  (if-let [cljs-env (cljs/grab-cljs-env msg)]
+    (binding [suitable-sources/*compiler-env* cljs-env]
+      (complete/documentation (str symbol) (misc/as-sym ns) {:sources cljs-sources}))
+    (complete/documentation (str symbol) (misc/as-sym ns) {:sources clj-sources})))
 
 (defn complete-reply [msg]
   {:completions (complete msg)})
@@ -39,7 +52,7 @@
 
 (defn flush-caches-reply
   [msg]
-  (jvm-complete-utils/flush-caches)
+  (complete-utils/flush-caches)
   {})
 
 (defn handle-complete [handler msg]

--- a/src/cider/nrepl/middleware/track_state.clj
+++ b/src/cider/nrepl/middleware/track_state.clj
@@ -5,7 +5,7 @@
    [cider.nrepl.middleware.util :as util]
    [cider.nrepl.middleware.util.cljs :as cljs]
    [cider.nrepl.middleware.util.meta :as um]
-   [cljs-tooling.util.analysis :as cljs-ana]
+   [orchard.cljs.analysis :as cljs-ana]
    [clojure.java.io :as io]
    [clojure.tools.namespace.find :as ns-find]
    [nrepl.misc :refer [response-for]]


### PR DESCRIPTION
This patch adds the new feature to `cider-nrepl` and also deprecates
`cljs-tooling`.

It depends on the new version of `clj-suitable` and `compliment`.


Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [ ] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)

**Note:** If you're just starting out to hack on `cider-nrepl` you might find
[nREPL's documentation](https://nrepl.org) and the
"Design" section of the README extremely useful.*

Thanks!