### PR TITLE
Respect default *print-length* and *print-level* in debugger output

### DIFF
--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -182,8 +182,10 @@ this map (identified by a key), and will `dissoc` it afterwards."}
 (defn pr-short
   "Like `pr-str` but limited in length and depth."
   [x]
-  (binding [*print-length* (:length @print-options)
-            *print-level*  (:level @print-options)]
+  (binding [*print-length* (or (:length @print-options)
+                               *print-length*)
+            *print-level*  (or (:level @print-options)
+                               *print-level*)]
     ;; TODO: Make it possible to use a random print function here
     (pr-str x)))
 


### PR DESCRIPTION
Fixes https://github.com/clojure-emacs/cider/issues/2621

I'm not familiar at all with the internals of `cider-nrepl`, but having been annoyed by the above issue one too many times I decided to grep for `*print-length*` in this repo and found that simply changing these lines solved the issue. 

Perhaps there's a better way to tackle it, hopefully this PR gives a starting point :)

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [x] All tests are passing
- [ ] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)

