### PR TITLE
Introduce `middleware.test/*test-error-handler*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#698](https://github.com/clojure-emacs/cider-nrepl/pull/698): Add `undef-all` op to undefine all symbols and aliases in namespace
+* Introduce `cider.nrepl.middleware.test/*test-error-handler*` var which you can override with arbitrary functions.
 
 ## 0.26.0 (2021-04-22)
 

--- a/test/clj/cider/nrepl/middleware/test_test.clj
+++ b/test/clj/cider/nrepl/middleware/test_test.clj
@@ -151,3 +151,17 @@
            (#'test/print-object (with-meta {:not :printed} {:type ::custom}))))
     (is (= "{:a :b, :c :d}\n"
            (#'test/print-object {:a :b :c :d})))))
+
+(deftest test-result-test
+  (testing "It passes `:error`s to `test/*test-error-handler*`"
+    (let [proof (atom [])
+          exception (ex-info "." {::unique (rand)})]
+      (binding [test/*test-error-handler* (fn [e]
+                                            (swap! proof conj e))]
+        (with-out-str
+          (test/test-result 'some-ns
+                            #'+
+                            {:type :error
+                             :actual exception}))
+        (is (= [exception]
+               @proof))))))


### PR DESCRIPTION
This allows users to attach arbitrary functionality when tests fail due to an exception.

For example, I used this to add an Expound-backed `println` for exceptions that were caused by Spec failures.

...While CIDER already prints Spec failures nicely via an Emacs UI, not all cider-nrepl clients necessarily have such an UI.

One might also appreciate a println with Expound's format, which is familiar for many, and will be consistent with printlns placed elsewhere in a given codebase.