### PR TITLE
Content-type dispatch via multimethod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#548](https://github.com/clojure-emacs/cider-nrepl/pull/548): Make the content-type middleware extensible via multimethod
+
 ## 0.27.4 (2021-12-15)
 
 ### Bugs fixed

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -156,7 +156,7 @@ Returns::
 {blank}
 
 
-=== `content-type-middleware`
+=== `content-type`
 
 Enhances the ``eval`` op by adding ``content-type`` and ``body`` to certain ``eval`` responses. Not an op in itself.
 
@@ -171,8 +171,9 @@ Optional parameters::
 
 Returns::
 * `:body` The rich response document, if applicable.
-* `:content-type` The Media type (MIME type) of the reponse, structured as a pair, `[type {:as attrs}]`
-* `:content-transfer-encoding` The encoding of the response body (Optional, currently only one possible value `"base64"`)
+* `:content-transfer-encoding` The encoding of the response body (Optional, currently only one possible value: ``"base64"``).
+* `:content-type` The Media type (MIME type) of the reponse, structured as a pair, ``[type {:as attrs}]``.
+
 
 
 === `debug-input`
@@ -928,7 +929,10 @@ Optional parameters::
 {blank}
 
 Returns::
-{blank}
+* `:body` The slurped content body.
+* `:content-transfer-encoding` The encoding (if any) for the content.
+* `:content-type` A MIME type for the response, if one can be detected.
+
 
 
 === `spec-example`
@@ -973,7 +977,7 @@ Required parameters::
 {blank}
 
 Optional parameters::
-* `:filter-regex` Only the specs that matches filter prefix regex will be returned
+* `:filter-regex` Only the specs that matches filter prefix regex will be returned 
 
 
 Returns::
@@ -1199,3 +1203,4 @@ Optional parameters::
 
 Returns::
 * `:status` done
+

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -158,7 +158,9 @@ Returns::
 
 === `content-type-middleware`
 
-Enhances the ``eval`` op by adding ``content-type`` and friends to some responses. Not an op in itself.
+Enhances the ``eval`` op by adding ``content-type`` and ``body`` to certain ``eval`` responses. Not an op in itself.
+
+Depending on the type of the return value of the evaluation this middleware may kick in and include a representation of the result in the response, together with a MIME/Media type to indicate how it should be handled by the client. Comes with implementations for ``URI``, ``URL``, ``File``, and ``java.awt.Image``. More type handlers can be provided by the user by extending the ``cider.nrepl.middleware.content-type/content-type-response`` multimethod. This dispatches using ``clojure.core/type``, so ``:type`` metadata on plain Clojure values can be used to provide custom handling.
 
 Required parameters::
 {blank}
@@ -168,7 +170,9 @@ Optional parameters::
 
 
 Returns::
-{blank}
+* `:body` The rich response document, if applicable.
+* `:content-type` The Media type (MIME type) of the reponse, structured as a pair, `[type {:as attrs}]`
+* `:content-transfer-encoding` The encoding of the response body (Optional, currently only one possible value `"base64"`)
 
 
 === `debug-input`

--- a/doc/modules/ROOT/pages/nrepl-api/supplied_middleware.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/supplied_middleware.adoc
@@ -27,6 +27,12 @@
 | `complete`
 | Code completion.
 
+| `wrap-content-type`
+| -
+| No
+| `eval`
+| Rich content handling, return multimedia results beyond plain text from `eval`.
+
 | `wrap-debug`
 | -
 | No

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -109,20 +109,22 @@
   {:doc "Middleware that adds `content-type` annotations to the result of the the eval op."
    :requires #{#'wrap-print}
    :expects #{"eval" "load-file"}
-   :returns {"content-type" "A MIME type for the response, if one can be detected."
-             "content-transfer-encoding" "The encoding (if any) of the content."
-             "body" "The content."}
-   :handles {"content-type-middleware"
-             {:doc "Enhances the `eval` op by adding `content-type` and friends to some responses. Not an op in itself."
+   :handles {"content-type"
+             {:doc "Enhances the `eval` op by adding `content-type` and `body` to certain `eval` responses. Not an op in itself.
+
+Depending on the type of the return value of the evaluation this middleware may kick in and include a representation of the result in the response, together with a MIME/Media type to indicate how it should be handled by the client. Comes with implementations for `URI`, `URL`, `File`, and `java.awt.Image`. More type handlers can be provided by the user by extending the `cider.nrepl.middleware.content-type/content-type-response` multimethod. This dispatches using `clojure.core/type`, so `:type` metadata on plain Clojure values can be used to provide custom handling."
+              :returns {"body" "The rich response document, if applicable."
+                        "content-type" "The Media type (MIME type) of the reponse, structured as a pair, `[type {:as attrs}]`."
+                        "content-transfer-encoding" "The encoding of the response body (Optional, currently only one possible value: `\"base64\"`)."}
               :optional {"content-type" "If present and non-nil, try to detect and handle content-types."}}}})
 
 (def-wrapper wrap-slurp cider.nrepl.middleware.slurp/handle-slurp
   {:doc "Middleware that handles slurp requests."
-   :returns {"content-type" "A MIME type for the response, if one can be detected."
-             "content-transfer-encoding" "The encoding (if any) for the content."
-             "body" "The slurped content body."}
    :handles {"slurp"
-             {:doc "Slurps a URL from the nREPL server, returning MIME data."}}})
+             {:doc "Slurps a URL from the nREPL server, returning MIME data."
+              :returns {"content-type" "A MIME type for the response, if one can be detected."
+                        "content-transfer-encoding" "The encoding (if any) for the content."
+                        "body" "The slurped content body."}}}})
 
 (def-wrapper wrap-apropos cider.nrepl.middleware.apropos/handle-apropos
   {:doc "Middleware that handles apropos requests"

--- a/src/cider/nrepl/middleware/content_type.clj
+++ b/src/cider/nrepl/middleware/content_type.clj
@@ -109,10 +109,9 @@
     (merge response (external-body-response file))
     response))
 
-(defmethod content-type-response java.awt.Image [{^java.awt.Image image :value :as response}]
+(defmethod content-type-response java.awt.image.RenderedImage [{^java.awt.image.RenderedImage image :value :as response}]
   (with-open [bos (ByteArrayOutputStream.)]
-    (ImageIO/write image "png" ^OutputStream bos)
-    (merge response (when (ImageIO/write ^RenderedImage image "png" ^OutputStream bos)
+    (merge response (when (ImageIO/write image "png" ^OutputStream bos)
                       (slurp-reply "" ["image/png" {}] (.toByteArray bos))))))
 
 (defn content-type-transport

--- a/src/cider/nrepl/middleware/content_type.clj
+++ b/src/cider/nrepl/middleware/content_type.clj
@@ -112,7 +112,7 @@
 (defmethod content-type-response java.awt.Image [{^java.awt.Image image :value :as response}]
   (with-open [bos (ByteArrayOutputStream.)]
     (ImageIO/write image "png" ^OutputStream bos)
-    (merge response (when (ImageIO/write ^RenderedImage value "png" ^OutputStream bos)
+    (merge response (when (ImageIO/write ^RenderedImage image "png" ^OutputStream bos)
                       (slurp-reply "" ["image/png" {}] (.toByteArray bos))))))
 
 (defn content-type-transport
@@ -126,7 +126,7 @@
     (recv [_this timeout]
       (.recv transport timeout))
 
-    (send [this response]
+    (send [_this response]
       (.send transport (content-type-response response)))))
 
 (defn handle-content-type

--- a/src/cider/nrepl/middleware/content_type.clj
+++ b/src/cider/nrepl/middleware/content_type.clj
@@ -56,24 +56,24 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defprotocol URLCoercable
-  (as-url [o]))
+  (as-url-string [o]))
 
 (extend-protocol URLCoercable
   Path
-  (as-url [^Path p]
-    (.. p normalize toUri toURL))
+  (as-url-string [^Path p]
+    (.. p normalize toUri toString))
 
   File
-  (as-url [^File f]
-    (.. f getCanonicalFile toURI toURL))
+  (as-url-string [^File f]
+    (.. f getCanonicalFile toURI toString))
 
   URI
-  (as-url [^URI u]
-    (.. u toURL))
+  (as-url-string [^URI u]
+    (.toString u))
 
   URL
-  (as-url [^URL u]
-    u))
+  (as-url-string [^URL u]
+    (.toString u)))
 
 (defn external-body-response
   "Partial response map having an external-body content-type referring to the given URL.
@@ -82,7 +82,7 @@
   [value]
   {:content-type ["message/external-body"
                   {"access-type" "URL"
-                   "URL" (.toString ^URL (as-url value))}]
+                   "URL" (as-url-string value)}]
    :body ""})
 
 (defmulti content-type-response

--- a/test/clj/cider/nrepl/middleware/content_type_test.clj
+++ b/test/clj/cider/nrepl/middleware/content_type_test.clj
@@ -3,7 +3,9 @@
    [cider.nrepl.middleware.content-type :as content-type]
    [cider.nrepl.test-session :as session]
    [clojure.string :as str]
-   [clojure.test :refer :all]))
+   [clojure.test :refer :all])
+  (:import
+   [org.apache.commons.lang3 SystemUtils]))
 
 (use-fixtures :each session/session-fixture)
 
@@ -55,12 +57,14 @@
                  (select-keys [:body :content-type :content-transfer-encoding :status]))))))
 
   (testing "java.awt.image.RenderedImage"
-    (is (= {:body "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4XmNgAAIAAAUAAQYUdaMAAAAASUVORK5CYII=",
+    (is (= {:body (if (SystemUtils/IS_JAVA_1_8)
+                    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR42mNgYGAAAAAEAAHI6uv5AAAAAElFTkSuQmCC"
+                    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4XmNgYGAAAAAEAAEP0q3kAAAAAElFTkSuQmCC")
             :content-type ["image/png" {}]
             :content-transfer-encoding "base64"
             :status #{"done"}}
            (-> {:op "eval"
-                :code "(java.awt.image.BufferedImage. 1 1 java.awt.image.BufferedImage/TYPE_INT_ARGB)"
+                :code "(java.awt.image.BufferedImage. 1 1 java.awt.image.BufferedImage/TYPE_INT_RGB)"
                 :content-type "true"}
                session/message
                (select-keys [:body :content-type :content-transfer-encoding :status])))))

--- a/test/clj/cider/nrepl/middleware/content_type_test.clj
+++ b/test/clj/cider/nrepl/middleware/content_type_test.clj
@@ -1,0 +1,79 @@
+(ns cider.nrepl.middleware.content-type-test
+  (:require
+   [cider.nrepl.middleware.content-type :as content-type]
+   [cider.nrepl.test-session :as session]
+   [clojure.string :as str]
+   [clojure.test :refer :all]))
+
+(use-fixtures :each session/session-fixture)
+
+(defmethod content-type/content-type-response :graphviz [{:keys [value] :as response}]
+  (let [{:keys [name edges]} value]
+    (assoc response
+           :content-type ["text/vnd.graphviz" {}]
+           :body
+           (str "graph " name " {\n"
+                (str/join "\n"
+                          (for [[from to] edges]
+                            (str from " -- " to ";")))
+                "\n}"))))
+
+(deftest content-type-middleware-test
+  (testing "java.net.URI"
+    (is (= {:body ""
+            :content-type ["message/external-body"
+                           {:URL "https://lambdaisland.com"
+                            :access-type "URL"}]
+            :status #{"done"}}
+           (select-keys (session/message {:op "eval"
+                                          :code "(java.net.URI. \"https://lambdaisland.com\")"
+                                          :content-type "true"})
+                        [:body :content-type :content-transfer-encoding :status]))))
+
+  (testing "java.net.URL"
+    (is (= {:body ""
+            :content-type ["message/external-body"
+                           {:URL "https://lambdaisland.com"
+                            :access-type "URL"}]
+            :status #{"done"}}
+           (select-keys (session/message {:op "eval"
+                                          :code "(java.net.URL. \"https://lambdaisland.com\")"
+                                          :content-type "true"})
+                        [:body :content-type :content-transfer-encoding :status]))))
+
+  (testing "java.io.File"
+    (let [f (java.io.File/createTempFile "foo" ".txt")]
+      (is (= {:body ""
+              :content-type
+              ["message/external-body"
+               {:URL (str "file:" f) :access-type "URL"}]
+              :status #{"done"}}
+             (-> {:op "eval"
+                  :code (str "(java.io.File. " (pr-str (str f)) ")")
+                  :content-type "true"}
+                 session/message
+                 (select-keys [:body :content-type :content-transfer-encoding :status]))))))
+
+  (testing "java.awt.image.RenderedImage"
+    (is (= {:body "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4XmNgAAIAAAUAAQYUdaMAAAAASUVORK5CYII=",
+            :content-type ["image/png" {}]
+            :content-transfer-encoding "base64"
+            :status #{"done"}}
+           (-> {:op "eval"
+                :code "(java.awt.image.BufferedImage. 1 1 java.awt.image.BufferedImage/TYPE_INT_ARGB)"
+                :content-type "true"}
+               session/message
+               (select-keys [:body :content-type :content-transfer-encoding :status])))))
+
+  (testing "custom type implementation"
+    (is (= {:body "graph foo {\na -- b;\nb -- c;\n}"
+            :content-type ["text/vnd.graphviz" {}]
+            :status #{"done"}}
+           (-> {:op "eval"
+                :code (str "^{:type :graphviz} "
+                           (pr-str
+                            {:name "foo"
+                             :edges [["a" "b"] ["b" "c"]]}))
+                :content-type "true"}
+               session/message
+               (select-keys [:body :content-type :content-transfer-encoding :status]))))))


### PR DESCRIPTION
Duplicate of #548 to see if CircleCI is happier this way.

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the README (if adding/changing middleware)

**Note:** If you're just starting out to hack on `cider-nrepl` you might find
[nREPL's documentation](https://nrepl.org) and the
"Design" section of the README extremely useful.*

Thanks!
