### PR TITLE
fix: remove reflection in forking-printer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs fixed
 
+* [#733](https://github.com/clojure-emacs/cider-nrepl/issues/719): `middleware.out`: remove reflection.
 * [#719](https://github.com/clojure-emacs/cider-nrepl/issues/719): `middleware.test`: gracefully handle exceptions thrown within fixtures.
 * [#722](https://github.com/clojure-emacs/cider-nrepl/issues/722): `middleware.format`: print otherwise non-serializable objects as strings.
 * [#708](https://github.com/clojure-emacs/cider-nrepl/issues/708): Upgrade Compliment, improving how autocompletion works in Windows.

--- a/project.clj
+++ b/project.clj
@@ -147,11 +147,4 @@
                          :eastwood {:config-files ["eastwood.clj"]
                                     :exclude-namespaces [cider.nrepl.middleware.test-filter-tests]
                                     :ignored-faults {:unused-ret-vals-in-try {cider.nrepl.middleware.profile-test [{:line 25}]}
-                                                     ;; This usage of `proxy` can't avoid reflection warnings given that the `proxy` construct dispatches based on name only:
-                                                     :reflection {cider.nrepl.middleware.out [{:line 55}
-                                                                                              {:line 57}
-                                                                                              {:line 59}
-                                                                                              {:line 61}
-                                                                                              {:line 63}
-                                                                                              {:line 65}]}
                                                      :suspicious-test {cider.nrepl.middleware.profile-test [{:line 25}]}}}}]})

--- a/src/cider/nrepl/middleware/out.clj
+++ b/src/cider/nrepl/middleware/out.clj
@@ -18,6 +18,8 @@
 
 (declare unsubscribe-session)
 
+(set! *warn-on-reflection* true)
+
 (defonce
   ^{:doc "Store the values of the original output streams so we can refer to them.
 Please do not inline; they must not be recomputed at runtime."}
@@ -30,10 +32,10 @@ Please do not inline; they must not be recomputed at runtime."}
   type is either :out or :err."
   [[v msg-seq type] & body]
   `(doseq [{:keys [~'session] :as ~'msg} ~msg-seq]
-     (let [~(with-meta v {:tag Writer}) (get @~'session
-                                             (case ~type
-                                               :out #'*out*
-                                               :err #'*err*))]
+     (let [~(with-meta v {:tag 'java.io.Writer}) (get @~'session
+                                                      (case ~type
+                                                        :out #'*out*
+                                                        :err #'*err*))]
        (try (binding [ieval/*msg* ~'msg]
               ~@body)
             ;; If a channel is faulty, dissoc it.
@@ -50,17 +52,42 @@ Please do not inline; they must not be recomputed at runtime."}
   [messages type]
   (PrintWriter. (proxy [Writer] []
                   (close [] (.flush ^Writer this))
+                  ;; unfortunately we can't type hint the method argument
+                  ;; as `int` and `char[]` aren't supported by proxy.
                   (write
                     ([x]
-                     (.write (original-output type) x)
                      (with-out-binding [printer messages type]
-                       (.write printer x)))
+                       (cond
+                         (string? x)
+                         (do
+                           (.write ^Writer (original-output type) ^String x)
+                           (.write printer ^String x))
+
+                         (integer? x)
+                         (do
+                           (.write ^Writer (original-output type) ^int x)
+                           (.write printer ^int x))
+                         :else
+                         (do
+                           (.write ^Writer (original-output type)
+                                   ^{:tag "[C"} x)
+                           (.write printer ^{:tag "[C"} x)))))
                     ([x ^Integer off ^Integer len]
-                     (.write (original-output type) x off len)
                      (with-out-binding [printer messages type]
-                       (.write printer x off len))))
+                       (cond
+                         (string? x)
+                         (do
+                           (.write ^Writer (original-output type)
+                                   ^String x off len)
+                           (.write printer ^String x off len))
+
+                         :else
+                         (do
+                           (.write ^Writer (original-output type)
+                                   ^{:tag "[C"} x off len)
+                           (.write printer ^{:tag "[C"} x off len))))))
                   (flush []
-                    (.flush (original-output type))
+                    (.flush ^Writer (original-output type))
                     (with-out-binding [printer messages type]
                       (.flush printer))))
                 true))

--- a/src/cider/nrepl/middleware/out.clj
+++ b/src/cider/nrepl/middleware/out.clj
@@ -18,8 +18,6 @@
 
 (declare unsubscribe-session)
 
-(set! *warn-on-reflection* true)
-
 (defonce
   ^{:doc "Store the values of the original output streams so we can refer to them.
 Please do not inline; they must not be recomputed at runtime."}


### PR DESCRIPTION
Remove reflection to improve speed and reduce garbage creation.


- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [] You've updated the README (if adding/changing middleware)