### PR TITLE
chore: add clj-kondo rewrite hook for with-out-binding

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,10 +1,11 @@
-{:linters {:unresolved-symbol {:exclude [(cider.nrepl/def-wrapper)
+{:hooks {:analyze-call {cider.nrepl.middleware.out/with-out-binding
+                        hooks.core/with-out-binding}}
+ :linters {:unresolved-symbol {:exclude [(cider.nrepl/def-wrapper)
                                          (cider.nrepl.middleware.util.instrument/definstrumenter)
                                          (cider.nrepl.middleware.util.instrument/with-break)
                                          (cider.nrepl.middleware.util.instrument/instrument-special-form)
                                          (cider.nrepl.middleware.util.instrument/instrument-coll)
-                                         (cider.nrepl.print-method/def-print-method)
-                                         (cider.nrepl.middleware.out/with-out-binding)]}
+                                         (cider.nrepl.print-method/def-print-method)]}
            :unused-import {:level :off}
            :unresolved-namespace {:exclude [clojure.main]}}
  :output {:progress true

--- a/.clj-kondo/hooks/core.clj
+++ b/.clj-kondo/hooks/core.clj
@@ -1,0 +1,24 @@
+(ns hooks.core
+  (:require
+   [clj-kondo.hooks-api :as api]))
+
+(defn with-out-binding
+  "Rewrite with-out-binding as a let on the first symbol in the arg vector.
+  The remaining args in the  arg vector are evaluated."
+  [{:keys [node]}]
+  (let [[_ binding-vec & body] (:children node)
+        [binding & others] (:children binding-vec)
+        new-node (api/list-node
+                  (list*
+                   (api/token-node 'let)
+                   (api/vector-node
+                    (reduce
+                     into
+                     [binding (api/token-node 'nil)]
+                     (mapv
+                      #(vector (api/token-node '_) %)
+                      others)))
+                   body))]
+    ;; un-comment below to debug changes
+    ;; (prn :with-binding (api/sexpr new-node))
+    {:node (with-meta new-node (meta node))}))


### PR DESCRIPTION
Allow clj-kondo to understand the with-out-binding form, so linters
still get applied to it.