### PR TITLE
[Inspector] Configure truncation limits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,12 @@ defaults: &defaults
   working_directory: ~/repo
   environment:
     LEIN_ROOT: "true"   # we intended to run lein as root
-    JVM_OPTS: -Xmx3200m # limit the maximum heap size to prevent out of memory errors
+    # JVM_OPTS:
+    # - limit the maximum heap size to prevent out of memory errors
+    # - print stacktraces to console
+    JVM_OPTS: >
+      -Xmx3200m
+      -Dclojure.main.report=stderr
 
 # Runners for OpenJDK 8 and 11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#694](https://github.com/clojure-emacs/cider-nrepl/pull/694): [Inspector] Configure truncation limits
+
 ## 0.25.11 (2021-04-12)
 
 ### Bugs Fixed

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject cider/cider-nrepl "0.25.11"
+(defproject cider/cider-nrepl "0.26.0-SNAPSHOT"
   :description "A collection of nREPL middlewares designed to enhance Clojure editors."
   :url "https://github.com/clojure-emacs/cider-nrepl"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/clojure-emacs/cider-nrepl"}
   :dependencies [[nrepl "0.8.3"]
-                 ^:inline-dep [cider/orchard "0.6.5"]
+                 ^:inline-dep [cider/orchard "0.7.0"]
                  ^:inline-dep [thunknyc/profile "0.5.2"]
                  ^:inline-dep [mvxcvi/puget "1.3.1"]
                  ^:inline-dep [fipp "0.6.23"] ; can be removed in unresolved-tree mode

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -258,6 +258,16 @@
                :requires {"page-size" "New page size."
                           "session" "The current session"}
                :returns {"status" "\"done\""}}
+              "inspect-set-max-atom-length"
+              {:doc "Set the max length of nested atoms to specified value."
+               :requires {"max-atom-length" "New max length."
+                          "session" "The current session"}
+               :returns {"status" "\"done\""}}
+              "inspect-set-max-coll-size"
+              {:doc "Set the number of nested collection members to display before truncating."
+               :requires {"max-coll-size" "New collection size."
+                          "session" "The current session"}
+               :returns {"status" "\"done\""}}
               "inspect-clear"
               {:doc "Clears the state state of the inspector."
                :requires {"session" "The current session"}

--- a/src/cider/nrepl/middleware/inspect.clj
+++ b/src/cider/nrepl/middleware/inspect.clj
@@ -25,10 +25,13 @@
      (response-for msg resp {:value value}))))
 
 (defn inspect-reply
-  [{:keys [page-size transport] :as msg} eval-response]
+  [{:keys [page-size transport max-atom-length max-coll-size] :as msg} eval-response]
   (let [value (cljs/response-value msg eval-response)
         page-size (or page-size 32)
-        inspector (swap-inspector! msg #(-> (assoc % :page-size page-size)
+        inspector (swap-inspector! msg #(-> %
+                                            (assoc :page-size page-size
+                                                   :max-atom-length max-atom-length
+                                                   :max-coll-size max-coll-size)
                                             (inspect/start value)))]
     (transport/send transport (inspector-response msg inspector {}))))
 
@@ -84,6 +87,14 @@
 (defn set-page-size-reply [msg]
   (inspector-response msg (swap-inspector! msg inspect/set-page-size (:page-size msg))))
 
+(defn set-max-atom-length-reply [msg]
+  (inspector-response msg (swap-inspector! msg inspect/set-max-atom-length
+                                           (:max-atom-length msg))))
+
+(defn set-max-coll-size-reply [msg]
+  (inspector-response msg (swap-inspector! msg inspect/set-max-coll-size
+                                           (:max-coll-size msg))))
+
 (defn clear-reply [msg]
   (inspector-response msg (swap-inspector! msg (constantly (inspect/fresh)))))
 
@@ -102,5 +113,7 @@
       "inspect-next-page" next-page-reply
       "inspect-prev-page" prev-page-reply
       "inspect-set-page-size" set-page-size-reply
+      "inspect-set-max-atom-length" set-max-atom-length-reply
+      "inspect-set-max-coll-size" set-max-coll-size-reply
       "inspect-clear" clear-reply
       "inspect-def-current-value" def-current-value)))


### PR DESCRIPTION
TODO: adjust cider/orchard version when published

The limits after which the inspector truncates collection members are now
configurable. Previously they were hardcoded to 5 and 150 for collection and
atom (non-collection) members.

---------------------------------

This continues the work in https://github.com/clojure-emacs/orchard/pull/111 and needs to be updated with the right orchard version number before it can merge.

---------------------------------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)

