### PR TITLE
fix: report test assertion line on exception

### DIFF
--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -7,6 +7,7 @@
    [cider.nrepl.middleware.util :as util]
    [cider.nrepl.middleware.util.coerce :as util.coerce]
    [clojure.pprint :as pp]
+   [clojure.string :as string]
    [clojure.test :as test]
    [clojure.walk :as walk]
    [nrepl.middleware.interruptible-eval :as ie]
@@ -65,7 +66,8 @@
           .getStackTrace
           (map (partial st/analyze-frame namespaces))
           (filter
-           #(clojure.string/starts-with? (:class %) (.getName (class f))))
+           #(some->  (:class %)
+                     (clojure.string/starts-with? class-name)))
           first))))
 
 (defn- print-object

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -64,7 +64,8 @@
      (->> e
           .getStackTrace
           (map (partial st/analyze-frame namespaces))
-          (filter #(= (:class %) class-name))
+          (filter
+           #(clojure.string/starts-with? (:class %) (.getName (class f))))
           first))))
 
 (defn- print-object

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -7,7 +7,7 @@
    [cider.nrepl.middleware.util :as util]
    [cider.nrepl.middleware.util.coerce :as util.coerce]
    [clojure.pprint :as pp]
-   [clojure.string :as string]
+   [clojure.string :as str]
    [clojure.test :as test]
    [clojure.walk :as walk]
    [nrepl.middleware.interruptible-eval :as ie]
@@ -66,8 +66,9 @@
           .getStackTrace
           (map (partial st/analyze-frame namespaces))
           (filter
-           #(some->  (:class %)
-                     (clojure.string/starts-with? class-name)))
+           #(when-let [frame-cname (:class %)]
+              (when (string? frame-cname)
+                (str/starts-with? frame-cname class-name))))
           first))))
 
 (defn- print-object

--- a/test/clj/cider/nrepl/middleware/test_test.clj
+++ b/test/clj/cider/nrepl/middleware/test_test.clj
@@ -210,3 +210,15 @@
            (comparable-stack-frame (test/stack-frame e throws)))
         "Returns a map representing the stack frame of the precise function
 that threw the exception")))
+
+(deftest stack-frame-line-test
+  (let [e (try
+            (throws)
+            (catch ExceptionInfo e
+              e))]
+    ;; NOTE this offset is subject to formatting of this test
+    (is (= (+ 2 (:line (meta #'stack-frame-line-test)))
+           (:line (test/stack-frame
+                   e
+                   (-> #'stack-frame-line-test meta :test))))
+        "Returns the line of the exception")))


### PR DESCRIPTION
Currently, when a clojure test assertion fails with an exception, the
:line reported is for the start of the test function.

This changes the reported line to the first line of any function within
the test function.