### PR TITLE
Refine `=-body` behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs fixed
 
+* [#735](https://github.com/clojure-emacs/cider-nrepl/issues/735): `middleware.test.extensions`: make `:actual` reporting clearer.
 * [#737](https://github.com/clojure-emacs/cider-nrepl/pull/737): Fix a regression in `middleware.out` that could result in duplicate output.
 
 ## 0.27.3 (2021-12-07)

--- a/project.clj
+++ b/project.clj
@@ -140,10 +140,10 @@
                                           try-if-let [[:block 1]]}}}]
 
              :clj-kondo [:test
-                         {:dependencies [[clj-kondo "2021.09.15"]]}]
+                         {:dependencies [[clj-kondo "2021.12.01"]]}]
 
              :eastwood [:test
-                        {:plugins [[jonase/eastwood "0.9.9"]]
+                        {:plugins [[jonase/eastwood "1.0.0"]]
                          :eastwood {:config-files ["eastwood.clj"]
                                     :exclude-namespaces [cider.nrepl.middleware.test-filter-tests]
                                     :ignored-faults {:unused-ret-vals-in-try {cider.nrepl.middleware.profile-test [{:line 25}]}

--- a/src/cider/nrepl/middleware/content_type.clj
+++ b/src/cider/nrepl/middleware/content_type.clj
@@ -117,11 +117,13 @@
   and inspect / alter them."
   [^Transport transport]
   (reify Transport
-    (recv [this]
+    (recv [_this]
       (.recv transport))
-    (recv [this timeout]
+
+    (recv [_this timeout]
       (.recv transport timeout))
-    (send [this response]
+
+    (send [_this response]
       (.send transport (response+content-type response)))))
 
 (defn handle-content-type

--- a/src/cider/nrepl/middleware/inspect.clj
+++ b/src/cider/nrepl/middleware/inspect.clj
@@ -38,8 +38,12 @@
 (defn inspector-transport
   [{:keys [^Transport transport] :as msg}]
   (reify Transport
-    (recv [this] (.recv transport))
-    (recv [this timeout] (.recv transport timeout))
+    (recv [_this]
+      (.recv transport))
+
+    (recv [_this timeout]
+      (.recv transport timeout))
+
     (send [this response]
       (cond (contains? response :value)
             (inspect-reply msg response)

--- a/src/cider/nrepl/middleware/test/extensions.clj
+++ b/src/cider/nrepl/middleware/test/extensions.clj
@@ -23,7 +23,13 @@
                            (map #(vector % (data/diff expected# %))))})
             (merge {:message ~msg
                     :expected expected#
-                    :actual more#})
+                    :actual
+                    (if (= 1 (count more#))
+                      ;; most times,` more` has a count of 1. For this case, we unwrap `more`,
+                      ;; which has been the traditional behavior of this feature:
+                      (first more#)
+                      ;; if `more` has 2+ arguments, our :actual will closely resemble clojure.test's own:
+                      (list ~''not (apply list ~(list 'quote '=) expected# more#)))})
             test/do-report)
        result#)
     `(throw (Exception. "= expects more than one argument"))))

--- a/src/cider/nrepl/middleware/track_state.clj
+++ b/src/cider/nrepl/middleware/track_state.clj
@@ -222,9 +222,13 @@
   about the state."
   [{:keys [^Transport transport session] :as msg}]
   (reify Transport
-    (recv [this] (.recv transport))
-    (recv [this timeout] (.recv transport timeout))
-    (send [this {:keys [status] :as response}]
+    (recv [_this]
+      (.recv transport))
+
+    (recv [_this timeout]
+      (.recv transport timeout))
+
+    (send [_this {:keys [status] :as response}]
       (.send transport response)
       (when (contains? status :done)
         (send ns-cache update-in [session]

--- a/test/clj/cider/nrepl/middleware/test/extensions_test.clj
+++ b/test/clj/cider/nrepl/middleware/test/extensions_test.clj
@@ -1,7 +1,7 @@
 (ns cider.nrepl.middleware.test.extensions-test
   (:require
    [cider.nrepl.middleware.test.extensions :as extensions]
-   [clojure.test :refer :all]))
+   [clojure.test :refer [are deftest is testing]]))
 
 (deftest =-body-test
   (testing "Only evalulates expected form once"
@@ -20,4 +20,16 @@
              (- (swap! a inc) 6)
              (- (swap! a inc) 7)
              (- (swap! a inc) 8)
-             (- (swap! a inc) 9))))))
+             (- (swap! a inc) 9)))))
+  (testing ":actual is a scalar for (= x y) (i.e. arity 2)
+ and an informative list for (= x y z) (i.e. arity 3+)"
+    (are [subject args expected] (= expected
+                                    (let [proof (atom nil)]
+                                      (with-redefs [clojure.test/do-report
+                                                    (fn [m]
+                                                      (reset! proof m))]
+                                        (eval (extensions/=-body "_" subject args))
+                                        @proof)))
+      1 [1]   '{:expected 1, :actual 1, :message "_", :type :pass}
+      1 [2]   '{:expected 1, :actual 2, :message "_", :type :fail, :diffs ([2 [1 2 nil]])}
+      1 [2 3] '{:expected 1, :actual (not (= 1 2 3)), :message "_", :type :fail, :diffs ([2 [1 2 nil]] [3 [1 3 nil]])})))


### PR DESCRIPTION
* Unwrap lists for `:actual` in `=` arity 2
* Use traditional clojure.test notation for `:actual` in `=` arity 3+

This is clearly reflected in the included tests.

Fixes https://github.com/clojure-emacs/cider-nrepl/issues/735