### PR TITLE
Fix debugger quit for http handler functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+### Bugs Fixed
+* [#695](https://github.com/clojure-emacs/cider-nrepl/pull/695): Fix debugger quit for http handler functions
+
 ## 0.25.10 (2021-04-08)
 
 ### Bugs Fixed

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -501,8 +501,12 @@ this map (identified by a key), and will `dissoc` it afterwards."}
   response with `read-debug-command`'."
   [coor val locals STATE__]
   (if-let [first-coor @(:session-id STATE__)]
+    ;; Check if the instrumented function is being evaluated
+    ;; from the root again.
     (when (= first-coor coor)
-      (reset! (:skip STATE__) false))
+      ;; Clear any previously set skip state.
+      (reset! (:skip STATE__) false)
+      (skip-breaks! false))
     (reset! (:session-id STATE__) coor))
   (cond
     (skip-breaks? coor STATE__) val


### PR DESCRIPTION
Fixes #689 

In the `break` function, we reset the `:skip` in `STATE` when the debuggable function is called again. 
This is checked using the `coor` as follows -- 
```clojure
(if-let [first-coor @(:session-id STATE__)]
    (when (= first-coor coor)
      (reset! (:skip STATE__) false)
    (reset! (:session-id STATE__) coor))
```

But in case of functions called via HTTP -- 
- We skip breakpoints not using the `STATE__` but by setting `*skip-breaks*` atom as `{:mode :all}`. 
- Hence along with resetting `STATE__` on function being called again, we also need to reset the `*skip-breaks*` atom. 

This fixes the behavior of `:continue-all` and `:quit` commands for functions being called via HTTP. 