### PR TITLE
Fix execution order for (is (= a b c))

### DIFF
--- a/src/cider/nrepl/middleware/test/extensions.clj
+++ b/src/cider/nrepl/middleware/test/extensions.clj
@@ -13,8 +13,8 @@
 (defn =-body
   [msg expected more]
   (if (seq more)
-    `(let [more# (list ~@more)
-           expected# ~expected
+    `(let [expected# ~expected
+           more# (list ~@more)
            result# (apply = expected# more#)]
        (->> (if result#
               {:type :pass}

--- a/test/clj/cider/nrepl/middleware/test/extensions_test.clj
+++ b/test/clj/cider/nrepl/middleware/test/extensions_test.clj
@@ -9,4 +9,15 @@
              `(let [~'x (atom 0)]
                 ~(extensions/=-body "" '(swap! x inc) '(1))
                 (deref ~'x)))]
-      (is (= 1 x)))))
+      (is (= 1 x))))
+  (testing "Evaluates forms in the right order"
+    (let [a (atom 0)]
+      (is (= (- (swap! a inc) 1)
+             (- (swap! a inc) 2)
+             (- (swap! a inc) 3)
+             (- (swap! a inc) 4)
+             (- (swap! a inc) 5)
+             (- (swap! a inc) 6)
+             (- (swap! a inc) 7)
+             (- (swap! a inc) 8)
+             (- (swap! a inc) 9))))))


### PR DESCRIPTION
The current implementation of `=-body` evaluates the rest of the arguments to `=` before evaluating the first argument. This causes problems in the presence of side-effects.