### PR TITLE
Fix non-recognized `recur` inside `case` in the debugger.  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## master (unreleased)
 
+### New Features
+
+### Changes
+
+* [#663](https://github.com/clojure-emacs/cider-nrepl/pull/663): Fix non-recognized `recur` inside `case` in the debugger.
+
 ## 0.23.0 (2019-01-18)
 
 ### New Features

--- a/src/cider/nrepl/middleware/util/instrument.clj
+++ b/src/cider/nrepl/middleware/util/instrument.clj
@@ -164,16 +164,19 @@
 (defn- contains-recur?
   "Return true if form is not a `loop` or a `fn` and a `recur` is found in it."
   [form]
-  (cond (seq? form) (case (first form)
-                      recur true
-                      loop* false
-                      fn*   false
-                      (some contains-recur? (rest form)))
-        ;; case* expands the non-default branches into a map
-        ;; this depends on internal logic
-        (map? form) (some contains-recur? (vals form))
-        (vector? form) (some contains-recur? (seq form))
-        :else false))
+  (cond
+    (seq? form) (case (first form)
+                  recur true
+                  loop* false
+                  fn*   false
+                  (some contains-recur? (rest form)))
+    ;; `case` expands the non-default branches into a map.
+    ;; We therefore expect a `recur` to appear in a map only
+    ;; as the result of a `case` expansion.
+    ;; This depends on Clojure implementation details.
+    (map? form) (some contains-recur? (vals form))
+    (vector? form) (some contains-recur? (seq form))
+    :else false))
 
 (defn- dont-break?
   "Return true if it's NOT ok to wrap form in a breakpoint.

--- a/src/cider/nrepl/middleware/util/instrument.clj
+++ b/src/cider/nrepl/middleware/util/instrument.clj
@@ -164,12 +164,15 @@
 (defn- contains-recur?
   "Return true if form is not a `loop` or a `fn` and a `recur` is found in it."
   [form]
-  (if (seq? form)
-    (case (first form)
-      recur true
-      loop* false
-      fn*   false
-      (some contains-recur? (rest form)))))
+  (cond (seq? form) (case (first form)
+                      recur true
+                      loop* false
+                      fn*   false
+                      (some contains-recur? (rest form)))
+        ;; case* expands the non-default branches into a map
+        ;; this depends on internal logic
+        (map? form) (some contains-recur? (->> (vals form) (map second)))
+        :else false))
 
 (defn- dont-break?
   "Return true if it's NOT ok to wrap form in a breakpoint.

--- a/src/cider/nrepl/middleware/util/instrument.clj
+++ b/src/cider/nrepl/middleware/util/instrument.clj
@@ -171,7 +171,8 @@
                       (some contains-recur? (rest form)))
         ;; case* expands the non-default branches into a map
         ;; this depends on internal logic
-        (map? form) (some contains-recur? (->> (vals form) (map second)))
+        (map? form) (some contains-recur? (vals form))
+        (vector? form) (some contains-recur? (seq form))
         :else false))
 
 (defn- dont-break?

--- a/test/clj/cider/nrepl/middleware/util/instrument_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/instrument_test.clj
@@ -12,7 +12,8 @@
   (are [x] (not (#'t/dont-break? (walk/macroexpand-all x)))
     '(loop [] (if 1 (recur (inc 2)) 0))
     '(inc 1)
-    '(inc 2)))
+    '(inc 2)
+    '(case i nil {:foo :bar} :default)))
 
 (deftest instrument-defrecord-and-new-test
   (are [exp res] (set/subset? res (t/breakpoint-tester exp))

--- a/test/clj/cider/nrepl/middleware/util/instrument_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/instrument_test.clj
@@ -6,8 +6,9 @@
    [clojure.walk :as walk]))
 
 (deftest dont-break?-test
-  (are [x] (#'t/dont-break? x)
-    '(if 1 (recur (inc 2)) 0))
+  (are [x] (#'t/dont-break? (walk/macroexpand-all x))
+    '(if 1 (recur (inc 2)) 0)
+    '(case i 10 (recur (inc i)) :halt))
   (are [x] (not (#'t/dont-break? (walk/macroexpand-all x)))
     '(loop [] (if 1 (recur (inc 2)) 0))
     '(inc 1)


### PR DESCRIPTION
Case expands the non-default branches into a map. This can be seen
when evaluating the following code:
```clj 
(walk/macroexpand-all '(case i
                         10 (recur (inc i))
                         :halt))
```
The `contains-recur?` function did so far not take that into account.

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing (kind of)
I was able to run tests for 1.9 and 1.10. 1.9 had 1 failure non related to my code and 1.10 none.
I was unable to run the tests for 1.8 because of some leiningen issue.
- [x] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)

This should be fixing [cider#2772](https://github.com/clojure-emacs/cider/issues/2772)
