### PR TITLE
add #exc reader to break on exception

### DIFF
--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -413,7 +413,7 @@ this map (identified by a key), and will `dissoc` it afterwards."}
                              (merge var-meta)
                              (assoc :file full-path))]
           (let [iform `(with-initial-debug-bindings
-                         ~(ins/instrument-tagged-code (debug-reader form)))]
+                        ~(ins/instrument-tagged-code (debug-reader form)))]
             ;; (ins/print-form iform true)
             (eval iform)
             (let [instrumented @v]
@@ -491,15 +491,15 @@ this map (identified by a key), and will `dissoc` it afterwards."}
   {:style/indent 1}
   [form dbg-state original-form]
   `(with-initial-debug-bindings
-     (breakpoint-if-interesting
-      ~form ~dbg-state ~original-form)))
+    (breakpoint-if-interesting
+     ~form ~dbg-state ~original-form)))
 
 (defmacro breakpoint-if-exception-with-initial-debug-bindings
   {:style/indent 1}
   [form dbg-state original-form]
   `(with-initial-debug-bindings
-     (breakpoint-if-exception
-      ~form ~dbg-state ~original-form)))
+    (breakpoint-if-exception
+     ~form ~dbg-state ~original-form)))
 
 (defn break
   "Breakpoint function.
@@ -602,12 +602,12 @@ this map (identified by a key), and will `dissoc` it afterwards."}
   (if (uninteresting-form? &env form)
     form
     `(try ~form
-          (catch Exception ex#
+          (catch Throwable ex#
             (let [exn-message# (.getMessage ex#)
                   break-result# (expand-break exn-message# ~dbg-state ~original-form)]
               (if  (= exn-message# break-result#)
-                ;; if they continued then rerun the form
-                ~form
+                ;; if they continued then rethrow the exception
+                (throw ex#)
                 ;; otherwise return the value they injected
                 break-result#))))))
 
@@ -635,7 +635,6 @@ this map (identified by a key), and will `dissoc` it afterwards."}
   "#dbgexn reader. Mark all forms in `form` for breakpointing on exception.
   `form` itself is also marked."
   [form]
-  (println "dbgexn")
   (ins/tag-form (ins/tag-form-recursively form #'breakpoint-if-exception)
                 #'breakpoint-if-exception-with-initial-debug-bindings))
 

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -413,7 +413,7 @@ this map (identified by a key), and will `dissoc` it afterwards."}
                              (merge var-meta)
                              (assoc :file full-path))]
           (let [iform `(with-initial-debug-bindings
-                        ~(ins/instrument-tagged-code (debug-reader form)))]
+                         ~(ins/instrument-tagged-code (debug-reader form)))]
             ;; (ins/print-form iform true)
             (eval iform)
             (let [instrumented @v]
@@ -491,15 +491,15 @@ this map (identified by a key), and will `dissoc` it afterwards."}
   {:style/indent 1}
   [form dbg-state original-form]
   `(with-initial-debug-bindings
-    (breakpoint-if-interesting
-     ~form ~dbg-state ~original-form)))
+     (breakpoint-if-interesting
+      ~form ~dbg-state ~original-form)))
 
 (defmacro breakpoint-if-exception-with-initial-debug-bindings
   {:style/indent 1}
   [form dbg-state original-form]
   `(with-initial-debug-bindings
-    (breakpoint-if-exception
-     ~form ~dbg-state ~original-form)))
+     (breakpoint-if-exception
+      ~form ~dbg-state ~original-form)))
 
 (defn break
   "Breakpoint function.

--- a/src/data_readers.clj
+++ b/src/data_readers.clj
@@ -1,3 +1,4 @@
 {dbg cider.nrepl.middleware.debug/debug-reader
  break cider.nrepl.middleware.debug/breakpoint-reader
+ exc cider.nrepl.middleware.debug/exception-reader
  light cider.nrepl.middleware.enlighten/light-reader}

--- a/src/data_readers.clj
+++ b/src/data_readers.clj
@@ -1,4 +1,5 @@
 {dbg cider.nrepl.middleware.debug/debug-reader
  break cider.nrepl.middleware.debug/breakpoint-reader
- exc cider.nrepl.middleware.debug/exception-reader
+ exn cider.nrepl.middleware.debug/break-on-exception-reader
+ dbgexn cider.nrepl.middleware.debug/debug-on-exception-reader
  light cider.nrepl.middleware.enlighten/light-reader}


### PR DESCRIPTION
I added malabarba's idea for simple break on exception from here https://github.com/clojure-emacs/cider/issues/2754#issuecomment-563189438

Basically when you run something and get an exception, you can click in the error buffer the location in your source closest to the top of the stacktrace, it takes you to the source location, you add a `#exc` before the form, and rerun whatever caused the exception, now the debugger will break there showing the exception and you can inspect local variables, eval stuff in the local context etc.
![screenshot](https://user-images.githubusercontent.com/122528427/218280543-27eac0d9-7f6b-4c6d-af3e-f038c3dd73c3.png)

Of course this is basic and limited, as noted in that issue:
> Wrapping the point of exception in a try-form and setting breakpoint on except. Kind of works, but only (1) in your own source code (not on exceptions thrown in libraries) (2) only after you known the position in the code which throws.

this is just a convenience macro for manually wrapping in try form and setting breakpoint on except, but I think the little extra convenience makes it more pleasant. If there's interest in merging this then I'll do the rest to make this a proper pull request (adding tests and documentation)