### PR TITLE
Add inspect-def-current-value to inspect middleware

### DIFF
--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -239,6 +239,12 @@
               "inspect-clear"
               {:doc "Clears the state state of the inspector."
                :requires {"session" "The current session"}
+               :returns {"status" "\"done\""}}
+              "inspect-def-current-value"
+              {:doc "Define the currently inspected value as a var with the given var-name in the provided namespace."
+               :requires {"session" "The current session"
+                          "ns" "Namespace to define var on"
+                          "var-name" "The var name"}
                :returns {"status" "\"done\""}}}}))
 
 (def-wrapper wrap-macroexpand cider.nrepl.middleware.macroexpand/handle-macroexpand

--- a/src/cider/nrepl/middleware/inspect.clj
+++ b/src/cider/nrepl/middleware/inspect.clj
@@ -87,6 +87,9 @@
 (defn clear-reply [msg]
   (inspector-response msg (swap-inspector! msg (constantly (inspect/fresh)))))
 
+(defn def-current-value [msg]
+  (inspector-response msg (swap-inspector! msg inspect/def-current-value (symbol (:ns msg)) (:var-name msg))))
+
 (defn handle-inspect [handler msg]
   (if (= (:op msg) "eval")
     (eval-reply handler msg)
@@ -99,4 +102,5 @@
       "inspect-next-page" next-page-reply
       "inspect-prev-page" prev-page-reply
       "inspect-set-page-size" set-page-size-reply
-      "inspect-clear" clear-reply)))
+      "inspect-clear" clear-reply
+      "inspect-def-current-value" def-current-value)))

--- a/test/clj/cider/nrepl/middleware/inspect_test.clj
+++ b/test/clj/cider/nrepl/middleware/inspect_test.clj
@@ -280,3 +280,20 @@
                    (first (:value (session/message {:op "eval"
                                                     :inspect "true"
                                                     :code "(range 100)"}))))))))
+
+(deftest inspect-def-current-value-test
+  (testing "inspect-def-current-value defines a var with the current inspector value"
+    (is (= "{3 4}"
+           (first (:value (do
+                            (session/message {:op "eval"
+                                              :code "(def test-val [{1 2} {3 4}])"})
+                            (session/message {:op "eval"
+                                              :inspect "true"
+                                              :code "test-val"})
+                            (session/message {:op "inspect-push"
+                                              :idx 2})
+                            (session/message {:op "inspect-def-current-value"
+                                              :ns "user"
+                                              :var-name "sub-map"})
+                            (session/message {:op "eval"
+                                              :code "sub-map"}))))))))


### PR DESCRIPTION
This PR adds inspect-def-current-value that will enable cider-inspector to define a var in your current namespace with a given name and current inspector value.

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)