### PR TITLE
Bump `puget`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* Bump `puget` to 1.3.3.
+
 ## 0.28.7 (2022-10-25)
 
 ### Changes

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
   :dependencies [[nrepl "1.0.0"]
                  ^:inline-dep [cider/orchard "0.11.0" :exclusions [com.google.code.findbugs/jsr305 com.google.errorprone/error_prone_annotations]]
                  ^:inline-dep [thunknyc/profile "0.5.2"]
-                 ^:inline-dep [mvxcvi/puget "1.3.1"]
+                 ^:inline-dep [mvxcvi/puget "1.3.3"]
                  ^:inline-dep [fipp ~fipp-version] ; can be removed in unresolved-tree mode
                  ^:inline-dep [compliment "0.3.14"]
                  ^:inline-dep [org.rksm/suitable "0.4.1" :exclusions [org.clojure/clojurescript]]


### PR DESCRIPTION
Build should be green now as puget/arrangement no longer use the workaround that made mranderson upset.