### PR TITLE
Complete local bindings for ClojureScript files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#766](https://github.com/clojure-emacs/cider-nrepl/issues/766) Complete local bindings for ClojureScript files.
+
 ## 0.29.0 (2022-12-05)
 
 * [#758](https://github.com/clojure-emacs/cider-nrepl/pull/758) Add nREPL op to parse stacktraces into data (`analyze-stacktrace`), rename `stacktrace` op to `analyze-last-stacktrace` and deprecate `stacktrace`.

--- a/src/cider/nrepl/middleware/complete.clj
+++ b/src/cider/nrepl/middleware/complete.clj
@@ -36,7 +36,13 @@
 
 (def cljs-sources
   "A list of ClojureScript completion sources for compliment."
-  [::suitable-sources/cljs-source])
+  [::suitable-sources/cljs-source
+   ;; The local binding analysis done by
+   ;; :compliment.sources.local-bindings/local-bindings doesn't perform any
+   ;; evaluation or execution of the context form. Thus, it is independent of
+   ;; the actual host platform differences. Given that, we can use that same
+   ;; source for ClojureScript completion.
+   :compliment.sources.local-bindings/local-bindings])
 
 (defn complete
   [{:keys [ns prefix symbol context extra-metadata enhanced-cljs-completion?] :as msg}]

--- a/test/cljs/cider/nrepl/middleware/cljs_complete_test.clj
+++ b/test/cljs/cider/nrepl/middleware/cljs_complete_test.clj
@@ -64,7 +64,18 @@
                                      :ns "cljs.user"
                                      :prefix "js/Ob"})
           candidates (:completions response)]
-      (is (empty? candidates)))))
+      (is (empty? candidates))))
+  (testing "local bindings"
+    (let [response (session/message {:op "complete"
+                                     :ns "cljs.user"
+                                     :prefix "ba"
+                                     ;; Including `quux :quux` helps ensuring that only
+                                     ;; bindings with the specified prefix (ba*) will be
+                                     ;; suggested, instead of all the local bindings.
+                                     :context "(defn foo [bar] (let [baz :baz, quux :quux] (str __prefix__)))"
+                                     :enhanced-cljs-completion? "t"})
+          candidates (:completions response)]
+      (is (= [{:candidate "bar", :type "local"}, {:candidate "baz", :type "local"}] candidates)))))
 
 (deftest cljs-complete-doc-test
   (testing "no suitable documentation can be found"


### PR DESCRIPTION
When editing a ClojureScript file, cider-nrepl doesn't offer any local binding names (the function name and argument names if inside the function, the let-like block bindings if inside a let-like block, etc.) as completion candidates, like it does when editing a Clojure file.

The root of the problem is that
`cider.nrepl.middleware.complete/cljs-sources` only includes `::suitable-sources/cljs-source` as a possible source. And `suitable` doesn't perform any local binding analysis.

Given that the local binding analysis done in
`compliment.sources.local-bindings` namespace doesn't perform any evaluation or execution of the context form (thus, it is independent of the actual host platform differences), we can use that same source for ClojureScript local bindings completion.

[Closes: #766]

Before submitting a PR make sure the following things have been done:

- [X] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [X] You've added tests to cover your change(s)
- [X] All tests are passing
- [X] The new code is not generating reflection warnings
- [ ] You've updated the README (if adding/changing middleware)

Thanks!
