### PR TITLE
chore: remove unnecessary binding of current message

### DIFF
--- a/src/cider/nrepl/middleware/out.clj
+++ b/src/cider/nrepl/middleware/out.clj
@@ -34,11 +34,11 @@ Please do not inline; they must not be recomputed at runtime."}
                                                       (case ~type
                                                         :out #'*out*
                                                         :err #'*err*))]
-       (try (binding [ieval/*msg* ~'msg]
-              ~@body)
-            ;; If a channel is faulty, dissoc it.
-            (catch Exception ~'e
-              (unsubscribe-session ~'session))))))
+       (try
+         ~@body
+         ;; If a channel is faulty, dissoc it.
+         (catch Exception ~'e
+           (unsubscribe-session ~'session))))))
 
 (defn forking-printer
   "Returns a PrintWriter suitable for binding as *out* or *err*. All

--- a/src/cider/nrepl/middleware/out.clj
+++ b/src/cider/nrepl/middleware/out.clj
@@ -10,8 +10,7 @@
   guarantee that the channel that sent the clone message will properly
   handle output replies."
   (:require
-   [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
-   [nrepl.middleware.interruptible-eval :as ieval])
+   [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]])
   (:import
    [java.io PrintWriter Writer PrintStream OutputStream]
    [java.util TimerTask Timer]))


### PR DESCRIPTION
The binding is not used within the body expressions, and costs a thread
local binding, producing garbage.  This changes ensures print-stream
produces no memory garbage.

-------

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)

**Note:** If you're just starting out to hack on `cider-nrepl` you might find
[nREPL's documentation](https://nrepl.org) and the
"Design" section of the README extremely useful.*

Thanks!