### PR TITLE
Fix info op not to return nil as a document for protocl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   Change the format of debugger command messages to a set of command names, leaving key mappings up to client implementations.
   * [#653](https://github.com/clojure-emacs/cider-nrepl/pull/653): Add `inspect-def-current-value` to inspect middleware.
 
+### Changes
+
+* [#661](https://github.com/clojure-emacs/cider-nrepl/pull/661): Fix `info` op not to return nil as a value of key.
+
 ## 0.22.4 (2019-10-08)
 
 ### Changes

--- a/src/cider/nrepl/middleware/info.clj
+++ b/src/cider/nrepl/middleware/info.clj
@@ -11,6 +11,16 @@
 
 (declare format-response)
 
+(defn dissoc-nil-keys
+  "Dissociate keys which has nil as a value to avoid returning empty list as a nil.
+  nrepl/bencode converts nil to empty list."
+  [info]
+  (reduce-kv
+   (fn [res k v]
+     (cond-> res
+       (some? v) (assoc k v)))
+   {} info))
+
 (defn format-nested
   "Apply response formatting to nested `:candidates` info for Java members."
   [info]
@@ -43,6 +53,7 @@
                    (info/file-info file))
                  (when-let [path (:javadoc info)]
                    (info/javadoc-info path)))
+          dissoc-nil-keys
           format-nested
           blacklist
           util/transform-value))))

--- a/test/clj/cider/nrepl/middleware/info_test.clj
+++ b/test/clj/cider/nrepl/middleware/info_test.clj
@@ -10,6 +10,10 @@
    [cider.nrepl.test TestClass AnotherTestClass YetAnotherTest]
    [org.apache.commons.lang3 SystemUtils]))
 
+(defprotocol FormatResponseTest
+  (proto-foo [this])
+  (proto-bar [this] "baz"))
+
 (deftest format-response-test
   (is (re-find #"^(https?|file|jar|zip):" ; resolved either locally or online
                (-> (info/info {:class "java.lang.Object" :member "toString"})
@@ -27,7 +31,14 @@
   ;; used to crash, sym is parsed as a class name
   (is (nil? (info/format-response (info/info {:ns "cider.nrepl.middleware.info" :symbol "notincanter.core"}))))
   ;; unfound nses should fall through
-  (is (nil? (info/format-response (info/info {:ns "cider.nrepl.middleware.nonexistent-namespace" :symbol "a-var"})))))
+  (is (nil? (info/format-response (info/info {:ns "cider.nrepl.middleware.nonexistent-namespace" :symbol "a-var"}))))
+  ;; protorol docstring
+  (is (-> (info/format-response (info/info {:ns "cider.nrepl.middleware.info-test" :symbol "proto-foo"}))
+          (contains? "doc")
+          not))
+  (is (-> (info/format-response (info/info {:ns "cider.nrepl.middleware.info-test" :symbol "proto-bar"}))
+          (get "doc")
+          (= "baz"))))
 
 (deftest response-test
   (let [v (ns-resolve 'cider.nrepl.middleware.info 'assoc)


### PR DESCRIPTION
- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)

Currently, the meta data for protocol method without docstring has a `nil` value for `:doc` key.
```clj
(defn foo [])
(defn bar "..." [])
(defprotocol Dummy
  (hello [this])
  (world [this] "..."))

(meta #'foo)   ; not containing `:doc`
(meta #'bar)   ; containing `:doc`
(meta #'hello) ; containing `:doc`, but nil
(meta #'world) ; containing `:doc`
```

The `nil` value is treated as a list by nrepl/bencode, so `info` op returns a empty list as a docstring for protocol method.
https://github.com/nrepl/bencode/blob/v1.0.0/src/bencode/core.clj#L324

E.g. `info` response for `hello`
```sh
d12:arglists-str6:[this]3:docle4:file47:file:/.../core.clj4:linei7e4:name5:hello2:ns8:foo.core8:protocol16:#'foo.core/Dummy7:session36:3b4401ac-a962-43b1-8fbc-1c17d
b0477346:statusl4:doneee

# 3:docle <= Here!
```

Is this an expected behavior?

This PR will dissociate `:doc` key when the value is nil not to return empty list as a bencode response.