### PR TITLE
Extend undef op to work on fully qualified symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### New Features
 
+* [#670](https://github.com/clojure-emacs/cider-nrepl/pull/670): Extend undef op to work on fully qualified symbols.
+
 ## 0.24.0 (2020-02-14)
 
 ### Bugs fixed

--- a/src/cider/nrepl/middleware/undef.clj
+++ b/src/cider/nrepl/middleware/undef.clj
@@ -6,9 +6,16 @@
 
 (defn undef
   [{:keys [ns symbol]}]
-  (let [[ns symbol] (map misc/as-sym [ns symbol])]
-    (ns-unalias ns symbol)
-    (ns-unmap ns symbol)
+  (let [ns (misc/as-sym ns)
+        [sym-ns sym-name] ((juxt (comp misc/as-sym namespace) misc/name-sym)
+                           (misc/as-sym symbol))]
+    (if sym-ns
+      ;; fully qualified => var in other namespace
+      (let [other-ns (get (ns-aliases ns) sym-ns sym-ns)]
+        (ns-unmap other-ns sym-name))
+      ;; unqualified => alias or var in current ns
+      (do (ns-unalias ns sym-name)
+          (ns-unmap ns sym-name)))
     symbol))
 
 (defn undef-reply

--- a/src/cider/nrepl/middleware/undef.clj
+++ b/src/cider/nrepl/middleware/undef.clj
@@ -1,10 +1,18 @@
 (ns cider.nrepl.middleware.undef
-  "Undefine a symbol"
+  "Middleware for undefining symbols.
+  Fully qualified symbols are interpreted as a var to be unmapped in its
+  original namespace, whereas unqualified symbols are interpreted as both a var
+  and ns alias to be unmapped from the current namespace."
   (:require
    [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
    [orchard.misc :as misc]))
 
 (defn undef
+  "Undefines a symbol.
+  When `symbol` is unqualified, it is interpreted as both an alias and var to be
+  unmapped from the namespace `ns`.
+  When qualified (eg. `foo/bar`), it is interpreted as a var to be unmapped in
+  the namespace `foo`, which may be an alias in `ns`."
   [{:keys [ns symbol]}]
   (let [ns (misc/as-sym ns)
         [sym-ns sym-name] ((juxt (comp misc/as-sym namespace) misc/name-sym)


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [ ] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)

See https://github.com/clojure-emacs/cider/issues/2814.
The current cider.el frontend sends `undef` op with `ns` as the current ns and `symbol` as a possibly ns-qualified var, which this PR interprets as unmapping the symbol from the corresponding other namespace.

For some reason running tests locally with `make test` turns up many failures in `cider.nrepl.middleware.debug-integration-test` which seem to be unrelated to the changes in this PR. 