### PR TITLE
Fix instrumentation of small map literals. Minor doc updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * [#663](https://github.com/clojure-emacs/cider-nrepl/pull/663): Fix non-recognized `recur` inside `case` in the debugger.
 * [#664](https://github.com/clojure-emacs/cider-nrepl/pull/664): Fix continue-all in conditional break.
+* [#665](https://github.com/clojure-emacs/cider-nrepl/pull/665): Fix form location in map literals.
 
 ## 0.23.0 (2019-01-18)
 

--- a/src/cider/nrepl/middleware/util/instrument.clj
+++ b/src/cider/nrepl/middleware/util/instrument.clj
@@ -236,30 +236,26 @@
    (let [map-inner (fn [forms]
                      (map-indexed #(walk-indexed (conj coor %1) f %2)
                                   forms))
-         ;; Clojure uses array-maps up to some threshold (8 currently).
+         ;; Clojure uses array-maps up to some map size (8 currently).
          ;; So for small maps we take advantage of that, otherwise fall
          ;; back to the heuristic below.
          ;; Maps are unordered, but we can try to use the keys as order
          ;; hoping they can be compared one by one and that the user
-         ;; has specified them in that order. If that fails we fall
-         ;; back to simply instrumenting the values in the order they
-         ;; they appear in the map.
+         ;; has specified them in that order. If that fails we don't
+         ;; instrument the map. We also don't instrument sets.
          ;; This depends on Clojure implementation details.
+         walk-indexed-map (fn [map]
+                            (map-indexed (fn [i [k v]]
+                                           [(walk-indexed (conj coor (* 2 i)) f k)
+                                            (walk-indexed (conj coor (inc (* 2 i))) f v)])
+                                         map))
          result (cond
                   (map? form) (if (<= (count form) 8)
-                                (into {} (map-indexed (fn [i [k v]]
-                                                        [(walk-indexed (conj coor (* 2 i)) f k)
-                                                         (walk-indexed (conj coor (inc (* 2 i))) f v)])
-                                                      form))
+                                (into {} (walk-indexed-map form))
                                 (try
-                                  (into {} (map-indexed (fn [i [k v]]
-                                                          [(walk-indexed (conj coor (* 2 i)) f k)
-                                                           (walk-indexed (conj coor (inc (* 2 i))) f v)])
-                                                        (into (sorted-map) form)))
+                                  (into (sorted-map) (walk-indexed-map (into (sorted-map) form)))
                                   (catch Exception e
-                                    (into {} (map-indexed (fn [i [k v]]
-                                                            [k (walk-indexed (conj coor (inc (* 2 i))) f v)])
-                                                          form)))))
+                                    form)))
                   ;; Order of sets is unpredictable, unfortunately.
                   (set? form)  form
                   ;; Borrowed from clojure.walk/walk

--- a/test/clj/cider/nrepl/middleware/debug_integration_test.clj
+++ b/test/clj/cider/nrepl/middleware/debug_integration_test.clj
@@ -429,7 +429,51 @@
   (<-- {:value "4"})
   (<-- {:status ["done"]}))
 
+;;; Tests for map literals
+
+(deftest small-literal-map-test
+  (--> :eval
+       "#dbg
+        (seq
+          {1 (+ 2 (+ 3 2))
+           (inc 3)  (+ 12345)})")
+  (<-- {:debug-value "5" :coor [1 1 2]}) ; (+ 3 2)
+  (--> :next)
+  (<-- {:debug-value "7" :coor [1 1]}) ; (+ 2 (+ 3 2))
+  (--> :next)
+  (<-- {:debug-value "4" :coor [1 2]}) ; (inc 3) 
+  (--> :next)
+  (<-- {:debug-value "12345" :coor [1 3]}) ; (+ 12345) 
+  (--> :next)
+  (<-- {:value "([1 7] [4 12345])"}) ; (seq ...) 
+  (<-- {:status ["done"]}))
+
+(deftest larger-literal-map-test
+  (--> :eval
+       "#dbg (count {1 2 3 (inc 4) 5 6 7 8 9 10 11 12 13 14 15 (inc 16) 17 (inc 18)})")
+  (<-- {:debug-value "5" :coor [1 3]}) ; (inc 4)
+  (--> :next)
+  (<-- {:debug-value "17" :coor [1 15]}) ; (inc 15)
+  (--> :next)
+  (<-- {:debug-value "19" :coor [1 17]}) ; (inc 18) 
+  (--> :next)
+  (<-- {:value "9"}) ; (count ...)
+  (<-- {:status ["done"]}))
+
 ;;; Tests for conditional breakpoints
+
+(deftest conditional-in-for-test
+  (--> :eval
+       "(for [i (range 5)]
+          #dbg ^{:break/when (= 2 i)}
+          (inc i))")
+  (<-- {:debug-value "2" :coor [2 1]}) ; i
+  (--> :next)
+  (<-- {:debug-value "3" :coor [2]}) ; (inc i)
+  (--> :next)
+  (<-- {:value "(1 2 3 4 5)"})              ; (for ...)
+  (<-- {:status ["done"]}))
+
 
 (deftest conditional-in-for-test
   (--> :eval

--- a/test/clj/cider/nrepl/middleware/debug_integration_test.clj
+++ b/test/clj/cider/nrepl/middleware/debug_integration_test.clj
@@ -474,18 +474,6 @@
   (<-- {:value "(1 2 3 4 5)"})              ; (for ...)
   (<-- {:status ["done"]}))
 
-(deftest conditional-in-for-test
-  (--> :eval
-       "(for [i (range 5)]
-          #dbg ^{:break/when (= 2 i)}
-          (inc i))")
-  (<-- {:debug-value "2" :coor [2 1]}) ; i
-  (--> :next)
-  (<-- {:debug-value "3" :coor [2]}) ; (inc i)
-  (--> :next)
-  (<-- {:value "(1 2 3 4 5)"})              ; (for ...)
-  (<-- {:status ["done"]}))
-
 (deftest conditional-in-for-continue-all-test
   (--> :eval
        "(for [i (range 5)]

--- a/test/clj/cider/nrepl/middleware/debug_integration_test.clj
+++ b/test/clj/cider/nrepl/middleware/debug_integration_test.clj
@@ -474,7 +474,6 @@
   (<-- {:value "(1 2 3 4 5)"})              ; (for ...)
   (<-- {:status ["done"]}))
 
-
 (deftest conditional-in-for-test
   (--> :eval
        "(for [i (range 5)]


### PR DESCRIPTION
Map literal instrumentation was relying on some heuristic before.
We use Clojures underlying array-map implementation for small map
literals and fall back to a sorted order of keys if that is not the
case. If this fails as well we simply instrument only the values of
the map in the order they appear in a sequential pass.

This fixes https://github.com/clojure-emacs/cider/issues/2773 for small maps at least.

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)
