### PR TITLE
Fix delayed middleware loading issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs Fixed
+
+* [#684](https://github.com/clojure-emacs/cider-nrepl/pull/684): Fix delayed middleware loading issue.
+
 ## 0.25.4 (2020-10-08)
 
 ### Changes


### PR DESCRIPTION
Hi,

This is an attempt to fix issue around delayed middleware loading.
The relevant discussion is present at https://github.com/clojure-emacs/cider-nrepl/issues/533 

Instead of adding the handler delay to the `delayed-handlers` atom in the macro, this takes care of adding
it in the atom through a function. 

Fixes:
https://github.com/clojure-emacs/cider-nrepl/issues/447
https://github.com/clojure-emacs/cider-nrepl/issues/533
https://github.com/clojure-emacs/cider-nrepl/issues/657
