### PR TITLE
fix double-reference to clj-suitable in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,7 @@ Let's also acknowledge some of the projects leveraged by cider-nrepl:
 
 * [orchard][] - extracted from `cider-nrepl`, so that non-nREPL clients can leverage the generic tooling functionality (like `inspect`, `apropos`, `var-info`, etc
 * [compliment][] - for Clojure code completion
-* [clj-suitable][] - for ClojureScript code completion
-* [suitable][] - for ClojureScript code completion using runtime inspection
+* [clj-suitable][] - for ClojureScript code completion using runtime inspection
 * [tools.trace][] - for tracing
 * [tools.namespace][] - for namespace reloading
 * [cljfmt][] - for code formatting
@@ -142,7 +141,6 @@ Distributed under the Eclipse Public License, the same as Clojure.
 [orchard]: https://github.com/clojure-emacs/orchard
 [compliment]: https://github.com/alexander-yakushev/compliment
 [clj-suitable]: https://github.com/rksm/clj-suitable
-[suitable]: https://github.com/rksm/clj-suitable
 [tools.trace]: https://github.com/clojure/tools.trace
 [tools.namespace]: https://github.com/clojure/tools.namespace
 [cljfmt]: https://github.com/weavejester/cljfmt


### PR DESCRIPTION
Took me a moment to realize these are the same project, clj-suitable