### PR TITLE
Run clj-kondo by a more stable means

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,10 +59,6 @@ commands:
           command: |
             sudo apt-get install make
       - run:
-          name: Install clj-kondo
-          command: |
-           sudo curl -sLO https://raw.githubusercontent.com/clj-kondo/clj-kondo/master/script/install-clj-kondo && sudo chmod +x install-clj-kondo && sudo ./install-clj-kondo
-      - run:
           name: Generate Cache Checksum
           command: |
             for file in << parameters.files >>
@@ -178,10 +174,6 @@ workflows:
           name: Code Linting
           steps:
             - run:
-                name: Running Eastwood
-                command: |
-                  make eastwood
-            - run:
                 name: Running cljfmt
                 command: |
                   make cljfmt
@@ -189,3 +181,7 @@ workflows:
                 name: Running clj-kondo
                 command: |
                   make kondo
+            - run:
+                name: Running Eastwood
+                command: |
+                  make eastwood

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ cljfmt:
 	lein with-profile +$(CLOJURE_VERSION),+cljfmt cljfmt check
 
 kondo:
-	clj-kondo --lint src
+	lein with-profile -dev,+clj-kondo run -m clj-kondo.main --lint src
 
 cloverage:
 	lein with-profile +$(CLOJURE_VERSION),+cloverage cloverage

--- a/project.clj
+++ b/project.clj
@@ -136,6 +136,9 @@
                                           merge-meta [[:inner 0]]
                                           try-if-let [[:block 1]]}}}]
 
+             :clj-kondo [:test
+                         {:dependencies [[clj-kondo "2021.03.31"]]}]
+
              :eastwood [:test
                         {:plugins [[jonase/eastwood "0.4.0"]]
                          :eastwood {:config-files ["eastwood.clj"]


### PR DESCRIPTION
Running `curl | bash` didn't seem exactly ideal, and also it seems a good idea to run a stable, fixed version.

Finally it's also good to stick to vanilla JVM clojure, removing the possibility of graalvm doing something funny.

Green build in my personal account

![image](https://user-images.githubusercontent.com/1162994/114126906-a22bf300-98f9-11eb-9a43-6705e1e86329.png)
