### PR TITLE
Change representation of debug-commands to a set of command names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## master (unreleased)
 
 ### New Features
-
-* [#653](https://github.com/clojure-emacs/cider-nrepl/pull/653): Add `inspect-def-current-value` to inspect middleware.
+* [#654](https://github.com/clojure-emacs/cider-nrepl/pull/654): 
+  Change the format of debugger command messages to a set of command names, leaving key mappings up to client implementations.
+  * [#653](https://github.com/clojure-emacs/cider-nrepl/pull/653): Add `inspect-def-current-value` to inspect middleware.
 
 ## 0.22.4 (2019-10-08)
 

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -297,19 +297,20 @@ this map (identified by a key), and will `dissoc` it afterwards."}
                               last :stacktrace)}]}))
 
 (def debug-commands
-  {"c" :continue
-   "C" :Continue
-   "e" :eval
-   "h" :here
-   "i" :in
-   "j" :inject
-   "l" :locals
-   "n" :next
-   "o" :out
-   "p" :inspect
-   "q" :quit
-   "s" :stacktrace
-   "t" :trace})
+  "An unsorted set of commands supported by the debugger."
+  #{:continue
+    :Continue
+    :eval
+    :here
+    :in
+    :inject
+    :locals
+    :next
+    :out
+    :inspect
+    :quit
+    :stacktrace
+    :trace})
 
 (defn read-debug-command
   "Read and take action on a debugging command.
@@ -337,8 +338,8 @@ this map (identified by a key), and will `dissoc` it afterwards."}
                           :coor coor
                           :locals locals)]
     (let [commands     (cond-> debug-commands
-                         (not (map? *msg*))         (dissoc "q")
-                         (nil? (:locals dbg-state)) (dissoc "e" "j" "l" "p")
+                         (not (map? *msg*))         (disj :quit)
+                         (nil? (:locals dbg-state)) (disj :eval :inject :locals :inspect)
                          (cljs/grab-cljs-env *msg*) identity)
           response-raw (read-debug-input dbg-state commands nil)
           dbg-state    (dissoc dbg-state :inspect)

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -299,7 +299,7 @@ this map (identified by a key), and will `dissoc` it afterwards."}
 (def debug-commands
   "An unsorted set of commands supported by the debugger."
   #{:continue
-    :Continue
+    :continue-all
     :eval
     :here
     :in
@@ -317,13 +317,17 @@ this map (identified by a key), and will `dissoc` it afterwards."}
   Ask for one of the following debug commands using `read-debug-input`:
 
     next: Return value.
-    continue: Skip breakpoints for the remainder of this eval session.
+    continue: Skip the current breakpoint.
+    continue-all: Skip breakpoints for the remainder of this eval session.
+    in: Step into a function
     out: Skip breakpoints in the current sexp.
-    inspect: Evaluate an expression and inspect it.
+    here: Skip all breakpoints up till specified coordinate `coord`
+    inspect: Prompt for an expression to evaluate and inspect it.
     locals: Inspect local variables.
     inject: Evaluate an expression and return it.
     eval: Evaluate an expression, display result, and prompt again.
     stacktrace: Print the current stacktrace, and prompt again.
+    trace: Continue, printing intermediate expressions and their values.
     quit: Abort current eval session.
 
   Response received can be any one of these values. It can also be a map
@@ -355,8 +359,8 @@ this map (identified by a key), and will `dissoc` it afterwards."}
                         value)
         :continue   (do (reset! (:skip STATE__) true)
                         value)
-        :Continue   (do (skip-breaks! :all)
-                        value)
+        :continue-all (do (skip-breaks! :all)
+                          value)
         :out        (do (skip-breaks! :deeper (butlast (:coor dbg-state)) (:code dbg-state) force?)
                         value)
         :here       (do (skip-breaks! :before coord (:code dbg-state) force?)

--- a/test/clj/cider/nrepl/middleware/debug_integration_test.clj
+++ b/test/clj/cider/nrepl/middleware/debug_integration_test.clj
@@ -96,7 +96,7 @@
 
 (def-debug-op :next)
 (def-debug-op :continue)
-(def-debug-op :Continue)
+(def-debug-op :continue-all)
 (def-debug-op :in)
 
 (defmethod debugger-send :out [_ & [force?]]
@@ -261,7 +261,7 @@
     (<-- {:debug-value "1" :coor [1 3 1]}) ; a in foo
     (--> :continue)
     (<-- {:debug-value "2" :coor [1 3 1]}) ; a in foo
-    (--> :Continue)
+    (--> :continue-all)
     (<-- {:value ":fin"})
     (<-- {:status ["done"]})))
 
@@ -615,6 +615,6 @@
     (.startsWith file "jar:file:")
     (.endsWith file "/nrepl/server.clj"))
 
-  (--> :Continue)
+  (--> :continue-all)
   (<-- {:value "{:transport 23}"})
   (<-- {:status ["done"]}))


### PR DESCRIPTION
Note: This is a breaking change that sends debug commands to the client as an unsorted
list of command names without key mapping information, as a means of separating
concerns.


Quick draft of the changes suggested in https://github.com/clojure-emacs/cider/pull/2731
If everything looks alright I'll go ahead with adding changelog notes and tests

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)
