### PR TITLE
`middleware.test`: gracefully handle exceptions thrown within fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#719](https://github.com/clojure-emacs/cider-nrepl/issues/719): `middleware.test`: gracefully handle exceptions thrown within fixtures.
+
 ## 0.27.2 (2021-10-03)
 
 ### Bugs fixed

--- a/project.clj
+++ b/project.clj
@@ -158,10 +158,10 @@
                                     :exclude-namespaces [cider.nrepl.middleware.test-filter-tests]
                                     :ignored-faults {:unused-ret-vals-in-try {cider.nrepl.middleware.profile-test [{:line 25}]}
                                                      ;; This usage of `proxy` can't avoid reflection warnings given that the `proxy` construct dispatches based on name only:
-                                                     :reflection {cider.nrepl.middleware.out [{:line 54}
-                                                                                              {:line 56}
-                                                                                              {:line 58}
-                                                                                              {:line 60}
-                                                                                              {:line 62}
-                                                                                              {:line 64}]}
+                                                     :reflection {cider.nrepl.middleware.out [{:line 55}
+                                                                                              {:line 57}
+                                                                                              {:line 59}
+                                                                                              {:line 61}
+                                                                                              {:line 63}
+                                                                                              {:line 65}]}
                                                      :suspicious-test {cider.nrepl.middleware.profile-test [{:line 25}]}}}}]})

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -61,7 +61,7 @@
    (stack-frame (st/directory-namespaces) e f))
   ([namespaces ^Exception e f]
    (->> (map (partial st/analyze-frame namespaces) (.getStackTrace e))
-        (filter #(= (:class %) (.getName (class f))))
+        (filter #(= (:class %) (some-> f class .getName)))
         (first))))
 
 (defn- print-object
@@ -81,6 +81,8 @@
   for pretty-printing Spec failures. Remember to `flush` if doing so."
   identity)
 
+(def fallback-var-name ::unknown)
+
 (defn test-result
   "Transform the result of a test assertion. Append ns, var, assertion index,
   and 'testing' context. Retain any exception. Pretty-print expected/actual or
@@ -88,14 +90,15 @@
   [ns v m]
   (let [{:keys [actual diffs expected fault]
          t :type} m
+        v-name (or (:name (meta v)) fallback-var-name)
         c (when (seq test/*testing-contexts*) (test/testing-contexts-str))
-        i (count (get-in (:results @current-report {}) [ns (:name (meta v))]))
+        i (count (get-in (:results @current-report {}) [ns v-name]))
         gen-input (:gen-input @current-report)]
 
     ;; Errors outside assertions (faults) do not return an :expected value.
     ;; Type :fail returns :actual value. Type :error returns :error and :line.
     (merge (dissoc m :expected :actual)
-           {:ns ns, :var (:name (meta v)), :index i, :context c}
+           {:ns ns, :var v-name, :index i, :context c}
            (when (and (#{:fail :error} t) (not fault))
              {:expected (print-object expected)})
            (when (and (#{:fail} t) gen-input)
@@ -106,7 +109,7 @@
              {:diffs (extensions/diffs-result diffs)})
            (when (#{:error} t)
              (let [e actual
-                   f (or (:test (meta v)) @v)] ; test fn or deref'ed fixture
+                   f (or (:test (meta v)) (some-> v deref))] ; test fn or deref'ed fixture
                (*test-error-handler* e)
                {:error e
                 :line (:line (stack-frame e f))})))))
@@ -151,7 +154,8 @@
            #(-> %
                 (update-in [:summary :test] inc)
                 (update-in [:summary type] (fnil inc 0))
-                (update-in [:results ns (:name (meta v))]
+                (update-in [:results ns (or (:name (meta v))
+                                            fallback-var-name)]
                            (fnil conj [])
                            (test-result ns v m))
                 (assoc :gen-input nil)))))

--- a/test/clj/cider/nrepl/middleware/test_test.clj
+++ b/test/clj/cider/nrepl/middleware/test_test.clj
@@ -22,7 +22,8 @@
                         {:op "test"
                          :ns "cider.nrepl.middleware.test-filter-tests"
                          :tests (map name tests)})]
-                   (is (= tests (keys (:cider.nrepl.middleware.test-filter-tests results)))))
+                   (is (= tests (keys (:cider.nrepl.middleware.test-filter-tests results))))
+                   true)
       [:a-puff-of-smoke-test]
       [:a-smokey-test]
       [:a-puff-of-smoke-test :a-smokey-test]
@@ -130,6 +131,21 @@
           "more tests were run")
       (is ((set tests) :a-puff-of-smoke-test)
           "smoke test is still present without a filter"))))
+
+(deftest handling-of-tests-with-throwing-fixtures
+  (require 'cider.nrepl.middleware.test-with-throwing-fixtures)
+  (testing "If a given deftest's fixture throw an exception, those are gracefully handled"
+    (let [{{{[{:keys [error]}] :cider.nrepl.middleware.test/unknown} :cider.nrepl.middleware.test-with-throwing-fixtures} :results
+           :keys [summary status]
+           :as test-result}
+          (session/message {:op "test"
+                            :ns "cider.nrepl.middleware.test-with-throwing-fixtures"})]
+      (testing (pr-str test-result)
+        (is (= error
+               "clojure.lang.ExceptionInfo: I'm an exception inside a fixture! {:data 42}"))
+        (is (= summary
+               {:error 1, :fail 0, :ns 1, :pass 0, :test 0, :var 0}))
+        (is (= status #{"done"}))))))
 
 (deftest run-test-with-map-as-documentation-message
   (testing "documentation message map is returned as string"

--- a/test/resources/cider/nrepl/middleware/test_with_throwing_fixtures.clj
+++ b/test/resources/cider/nrepl/middleware/test_with_throwing_fixtures.clj
@@ -1,0 +1,10 @@
+(ns cider.nrepl.middleware.test-with-throwing-fixtures
+  (:require
+   [clojure.test :refer [deftest is use-fixtures]]))
+
+(use-fixtures :once (fn [t]
+                      (throw (ex-info "I'm an exception inside a fixture!" {:data 42}))
+                      (t)))
+
+(deftest foo
+  (is (= 42 (* 21 2))))


### PR DESCRIPTION
Fixes https://github.com/clojure-emacs/cider-nrepl/issues/719 (moved from the cider.el issue tracker)