### PR TITLE
Filter non file urls from classpath response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * [#666](https://github.com/clojure-emacs/cider-nrepl/pull/666): Add a check in apropos var-query-map.
 * [#669](https://github.com/clojure-emacs/cider-nrepl/pull/669): Fix NPE and add isDirectory check in slurp
+* [#667](https://github.com/clojure-emacs/cider-nrepl/pull/667): Filter non file urls from classpath response.
+
 
 ### New Features
 

--- a/src/cider/nrepl/middleware/classpath.clj
+++ b/src/cider/nrepl/middleware/classpath.clj
@@ -2,10 +2,17 @@
   (:require
    [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
    [clojure.java.io :as io]
-   [orchard.java.classpath :as cp]))
+   [orchard.java.classpath :as cp]
+   [orchard.misc :as misc]))
+
+(defn file-url?
+  [u]
+  (and (misc/url? u)
+       (= (.getProtocol ^java.net.URL u) "file")))
 
 (defn classpath-reply [msg]
   {:classpath (->> (cp/classpath)
+                   (filter file-url?)
                    (map io/as-file)
                    (map str))})
 

--- a/test/clj/cider/nrepl/middleware/classpath_test.clj
+++ b/test/clj/cider/nrepl/middleware/classpath_test.clj
@@ -21,3 +21,7 @@
       (is (.startsWith (:err response) "java.lang.Exception: cp error"))
       (is (= (:ex response) "class java.lang.Exception"))
       (is (:pp-stacktrace response)))))
+
+(deftest file-url?-test
+  (is (file-url? (.toURL (.toURI (java.io.File. "")))))
+  (is (not (file-url? (java.net.URL. "jar:file:/tmp/test.jar!/BOOT-INF/classes")))))


### PR DESCRIPTION
Not all urls on a classpath are necessarily files. Eg. spring boot
adds "jar:file:..." urls

This can only be merged after https://github.com/clojure-emacs/orchard/commit/9fe7a70e7ea0e7984317aa80634367ff5ca327e9 was released.

This is at least related to https://github.com/clojure-emacs/orchard/pull/83
