### PR TITLE
Fix instrument for a dot special form case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#666](https://github.com/clojure-emacs/cider-nrepl/pull/666): Add a check in apropos var-query-map.
 * [#669](https://github.com/clojure-emacs/cider-nrepl/pull/669): Fix NPE and add isDirectory check in slurp
+* [#672](https://github.com/clojure-emacs/cider-nrepl/pull/672): Fix instrument for a dot special form case
 
 ### New Features
 

--- a/src/cider/nrepl/middleware/util/instrument.clj
+++ b/src/cider/nrepl/middleware/util/instrument.clj
@@ -73,7 +73,15 @@
             '#{new} (cons (first args) (instrument-coll (rest args)))
             '#{quote & var clojure.core/import*} args
             '#{.} (list* (first args)
-                         (second args)
+                         ;; To handle the case when second argument to dot call
+                         ;; is a list e.g (. class-name (method-name args*))
+                         ;; The values present as args* should be instrumented.
+                         (let [s (second args)]
+                           (if (coll? s)
+                             (->> (rest s)
+                                  instrument-coll
+                                  (concat (cons (first s) '())))
+                             s))
                          (instrument-coll (rest (rest args))))
             '#{def} (let [sym (first args)]
                       (list* (m/merge-meta sym

--- a/test/clj/cider/nrepl/middleware/util/instrument_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/instrument_test.clj
@@ -138,6 +138,17 @@
          '#{[(def foo "foo doc" (bp (bar) {:coor [3]} (bar))) []]
             [(bar) [3]]})))
 
+(deftest instrument-dot-test
+  (testing "Instrument dot special form of type"
+    (testing "(. class-name method-name args*)"
+      (is (= (t/breakpoint-tester '(. clojure.lang.Numbers add 1 x))
+             '#{[(. clojure.lang.Numbers add 1 (bp x {:coor [4]} x)) []]
+                [x [4]]})))
+    (testing "(. class-name (method-name args*))"
+      (is (= (t/breakpoint-tester '(. clojure.lang.Numbers (add 1 x)))
+             '#{[x [2 2]]
+                [(. clojure.lang.Numbers (add 1 (bp x {:coor [2 2]} x))) []]})))))
+
 (deftest instrument-set!-test
   (is (= (t/breakpoint-tester '(set! foo (bar)))
          '#{[(set! foo (bp (bar) {:coor [2]} (bar))) []]


### PR DESCRIPTION
Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the README (if adding/changing middleware)
--- 

Fix for https://github.com/clojure-emacs/cider-nrepl/issues/671

Instrumentation for dot special forms of type `(. clojure.lang.Numers (add 1 x))` fails. There is no breakpoint set for `x`.

This PR fixes this so that the breakpoints are set inside the dot special form.
