### PR TITLE
update compliment dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  ^:inline-dep [thunknyc/profile "0.5.2"]
                  ^:inline-dep [mvxcvi/puget "1.3.1"]
                  ^:inline-dep [fipp "0.6.23"] ; can be removed in unresolved-tree mode
-                 ^:inline-dep [compliment "0.3.10"]
+                 ^:inline-dep [compliment "0.3.11"]
                  ^:inline-dep [org.rksm/suitable "0.3.5" :exclusions [org.clojure/clojurescript]]
                  ^:inline-dep [cljfmt "0.6.8" :exclusions [org.clojure/clojurescript]]
                  ^:inline-dep [org.clojure/tools.namespace "1.0.0"]


### PR DESCRIPTION
This brings the reflection warnings fixes made in compliment with the following PR: https://github.com/alexander-yakushev/compliment/pull/75


---
- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [X] You've added tests to cover your change(s)
- [FAIL] All tests are passing - same failure as `master`
- [X] The new code is not generating reflection warnings
- [X] You've updated the README (if adding/changing middleware)
