### PR TITLE
Support custom print-methods in test reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#683](https://github.com/clojure-emacs/cider-nrepl/pull/683): Support custom `print-method`s in test reports.
+
 ## 0.25.4 (2020-10-08)
 
 ### Changes

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -63,30 +63,34 @@
        (filter #(= (:class %) (.getName (class f))))
        (first)))
 
-(defn- custom-print-method? [o]
-  (= (get-method print-method (:type (meta o)))
-     (get-method print-method :default)))
+(defn- print-object [object]
+  (let [print-fn (if (= (get-method print-method (:type (meta object)))
+                        (get-method print-method :default))
+                   pp/pprint
+                   println)]
+    (with-out-str (print-fn object))))
 
 (defn test-result
   "Transform the result of a test assertion. Append ns, var, assertion index,
-  and 'testing' context. Retain any exception. Pretty-print expected/actual."
+  and 'testing' context. Retain any exception. Pretty-print expected/actual or
+  use its `print-method`, if applicable."
   [ns v m]
   (let [{:keys [actual diffs expected fault]
          t :type} m
         c (when (seq test/*testing-contexts*) (test/testing-contexts-str))
         i (count (get-in (@current-report :results) [ns (:name (meta v))]))
-        gen-input (:gen-input @current-report)
-        pprint-str #(with-out-str (if (custom-print-method? %) (pp/pprint %) (println %)))]
+        gen-input (:gen-input @current-report)]
+
     ;; Errors outside assertions (faults) do not return an :expected value.
     ;; Type :fail returns :actual value. Type :error returns :error and :line.
     (merge (dissoc m :expected :actual)
            {:ns ns, :var (:name (meta v)), :index i, :context c}
            (when (and (#{:fail :error} t) (not fault))
-             {:expected (pprint-str expected)})
+             {:expected (print-object expected)})
            (when (and (#{:fail} t) gen-input)
-             {:gen-input (pprint-str gen-input)})
+             {:gen-input (print-object gen-input)})
            (when (#{:fail} t)
-             {:actual (pprint-str actual)})
+             {:actual (print-object actual)})
            (when diffs
              {:diffs (extensions/diffs-result diffs)})
            (when (#{:error} t)

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -63,6 +63,10 @@
        (filter #(= (:class %) (.getName (class f))))
        (first)))
 
+(defn- custom-print-method? [o]
+  (= (get-method print-method (:type (meta o)))
+     (get-method print-method :default)))
+
 (defn test-result
   "Transform the result of a test assertion. Append ns, var, assertion index,
   and 'testing' context. Retain any exception. Pretty-print expected/actual."
@@ -72,7 +76,7 @@
         c (when (seq test/*testing-contexts*) (test/testing-contexts-str))
         i (count (get-in (@current-report :results) [ns (:name (meta v))]))
         gen-input (:gen-input @current-report)
-        pprint-str #(with-out-str (pp/pprint %))]
+        pprint-str #(with-out-str (if (custom-print-method? %) (pp/pprint %) (println %)))]
     ;; Errors outside assertions (faults) do not return an :expected value.
     ;; Type :fail returns :actual value. Type :error returns :error and :line.
     (merge (dissoc m :expected :actual)

--- a/test/clj/cider/nrepl/middleware/test_test.clj
+++ b/test/clj/cider/nrepl/middleware/test_test.clj
@@ -140,3 +140,14 @@
                                     :test-with-map-as-message
                                     first
                                     :message))))))
+
+(defmethod clojure.core/print-method ::custom [_ out]
+  (binding [*out* out]
+    (print "custom-output")))
+
+(deftest print-object-test
+  (testing "use an object's print-method when applicable, otherwise invoke pprint"
+    (is (= "custom-output\n"
+           (#'test/print-object (with-meta {:not :printed} {:type ::custom}))))
+    (is (= "{:a :b, :c :d}\n"
+           (#'test/print-object {:a :b :c :d})))))


### PR DESCRIPTION
This PR fixes test reporting for libraries that rely on custom print logic that can be added by `(defmethod print-method ,,,`, such as `matcher-combinators`: https://github.com/clojure-emacs/cider/issues/2901#issuecomment-723312712