### PR TITLE
Improve build stability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,6 @@ commands:
           paths:
             - ~/.m2
             - .cpcache
-            - repo
           key: clojure-<< parameters.cache_version >>-{{ checksum "/tmp/clojure_cache_seed" }}
 
 # The jobs are relatively simple. One runs utility commands against

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
     steps:
       - checkout
       - with_cache:
-          cache_version: << parameters.clojure_version >>
+          cache_version: << parameters.clojure_version >>|<< parameters.jdk_version >>
           steps:
             - run:
                 name: Running tests with inlined deps

--- a/test/clj/cider/nrepl/print_method_test.clj
+++ b/test/clj/cider/nrepl/print_method_test.clj
@@ -26,6 +26,7 @@
     (Thread/sleep 300)
     @d
     (deliver p 1)
+    @f
     (are [o r] (re-find r (pr-str o))
       f #"#future\[\{:status :ready, :val 1\} 0x[a-z0-9]+\]"
       d #"#delay\[\{:status :ready, :val 1\} 0x[a-z0-9]+\]"


### PR DESCRIPTION
* CI: remove repo cache
  * Rationale: https://github.com/clojure-emacs/refactor-nrepl/pull/325#issuecomment-909417615
* Refine `test_code` cache key
  * Inspired by refactor-nrepl's setup, it had a problem that was solved this way.
* Fix flaky `print-idrefs-test`
  * Closes https://github.com/clojure-emacs/cider-nrepl/issues/706