### PR TITLE
Add a check in apropos var-query-map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#666](https://github.com/clojure-emacs/cider-nrepl/pull/666): Add a check in apropos var-query-map.
+
 ### New Features
 
 ## 0.24.0 (2020-02-14)

--- a/src/cider/nrepl/middleware/apropos.clj
+++ b/src/cider/nrepl/middleware/apropos.clj
@@ -19,7 +19,8 @@
       (:query msg)
       (assoc-in [:var-query :search] (:query msg))
 
-      (not (:case-sensitive? msg))
+      (and (:query msg)
+           (not (:case-sensitive? msg)))
       (update-in [:var-query :search] #(format "(?i:%s)" %))
 
       (:docs? msg)
@@ -38,7 +39,9 @@
       (update :ns (comp find-ns symbol)))))
 
 (defn apropos [msg]
-  {:apropos-matches (-> msg msg->var-query-map apropos/find-symbols)})
+  {:apropos-matches (-> msg
+                        msg->var-query-map
+                        apropos/find-symbols)})
 
 (defn handle-apropos [handler msg]
   (with-safe-transport handler msg

--- a/test/clj/cider/nrepl/middleware/apropos_test.clj
+++ b/test/clj/cider/nrepl/middleware/apropos_test.clj
@@ -15,7 +15,12 @@
                :query "spelling"}
           query-map (#'apropos/msg->var-query-map msg)]
       (is (contains? (:var-query query-map) :ns-query))
-      (is (= 3 (count (-> query-map :var-query :ns-query :exclude-regexps)))))))
+      (is (= 3 (count (-> query-map :var-query :ns-query :exclude-regexps))))))
+
+  (testing "No :search key in the query-map if no :query in message"
+    (let [msg {:exclude-regexps ["^cider.nrepl" "^refactor-nrepl" "^nrepl"]}
+          query-map (#'apropos/msg->var-query-map msg)]
+      (is ((complement contains?) (:var-query query-map) :search)))))
 
 (deftest integration-test
   (testing "Apropos op, typical case"


### PR DESCRIPTION
This is a change as described in https://github.com/clojure-emacs/cider-nrepl/issues/530.

In `apropos` middleware, if no `query` is passed in the message then a redundant regex is formed.
This is because there is no condition that checks whether the value exists before constructing the regex.

I have added such a check. I have also added a test for this specific case.
