### PR TITLE
chore: use single executor service instead of timer per stream

### DIFF
--- a/src/cider/nrepl/middleware/out.clj
+++ b/src/cider/nrepl/middleware/out.clj
@@ -96,6 +96,12 @@ Please do not inline; they must not be recomputed at runtime."}
 
 (let [id-counter (atom 0)]
   (def ^ScheduledExecutorService flush-executor
+    "An executor used to run flush on `print-stream` instances.
+   Using a single thread reduces resource usage, and possibly reduces
+   the interleaving of output from different streams.
+   The executor service will ensure there is always a thread available,
+   should a flush throw an exception and kill a thread.
+   Thread names are generated with id-counter, to make them unique."
     (Executors/newScheduledThreadPool
      1
      (proxy [ThreadFactory] []

--- a/src/cider/nrepl/middleware/out.clj
+++ b/src/cider/nrepl/middleware/out.clj
@@ -94,13 +94,15 @@ Please do not inline; they must not be recomputed at runtime."}
                       (.flush printer))))
                 true))
 
-(def ^ScheduledExecutorService flush-executor
-  (Executors/newScheduledThreadPool
-   1
-   (proxy [ThreadFactory] []
-     (newThread [^Runnable r]
-       (doto (Thread. r "cider-nrepl output flusher")
-         (.setDaemon true))))))
+(let [id-counter (atom 0)]
+  (def ^ScheduledExecutorService flush-executor
+    (Executors/newScheduledThreadPool
+     1
+     (proxy [ThreadFactory] []
+       (newThread [^Runnable r]
+         (doto (Thread.
+                (str "cider-nrepl output flusher " (swap! id-counter inc)))
+           (.setDaemon true)))))))
 
 (defn print-stream
   "Returns a PrintStream suitable for binding as java.lang.System/out or

--- a/src/cider/nrepl/middleware/out.clj
+++ b/src/cider/nrepl/middleware/out.clj
@@ -120,6 +120,8 @@ Please do not inline; they must not be recomputed at runtime."}
     (PrintStream.
      (proxy [OutputStream] []
        (close []
+         ;; cancel, allowing any running flush to finish
+         ;; (false passed as mayInterruptIfRunning argument)
          (.cancel flush-future false)
          (.flush ^OutputStream this))
        (write

--- a/src/cider/nrepl/middleware/out.clj
+++ b/src/cider/nrepl/middleware/out.clj
@@ -118,7 +118,7 @@ Please do not inline; they must not be recomputed at runtime."}
 
   `printer` is the printer var, either #'clojure.core/*out* or
   #'clojure.core/*err*."
-  [printer]
+  ^PrintStream [printer]
   (let [delay 100
         print-flusher (fn [] (.flush ^Writer @printer))
         flush-future (.scheduleWithFixedDelay

--- a/src/cider/nrepl/middleware/out.clj
+++ b/src/cider/nrepl/middleware/out.clj
@@ -101,7 +101,7 @@ Please do not inline; they must not be recomputed at runtime."}
      (proxy [ThreadFactory] []
        (newThread [^Runnable r]
          (doto (Thread.
-                (str "cider-nrepl output flusher " (swap! id-counter inc)))
+                (str "cider-nrepl-output-flusher-" (swap! id-counter inc)))
            (.setDaemon true)))))))
 
 (defn print-stream

--- a/src/cider/nrepl/middleware/out.clj
+++ b/src/cider/nrepl/middleware/out.clj
@@ -94,12 +94,13 @@ Please do not inline; they must not be recomputed at runtime."}
                       (.flush printer))))
                 true))
 
-(def flush-executor (Executors/newScheduledThreadPool
-                     1
-                     (proxy [ThreadFactory] []
-                       (newThread [^Runnable r]
-                         (doto (Thread. r "cider-nrepl output flusher")
-                           (.setDaemon true))))))
+(def ^ScheduledExecutorService flush-executor
+  (Executors/newScheduledThreadPool
+   1
+   (proxy [ThreadFactory] []
+     (newThread [^Runnable r]
+       (doto (Thread. r "cider-nrepl output flusher")
+         (.setDaemon true))))))
 
 (defn print-stream
   "Returns a PrintStream suitable for binding as java.lang.System/out or
@@ -113,7 +114,7 @@ Please do not inline; they must not be recomputed at runtime."}
   (let [delay 100
         print-flusher (fn [] (.flush ^Writer @printer))
         flush-future (.scheduleWithFixedDelay
-                      ^ScheduledExecutorService flush-executor
+                      flush-executor
                       print-flusher
                       delay delay TimeUnit/MILLISECONDS)]
 

--- a/src/cider/nrepl/middleware/out.clj
+++ b/src/cider/nrepl/middleware/out.clj
@@ -93,7 +93,6 @@ Please do not inline; they must not be recomputed at runtime."}
                       (.flush printer))))
                 true))
 
-
 (def flush-executor (Executors/newScheduledThreadPool
                      1
                      (proxy [ThreadFactory] []

--- a/test/clj/cider/nrepl/middleware/out_test.clj
+++ b/test/clj/cider/nrepl/middleware/out_test.clj
@@ -145,10 +145,10 @@
       (when (and (= "" (.toString out-writer)) (>= 0 i))
         (Thread/sleep 1)
         (recur (unchecked-dec i))))
-    (is (str/starts-with?
+    (is (re-matches
+         #"cider-nrepl-output-flusher-\d+"
          (-> ^ThreadPoolExecutor o/flush-executor
              .getThreadFactory
              (.newThread #())
-             .getName)
-         "cider-nrepl-output-flusher-"))
+             .getName)))
     (is (= " " (.toString out-writer)))))

--- a/test/clj/cider/nrepl/middleware/out_test.clj
+++ b/test/clj/cider/nrepl/middleware/out_test.clj
@@ -149,5 +149,5 @@
       (when (and (= "" (.toString out-writer)) (>= 0 i))
         (Thread/sleep 1)
         (recur (unchecked-dec i))))
-    (is (find-thread "cider-nrepl output flusher"))
+    (is (find-thread "cider-nrepl output flusher 1"))
     (is (= " " (.toString out-writer)))))

--- a/test/clj/cider/nrepl/middleware/out_test.clj
+++ b/test/clj/cider/nrepl/middleware/out_test.clj
@@ -4,7 +4,8 @@
    [clojure.string :as str]
    [clojure.test :refer :all])
   (:import
-   [java.io PrintWriter StringWriter]))
+   [java.io PrintWriter StringWriter]
+   [java.util.concurrent ThreadPoolExecutor]))
 
 (defn random-str []
   (->> #(format "%x" (rand-int 15))
@@ -145,6 +146,9 @@
         (Thread/sleep 1)
         (recur (unchecked-dec i))))
     (is (str/starts-with?
-         (.getName (.newThread (.getThreadFactory o/flush-executor) #()))
+         (-> ^ThreadPoolExecutor o/flush-executor
+             .getThreadFactory
+             (.newThread #())
+             .getName)
          "cider-nrepl-output-flusher-"))
     (is (= " " (.toString out-writer)))))


### PR DESCRIPTION
Replace the per output-stream Timer instance with a single scheduled
thread pool executor with a single thread.

- Removes the need for a proxy object on every print-stream.

- Executor service is generally preferred over Timer.

- The thread is named so its purpose is apparent.

-------

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)