### PR TITLE
Remove workaround for converting column numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* Remove workaround for converting column numbers to 0-based indexing. ([Cider issue](https://github.com/clojure-emacs/cider/issues/2852))
+
 ## 0.25.1 (2020-06-04)
 
 ### Bugs fixed

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -473,17 +473,16 @@ this map (identified by a key), and will `dissoc` it afterwards."}
   [& body]
   ;; NOTE: *msg* is the message that instrumented the function,
   `(let [~'STATE__ {:msg ~(let [{:keys [code id file line column ns]} *msg*]
-                            (-> {:code code
-                                 ;; Passing clojure.lang.Namespace object
-                                 ;; as :original-ns breaks nREPL in bewildering
-                                 ;; ways.
-                                 :original-id id, :original-ns (str (or ns *ns*))
-                                 :file file, :line line, :column column}
-                                ;; There's an nrepl bug where the column starts counting
-                                ;; at 1 if it's after the first line. Since this is a
-                                ;; top-level sexp, a (= col 1) is much more likely to be
-                                ;; wrong than right.
-                                (update :column #(if (= % 1) 0 %))))
+                            {:code code
+                             ;; Passing clojure.lang.Namespace object
+                             ;; as :original-ns breaks nREPL in bewildering
+                             ;; ways.
+                             ;; NOTE: column numbers in the response map
+                             ;; start from 1 according to Clojure.
+                             ;; This is not a bug and should be converted to
+                             ;; 0-based indexing by the client if necessary.
+                             :original-id id, :original-ns (str (or ns *ns*))
+                             :file file, :line line, :column column})
                     ;; the coor of first form is used as the debugger session id
                     :session-id (atom nil)
                     :skip (atom false)

--- a/test/clj/cider/nrepl/middleware/debug_integration_test.clj
+++ b/test/clj/cider/nrepl/middleware/debug_integration_test.clj
@@ -580,7 +580,7 @@
 
     ;; Note - if changing test/src/cider/nrepl/middleware/debug_integration_test/fn.clj, also change this:
     (let [msg (<-- {:line        7
-                    :column      0
+                    :column      1
                     :debug-value "\"bar\""
                     :coor        [3 1 1]
                     :locals      [["x" "\"bar\""]]})


### PR DESCRIPTION
Fixes https://github.com/clojure-emacs/cider/issues/2852

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the README (if adding/changing middleware)

