### PR TITLE
Fix stack overflow error in cider.nrepl.middleware.out

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -158,9 +158,10 @@
                                     :exclude-namespaces [cider.nrepl.middleware.test-filter-tests]
                                     :ignored-faults {:unused-ret-vals-in-try {cider.nrepl.middleware.profile-test [{:line 25}]}
                                                      ;; This usage of `proxy` can't avoid reflection warnings given that the `proxy` construct dispatches based on name only:
-                                                     :reflection {cider.nrepl.middleware.out [{:line 55}
-                                                                                              {:line 57}
-                                                                                              {:line 59}
-                                                                                              {:line 61}
-                                                                                              {:line 65}]}
+                                                     :reflection {cider.nrepl.middleware.out [{:line 54}
+                                                                                              {:line 56}
+                                                                                              {:line 58}
+                                                                                              {:line 60}
+                                                                                              {:line 62}
+                                                                                              {:line 64}]}
                                                      :suspicious-test {cider.nrepl.middleware.profile-test [{:line 25}]}}}}]})

--- a/src/cider/nrepl/middleware/out.clj
+++ b/src/cider/nrepl/middleware/out.clj
@@ -18,12 +18,11 @@
 
 (declare unsubscribe-session)
 
-(defn original-output
-  "Store the values of the original output streams so we can refer to them."
-  ^PrintWriter
-  [k]
-  ({:out *out*
-    :err *err*} k))
+(defonce original-output
+  ^{:doc "Store the values of the original output streams so we can refer to them.
+Please do not inline; they must not be recomputed at runtime."}
+  {:out *out*
+   :err *err*})
 
 (defmacro with-out-binding
   "Run body with v bound to the output stream of each msg in msg-seq.


### PR DESCRIPTION
> Fixes https://github.com/clojure-emacs/cider-nrepl/issues/716

I saw following error messages when starting REPL.
```
;; on `*nrepl-server ... *` buffer
Exception: java.lang.StackOverflowError thrown from the UncaughtExceptionHandler in thread "Timer-0"

Exception: java.lang.StackOverflowError thrown from the UncaughtExceptionHandler in thread "Timer-1"
```

It was introduced at 1007408 commit.
```clojure
;; new
(defn original-output
  "Store the values of the original output streams so we can refer to them."
  ^PrintWriter
  [k]
  ({:out *out*
    :err *err*} k))

;; old
(def original-output
  "Store the values of the original output streams so we can refer to them."
  {:out *out*
   :err *err*})
```

`original-output` in `cider.nrepl.middleware.out` was changed to the function from the variable. 
If you change `*out*`/`*err*` via `alter-var-root` or another ways, `original-output` will use the changed value.

In `write`/`flush` method of proxy of `forking-printer`, call `write`/`flush` method with a value that return from `original-output`
`tracked-sessions-map-watch` replace `*out*` and `*err*` to return value of `forking-printer`.

I think this circle (i.e. infinite recursion) cuase the stack overflow.

(Sorry for the lack of explanation. Explaining in English difficult for me.)
