### PR TITLE
undef-all: skip unmapping of default imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## 0.28.3 (2022-02-22)
 
+### Bugs Fixed 
+
+* [#751](https://github.com/clojure-emacs/cider-nrepl/issues/751): Skip unmapping of default imports in `undef-all` op.
+
+### Changes
+
 * Upgrade [Orchard to version 0.9.2](https://github.com/clojure-emacs/orchard/blob/v0.9.2/CHANGELOG.md#092-2022-02-22).
 
 ## 0.28.2 (2022-02-01)

--- a/src/cider/nrepl/middleware/undef.clj
+++ b/src/cider/nrepl/middleware/undef.clj
@@ -31,8 +31,11 @@
   "Undefines all symbol mappings and aliases in the namespace."
   [{:keys [ns]}]
   (let [ns (misc/as-sym ns)]
-    (doseq [[sym _] (ns-map ns)]
-      (ns-unmap ns sym))
+    ;; Do not remove the default java.lang imports, as they are not relinked on the next load
+    ;; see https://github.com/clojure-emacs/cider/issues/3194
+    (doseq [[sym ref] (ns-map ns)]
+      (when-not (identical? ref (get clojure.lang.RT/DEFAULT_IMPORTS sym))
+        (ns-unmap ns sym)))
     (doseq [[sym _] (ns-aliases ns)]
       (ns-unalias ns sym))
     ns))

--- a/test/clj/cider/nrepl/middleware/undef_test.clj
+++ b/test/clj/cider/nrepl/middleware/undef_test.clj
@@ -103,7 +103,7 @@
       (is (:ex response)))))
 
 (deftest undef-all-test
-  (testing "undef-all undefines all vars in namespace"
+  (testing "undef-all undefines all vars in namespace, except default imports"
     (is (= #{"done"}
            (:status (session/message {:op "eval"
                                       :code "(do (ns other.ns (:require [clojure.walk :as walk :refer [postwalk]])))"}))))
@@ -113,6 +113,9 @@
     (is (= ["#'clojure.walk/postwalk"]
            (:value (session/message {:op "eval"
                                      :code "(ns-resolve 'other.ns 'postwalk)"}))))
+    (is (= ["java.lang.System"]
+           (:value (session/message {:op "eval"
+                                     :code "(ns-resolve 'other.ns 'System)"}))))
     (is (= #{"done"}
            (:status (session/message {:op "undef-all"
                                       :ns "other.ns"}))))
@@ -122,6 +125,9 @@
     (is (= ["nil"]
            (:value (session/message {:op "eval"
                                      :code "(ns-resolve 'other.ns 'postwalk)"}))))
+    (is (= ["java.lang.System"]
+           (:value (session/message {:op "eval"
+                                     :code "(ns-resolve 'other.ns 'System)"}))))
     (is (= ["{}"]
            (:value (session/message {:op "eval"
                                      :code "(ns-aliases 'other.ns)"}))))))


### PR DESCRIPTION
See https://github.com/clojure-emacs/cider/issues/3194



- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)
