### PR TITLE
Use session classloader when loading deferred middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Changes
 
 * Parallelize `cider.nrepl.middleware.stacktrace/analyze-stacktrace`.
+* [#705](https://github.com/clojure-emacs/cider-nrepl/pull/705): Use the session classloader when loading deferred middleware
 
 ## 0.26.0 (2021-04-22)
 


### PR DESCRIPTION
When loading CIDER middleware via the sideloader we need to make sure that extra
namespaces that are loaded later are also requested via the sideloader. The
original sideloader already provided a macro for
this (with-session-classloader), we just need to use it. This does mean that now
all our middlewares need to depend on the session middleware.

(see an earlier comment hinting at the fact this would still need to happen: https://github.com/nrepl/nrepl/pull/185#issuecomment-624317912)

Part of: https://github.com/clojure-emacs/cider/issues/3037

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)
