### PR TITLE
Make inspect command work on current expression, add inspect-prompt 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## master (unreleased)
 
 ### New Features
+
+* [#613](https://github.com/clojure-emacs/cider-nrepl/pull/613): Change the `:inspect` command to work on the current expression. Add a new command `:inspect-prompt` to inspect an arbitrary value. 
 * [#654](https://github.com/clojure-emacs/cider-nrepl/pull/654): 
   Change the format of debugger command messages to a set of command names, leaving key mappings up to client implementations.
   * [#653](https://github.com/clojure-emacs/cider-nrepl/pull/653): Add `inspect-def-current-value` to inspect middleware.

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -308,6 +308,7 @@ this map (identified by a key), and will `dissoc` it afterwards."}
     :next
     :out
     :inspect
+    :inspect-prompt
     :quit
     :stacktrace
     :trace})
@@ -322,7 +323,8 @@ this map (identified by a key), and will `dissoc` it afterwards."}
     in: Step into a function
     out: Skip breakpoints in the current sexp.
     here: Skip all breakpoints up till specified coordinate `coord`
-    inspect: Prompt for an expression to evaluate and inspect it.
+    inspect: Inspect the current expression
+    inspect-prompt: Prompt for an expression to evaluate and inspect it.
     locals: Inspect local variables.
     inject: Evaluate an expression and return it.
     eval: Evaluate an expression, display result, and prompt again.
@@ -372,11 +374,14 @@ this map (identified by a key), and will `dissoc` it afterwards."}
         :locals     (->> (debug-inspect page-size (:locals dbg-state))
                          (assoc dbg-state :inspect)
                          (recur value))
-        :inspect    (try-if-let [val (read-eval-expression "Inspect value: " dbg-state code)]
-                      (->> (debug-inspect page-size val)
-                           (assoc dbg-state :inspect)
-                           (recur value))
-                      (recur value dbg-state))
+        :inspect    (->> (debug-inspect page-size value)
+                         (assoc dbg-state :inspect)
+                         (recur value))
+        :inspect-prompt (try-if-let [val (read-eval-expression "Inspect value: " dbg-state code)]
+                          (->> (debug-inspect page-size val)
+                               (assoc dbg-state :inspect)
+                               (recur value))
+                          (recur value dbg-state))
         :inject     (try-if-let [val (read-eval-expression "Expression to inject: " dbg-state code)]
                       val
                       (recur value dbg-state))


### PR DESCRIPTION
Credit goes to @alexander-yakushev in #613 :)


- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the README (if adding/changing middleware)