### PR TITLE
suitable upgrade to 0.2.6

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  ^:inline-dep [fipp "0.6.18"] ; can be removed in unresolved-tree mode
                  ^:inline-dep [compliment "0.3.9"]
                  ^:inline-dep [cljs-tooling "0.3.1"]
-                 ^:inline-dep [org.rksm/suitable "0.2.5" :exclusions [org.clojure/clojurescript]]
+                 ^:inline-dep [org.rksm/suitable "0.2.6" :exclusions [org.clojure/clojurescript]]
                  ^:inline-dep [cljfmt "0.6.4" :exclusions [org.clojure/clojurescript]]
                  ^:inline-dep [org.clojure/tools.namespace "0.3.1"]
                  ^:inline-dep [org.clojure/tools.trace "0.7.10"]


### PR DESCRIPTION
This fixes calls to suitable when the completion context contains no
`__prefix__` (e.g. when typing the metadata of a ns like `(ns ^foo| bar.baz)`)

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)

**Note:** If you're just starting out to hack on `cider-nrepl` you might find
[nREPL's documentation](https://nrepl.org) and the
"Design" section of the README extremely useful.*

Thanks!
