### PR TITLE
cider-macroexpand: Bind `LOADER` if unbound

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,8 @@ commands:
       - save_cache:
           paths:
             - ~/.m2
+            - linux-install-1.10.3.1040.sh
+            - clojure-tools-1.10.3.1040.tar.gz
             - .cpcache
           key: clojure-<< parameters.cache_version >>-{{ checksum "/tmp/clojure_cache_seed" }}
 
@@ -131,6 +133,18 @@ jobs:
             - run:
                 name: Running tests with inlined deps
                 command: make test smoketest
+            - run:
+                name: Install the Clojure CLI
+                command: |
+                  # the `nc` option skips downloading a file as already present
+                  # (as allowed by the Circle caching).
+                  wget -nc https://download.clojure.org/install/linux-install-1.10.3.1040.sh
+                  sed -i 's/curl -O/wget -nc/g' linux-install-1.10.3.1040.sh
+                  chmod +x linux-install-1.10.3.1040.sh
+                  sudo ./linux-install-1.10.3.1040.sh
+            - run:
+                name: Running tests specific to tools.deps
+                command: make tools-deps-test
 
 ######################################################################
 #

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -3,7 +3,8 @@
                                          (cider.nrepl.middleware.util.instrument/with-break)
                                          (cider.nrepl.middleware.util.instrument/instrument-special-form)
                                          (cider.nrepl.middleware.util.instrument/instrument-coll)
-                                         (cider.nrepl.print-method/def-print-method)]}
+                                         (cider.nrepl.print-method/def-print-method)
+                                         (cider.nrepl.middleware.out/with-out-binding)]}
            :unused-import {:level :off}
            :unresolved-namespace {:exclude [clojure.main]}}
  :output {:progress true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs fixed
 
+* [#721](https://github.com/clojure-emacs/cider-nrepl/issues/721): `middleware.macroexpand`: support a corner case for tools.deps.
 * [#735](https://github.com/clojure-emacs/cider-nrepl/issues/735): `middleware.test.extensions`: make `:actual` reporting clearer.
 * [#737](https://github.com/clojure-emacs/cider-nrepl/pull/737): Fix a regression in `middleware.out` that could result in duplicate output.
 

--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,14 @@ test/resources/cider/nrepl/clojuredocs/export.edn:
 
 inline-deps: .inline-deps
 
-test: .inline-deps test/resources/cider/nrepl/clojuredocs/export.edn
+test: clean .inline-deps test/resources/cider/nrepl/clojuredocs/export.edn
 	lein with-profile -user,-dev,+$(CLOJURE_VERSION),+test,+plugin.mranderson/config test
 
 quick-test: clean
 	lein with-profile -user,-dev,+$(CLOJURE_VERSION),+test test
+
+tools-deps-test: clean install
+	cd tools-deps-testing; clojure -M:test
 
 eastwood:
 	lein with-profile -user,-dev,+$(CLOJURE_VERSION),+eastwood eastwood

--- a/tools-deps-testing/deps.edn
+++ b/tools-deps-testing/deps.edn
@@ -1,0 +1,5 @@
+{:paths ["."]
+ :aliases {:test {:main-opts ["-m" "macroexpand-tools-deps-test"]
+                 :jvm-opts    ["-XX:-OmitStackTraceInFastThrow"
+                               "-Dclojure.main.report=stderr"]}}
+ :deps {cider/cider-nrepl {:mvn/version "RELEASE"}}}

--- a/tools-deps-testing/example.clj
+++ b/tools-deps-testing/example.clj
@@ -1,0 +1,6 @@
+(ns example)
+
+(defmacro foo []
+  (println (class @clojure.lang.Compiler/LOADER))
+  (assert (not (instance? clojure.lang.Var$Unbound @clojure.lang.Compiler/LOADER)))
+  42)

--- a/tools-deps-testing/macroexpand_tools_deps_test.clj
+++ b/tools-deps-testing/macroexpand_tools_deps_test.clj
@@ -1,0 +1,9 @@
+(ns macroexpand-tools-deps-test
+  (:require
+   [example]
+   [cider.nrepl.middleware.macroexpand]))
+
+(defn -main [& _]
+  (println (cider.nrepl.middleware.macroexpand/macroexpansion {:ns 'example
+                                                               :code "(foo)"}))
+  (System/exit 0))


### PR DESCRIPTION
Fixes https://github.com/clojure-emacs/cider-nrepl/issues/721

This issue is best summarized at https://github.com/clojure-emacs/cider-nrepl/issues/721#issuecomment-982690676

I was only able to reproduce it with tools.deps (just like OP), which is why a tools.deps-based integration test is proposed.

I verified that the test would fail the build if the fix is reverted: https://app.circleci.com/pipelines/github/clojure-emacs/cider-nrepl/500/workflows/bf930f3b-3deb-4c75-9f03-aa8c30ebca49