### PR TITLE
Fix continue-all in conditional break.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## master (unreleased)
 
+### New Features
+
+### Changes
+
+* [#664](https://github.com/clojure-emacs/cider-nrepl/pull/664): Fix continue-all in conditional break.
+
 ## 0.23.0 (2019-01-18)
 
 ### New Features

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -570,7 +570,10 @@ this map (identified by a key), and will `dissoc` it afterwards."}
              (skip-breaks! :deeper ~(vec (butlast coor)) (:code (:msg ~'STATE__)) false))
            (try
              (expand-break ~form ~dbg-state ~original-form)
-             (finally (reset! *skip-breaks* old-breaks#))))
+             ;; in case :continue-all was requested in a deeper level
+             ;; we don't want go back to the old-breaks
+             (finally (when (not= :all (:mode @*skip-breaks*))
+                        (reset! *skip-breaks* old-breaks#)))))
         `(expand-break ~form ~dbg-state ~original-form)))))
 
 ;;; ## Data readers

--- a/test/clj/cider/nrepl/middleware/debug_integration_test.clj
+++ b/test/clj/cider/nrepl/middleware/debug_integration_test.clj
@@ -443,6 +443,18 @@
   (<-- {:value "(1 2 3 4 5)"})              ; (for ...)
   (<-- {:status ["done"]}))
 
+(deftest conditional-in-for-continue-all-test
+  (--> :eval
+       "(for [i (range 5)]
+          #dbg ^{:break/when (even? i)}
+          (inc i))")
+  (<-- {:debug-value "0" :coor [2 1]}) ; i
+  (--> :continue)
+  (<-- {:debug-value "2" :coor [2 1]}) ; i
+  (--> :continue-all)
+  (<-- {:value "(1 2 3 4 5)"}) ; (for ...)
+  (<-- {:status ["done"]}))
+
 (deftest conditional-in-defn-test
   (--> :eval "(ns user.test.conditional-break)")
   (<-- {:ns "user.test.conditional-break"})


### PR DESCRIPTION
The :continue-all command was previously not
ignoring conditional breakpoints as in the
following code.

(for [i (range 10)]
  #dbg ^{:break/when (even? i)}
  (inc i))

Fixes #656.

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)