### PR TITLE
Demonstrate an incompatibility with clojure.java.classpath

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,8 @@
                  ^:inline-dep [cljfmt "0.7.0" :exclusions [org.clojure/clojurescript]]
                  ^:inline-dep [org.clojure/tools.namespace "1.0.0"]
                  ^:inline-dep [org.clojure/tools.trace "0.7.10"]
-                 ^:inline-dep [org.clojure/tools.reader "1.3.2"]]
+                 ^:inline-dep [org.clojure/tools.reader "1.3.2"]
+                 [org.clojure/java.classpath "1.0.0"]]
   :exclusions [org.clojure/clojure] ; see Clojure version matrix in profiles below
 
   :plugins [[thomasa/mranderson "0.5.3"]]

--- a/test/classpath_test.clj
+++ b/test/classpath_test.clj
@@ -1,8 +1,0 @@
-(ns classpath-test
-  (:require
-   [clojure.java.classpath]
-   [clojure.test :refer :all]))
-
-(deftest works
-  (testing "The presence of the cider-nrepl library does not affect the clojure.java.classpath library, particularly on JDK11"
-    (is (seq (clojure.java.classpath/classpath-directories)))))

--- a/test/classpath_test.clj
+++ b/test/classpath_test.clj
@@ -1,0 +1,8 @@
+(ns classpath-test
+  (:require
+   [clojure.java.classpath]
+   [clojure.test :refer :all]))
+
+(deftest works
+  (testing "The presence of the cider-nrepl library does not affect the clojure.java.classpath library, particularly on JDK11"
+    (is (seq (clojure.java.classpath/classpath-directories)))))

--- a/test/clj/cider/nrepl/middleware/classpath_test.clj
+++ b/test/clj/cider/nrepl/middleware/classpath_test.clj
@@ -2,6 +2,7 @@
   (:require
    [cider.nrepl.test-session :as session]
    [cider.nrepl.middleware.classpath :refer :all]
+   [clojure.java.classpath]
    [clojure.test :refer :all]))
 
 (use-fixtures :each session/session-fixture)
@@ -25,3 +26,7 @@
 (deftest file-url?-test
   (is (file-url? (.toURL (.toURI (java.io.File. "")))))
   (is (not (file-url? (java.net.URL. "jar:file:/tmp/test.jar!/BOOT-INF/classes")))))
+
+(deftest works
+  (testing "The presence of the cider-nrepl library does not affect the clojure.java.classpath library, particularly on JDK11"
+    (is (seq (clojure.java.classpath/classpath-directories)))))


### PR DESCRIPTION
Hi,

in a project of mine I found out that the presence of a recent `cider-nrepl` dependency would make `c.j.classpath/classpath-directories` return an empty seq.

Were you aware of that?