### PR TITLE
Make `stacktrace/ns-common-prefix` work in presence of user.clj files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#698](https://github.com/clojure-emacs/cider-nrepl/pull/698): Add `undef-all` op to undefine all symbols and aliases in namespace
 
+### Bugs fixed
+
+* Make `middleware.stacktrace` detect a given project's common ns prefix even in face of single-segment namespaces such as `user`.
+
 ## 0.26.0 (2021-04-22)
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 * Make `middleware.stacktrace` detect a given project's common ns prefix even in face of single-segment namespaces such as `user`.
 
+### Changes
+
+* Parallelize `cider.nrepl.middleware.stacktrace/analyze-stacktrace`.
+
 ## 0.26.0 (2021-04-22)
 
 ### New features

--- a/project.clj
+++ b/project.clj
@@ -129,7 +129,7 @@
                                       :test-ns-regex [#"^((?!debug-integration-test).)*$$"]}}]
 
              :cljfmt [:test
-                      {:plugins [[lein-cljfmt "0.7.0"]]
+                      {:plugins [[lein-cljfmt "0.8.0"]]
                        :cljfmt {:indents {as-> [[:inner 0]]
                                           delay [[:inner 0]]
                                           with-debug-bindings [[:inner 0]]
@@ -137,10 +137,10 @@
                                           try-if-let [[:block 1]]}}}]
 
              :clj-kondo [:test
-                         {:dependencies [[clj-kondo "2021.03.31"]]}]
+                         {:dependencies [[clj-kondo "2021.08.06"]]}]
 
              :eastwood [:test
-                        {:plugins [[jonase/eastwood "0.9.2"]]
+                        {:plugins [[jonase/eastwood "0.9.6"]]
                          :eastwood {:config-files ["eastwood.clj"]
                                     :exclude-namespaces [cider.nrepl.middleware.test-filter-tests]
                                     :ignored-faults {:unused-ret-vals-in-try {cider.nrepl.middleware.profile-test [{:line 25}]}

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -50,7 +50,6 @@
 ;;;   - the keyword :expression, in which case a single sexp must be
 ;;;     returned (as a string).
 
-
 ;;;; ## Internal breakpoint logic
 ;;;
 ;;; Variables and functions used for navigating between breakpoints.

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -31,7 +31,6 @@
 ;; Whenever a var's tests are run, their previous results are overwritten, so
 ;; the session always holds the most recent test result for each var.
 
-
 ;;; ## Test Results
 ;;
 ;; `clojure.test` allows extensible test reporting by rebinding the `report`


### PR DESCRIPTION
Prior to this fix, the cider-stacktrace "project-only" filter could be easily broken in presence of user.clj/dev.clj, because those single-segment namespaces would break the commonality between all other namespaces.

Also, performance is improved. The old `(map vector common ns)` created two vectors of chars, an operation to be repeated once per ns in the project. This is memory-hungry, even more so with the related `take-while` which is lazy.

An approach based on `reduce`/`reduce-kv`/`reduced` is introduced instead.

Parallelism is introduced as well.

Finally, `def directory-namespaces` is changed for `defn directory-namespaces`. The set of directory namespaces is always subject to change, so one has to ensure up-to-date accuracy on every invocation.

Accordingly, I had to perform adaptations throughout `middleware/stacktrace.clj` and `middleware/test.clj`, making sure that `(directory-namespaces)` is computed once per middleware op (instead of once _per frame_ - woud be quite expensive!).