### PR TITLE
Generate ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* [#758](https://github.com/clojure-emacs/cider-nrepl/pull/758) Add NREPL op to parse stacktraces into data (`analyze-stacktrace`), rename `stacktrace` op to `analyze-last-stacktrace` and deprecate `stacktrace`.
 * Bump `puget` to 1.3.3.
 
 ## 0.28.7 (2022-10-25)

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -4,9 +4,81 @@ This file is _generated_ by #'cider.nrepl.impl.docs/-main
 ////
 = Supported nREPL operations
 
-[small]#generated from a verbose 'describe' response (cider-nrepl v0.28.7)#
+[small]#generated from a verbose 'describe' response (cider-nrepl v0.0.0)#
 
 == Operations
+
+=== `analyze-last-stacktrace`
+
+Return messages describing each cause and stack frame of the most recent exception.
+
+Required parameters::
+{blank}
+
+Optional parameters::
+* `:nrepl.middleware.print/buffer-size` The size of the buffer to use when streaming results. Defaults to 1024.
+* `:nrepl.middleware.print/keys` A seq of the keys in the response whose values should be printed.
+* `:nrepl.middleware.print/options` A map of options to pass to the printing function. Defaults to ``nil``.
+* `:nrepl.middleware.print/print` A fully-qualified symbol naming a var whose function to use for printing. Must point to a function with signature [value writer options].
+* `:nrepl.middleware.print/quota` A hard limit on the number of bytes printed for each value.
+* `:nrepl.middleware.print/stream?` If logical true, the result of printing each value will be streamed to the client over one or more messages.
+
+
+Returns::
+* `:status` "done", or "no-error" if ``*e`` is nil
+
+
+
+=== `analyze-stacktrace`
+
+Parse and analyze the ``:stacktrace``
+parameter and return messages describing each cause and stack frame. The
+stacktrace must be a string formatted in one of the following formats:
+
+* ``:aviso`` Stacktraces printed with the
+  https://ioavisopretty.readthedocs.io/en/latest/exceptions.html[write-exception]
+  function of the https://github.com/AvisoNovate/pretty[Aviso] library.
+
+* ``:clojure.tagged-literal`` Stacktraces printed as a tagged literal, like a
+  https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html[java.lang.Throwable]
+  printed with the
+  https://clojure.github.io/clojure/branch-master/clojure.core-api.html#clojure.core/pr[pr]
+  function.
+
+* ``:clojure.stacktrace`` Stacktraces printed with the
+  https://clojure.github.io/clojure/branch-master/clojure.stacktrace-api.html#clojure.stacktrace/print-cause-trace[print-cause-trace]
+  function of the
+  https://clojure.github.io/clojure/branch-master/clojure.stacktrace-api.html[clojure.stacktrace]
+  namespace.
+
+* ``:clojure.repl`` Stacktraces printed with the
+  https://clojure.github.io/clojure/branch-master/clojure.repl-api.html#clojure.repl/pst[pst]
+  function of the
+  https://clojure.github.io/clojure/branch-master/clojure.repl-api.html[clojure.repl]
+  namespace.
+
+* ``:java`` Stacktraces printed with the
+  link:++https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html#printStackTrace--++[printStackTrace]
+  method of
+  https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html[java.lang.Throwable].
+
+Required parameters::
+* `:stacktrace` The stacktrace to be parsed and analyzed as a string.
+
+
+Optional parameters::
+* `:nrepl.middleware.print/buffer-size` The size of the buffer to use when streaming results. Defaults to 1024.
+* `:nrepl.middleware.print/keys` A seq of the keys in the response whose values should be printed.
+* `:nrepl.middleware.print/options` A map of options to pass to the printing function. Defaults to ``nil``.
+* `:nrepl.middleware.print/print` A fully-qualified symbol naming a var whose function to use for printing. Must point to a function with signature [value writer options].
+* `:nrepl.middleware.print/quota` A hard limit on the number of bytes printed for each value.
+* `:nrepl.middleware.print/stream?` If logical true, the result of printing each value will be streamed to the client over one or more messages.
+
+
+Returns::
+* `:status` "done", or "no-error" if ``stracktrace`` is not recognized
+
+
 
 === `apropos`
 
@@ -977,7 +1049,7 @@ Required parameters::
 {blank}
 
 Optional parameters::
-* `:filter-regex` Only the specs that matches filter prefix regex will be returned
+* `:filter-regex` Only the specs that matches filter prefix regex will be returned 
 
 
 Returns::
@@ -986,57 +1058,11 @@ Returns::
 
 
 
-=== `analyze-last-stacktrace`
-
-Return messages describing each cause and stack frame of the most recent exception.
-
-Required parameters::
-{blank}
-
-Optional parameters::
-* `:nrepl.middleware.print/buffer-size` The size of the buffer to use when streaming results. Defaults to 1024.
-* `:nrepl.middleware.print/keys` A seq of the keys in the response whose values should be printed.
-* `:nrepl.middleware.print/options` A map of options to pass to the printing function. Defaults to ``nil``.
-* `:nrepl.middleware.print/print` A fully-qualified symbol naming a var whose function to use for printing. Must point to a function with signature [value writer options].
-* `:nrepl.middleware.print/quota` A hard limit on the number of bytes printed for each value.
-* `:nrepl.middleware.print/stream?` If logical true, the result of printing each value will be streamed to the client over one or more messages.
-
-
-Returns::
-* `:status` "done", or "no-error" if ``*e`` is nil
-
-
-
-=== `analyze-stacktrace`
-
-Parse and analyze the `:stacktrace` parameter and return messages describing each cause and stack frame. The stacktrace must be a string formatted in one of the following formats:
-
-* `:aviso` Stacktraces printed with the https://ioavisopretty.readthedocs.io/en/latest/exceptions.html[write-exception] function of the https://github.com/AvisoNovate/pretty[Aviso] library.
-* `:clojure.tagged-literal` Stacktraces printed as a tagged literal, like a https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html[java.lang.Throwable] printed with the https://clojure.github.io/clojure/branch-master/clojure.core-api.html#clojure.core/pr[pr] function.
-* `:clojure.stacktrace` Stacktraces printed with the https://clojure.github.io/clojure/branch-master/clojure.stacktrace-api.html#clojure.stacktrace/print-cause-trace[print-cause-trace] function of the https://clojure.github.io/clojure/branch-master/clojure.stacktrace-api.html[clojure.stacktrace] namespace.
-* `:clojure.repl` Stacktraces printed with the https://clojure.github.io/clojure/branch-master/clojure.repl-api.html#clojure.repl/pst[pst] function of the https://clojure.github.io/clojure/branch-master/clojure.repl-api.html[clojure.repl] namespace.
-* `:java` Stacktraces printed with the link:++https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html#printStackTrace--++[printStackTrace] method of https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html[java.lang.Throwable].
-{blank}
-
-Required parameters::
-* `:stacktrace` The stacktrace to be parsed and analyzed as a string.
-
-Optional parameters::
-* `:nrepl.middleware.print/buffer-size` The size of the buffer to use when streaming results. Defaults to 1024.
-* `:nrepl.middleware.print/keys` A seq of the keys in the response whose values should be printed.
-* `:nrepl.middleware.print/options` A map of options to pass to the printing function. Defaults to ``nil``.
-* `:nrepl.middleware.print/print` A fully-qualified symbol naming a var whose function to use for printing. Must point to a function with signature [value writer options].
-* `:nrepl.middleware.print/quota` A hard limit on the number of bytes printed for each value.
-* `:nrepl.middleware.print/stream?` If logical true, the result of printing each value will be streamed to the client over one or more messages.
-
-
-Returns::
-* `:status` "done", or "no-error" if ``*e`` is nil
-
-
 === `stacktrace`
 
-Return messages describing each cause and stack frame of the most recent exception. This op is deprecated, please use the `analyze-last-stacktrace`` op instead.
+Return messages describing each cause and
+stack frame of the most recent exception. This op is deprecated, please use the
+``analyze-last-stacktrace`` op instead.
 
 Required parameters::
 {blank}
@@ -1052,6 +1078,7 @@ Optional parameters::
 
 Returns::
 * `:status` "done", or "no-error" if ``*e`` is nil
+
 
 
 === `test`
@@ -1250,3 +1277,4 @@ Optional parameters::
 
 Returns::
 * `:status` done
+

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -438,11 +438,42 @@ Depending on the type of the return value of the evaluation this middleware may 
     :handles {"analyze-last-stacktrace" {:doc "Return messages describing each cause and stack frame of the most recent exception."
                                          :optional wrap-print-optional-arguments
                                          :returns {"status" "\"done\", or \"no-error\" if `*e` is nil"}}
-              "analyze-stacktrace" {:doc "Parse the `stacktrace` and return messages describing each cause and stack frame."
+              "analyze-stacktrace" {:doc "Parse and analyze the `:stacktrace`
+parameter and return messages describing each cause and stack frame. The
+stacktrace must be a string formatted in one of the following formats:
+
+* `:aviso` Stacktraces printed with the
+  https://ioavisopretty.readthedocs.io/en/latest/exceptions.html[write-exception]
+  function of the https://github.com/AvisoNovate/pretty[Aviso] library.
+
+* `:clojure.tagged-literal` Stacktraces printed as a tagged literal, like a
+  https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html[java.lang.Throwable]
+  printed with the
+  https://clojure.github.io/clojure/branch-master/clojure.core-api.html#clojure.core/pr[pr]
+  function.
+
+* `:clojure.stacktrace` Stacktraces printed with the
+  https://clojure.github.io/clojure/branch-master/clojure.stacktrace-api.html#clojure.stacktrace/print-cause-trace[print-cause-trace]
+  function of the
+  https://clojure.github.io/clojure/branch-master/clojure.stacktrace-api.html[clojure.stacktrace]
+  namespace.
+
+* `:clojure.repl` Stacktraces printed with the
+  https://clojure.github.io/clojure/branch-master/clojure.repl-api.html#clojure.repl/pst[pst]
+  function of the
+  https://clojure.github.io/clojure/branch-master/clojure.repl-api.html[clojure.repl]
+  namespace.
+
+* `:java` Stacktraces printed with the
+  link:++https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html#printStackTrace--++[printStackTrace]
+  method of
+  https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html[java.lang.Throwable]."
                                     :requires {"stacktrace" "The stacktrace to be parsed and analyzed as a string."}
                                     :optional wrap-print-optional-arguments
                                     :returns {"status" "\"done\", or \"no-error\" if `stracktrace` is not recognized"}}
-              "stacktrace" {:doc "Return messages describing each cause and stack frame of the most recent exception. Deprecated: Use analyze-last-stacktrace instead."
+              "stacktrace" {:doc "Return messages describing each cause and
+stack frame of the most recent exception. This op is deprecated, please use the
+`analyze-last-stacktrace` op instead."
                             :optional wrap-print-optional-arguments
                             :returns {"status" "\"done\", or \"no-error\" if `*e` is nil"}}}}))
 


### PR DESCRIPTION
I missed that the NREPL op documentation is generated from the descriptors. I moved the documentation there, and generated the docs with `lein docs`. I also updated the changelog entry, which I previously missed.

---
Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] The new code is not generating reflection warnings
- [x] You've updated the README (if adding/changing middleware)

Thanks!
