### PR TITLE
Infer `:style/indent` metadata when suitable

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -87,7 +87,7 @@
                    ;; TODO: Merge the tests in this dir in to test/clj once we
                    ;; drop support for Clojure 1.8
                    :test-paths ["test/spec"]}
-             :1.10 {:dependencies [[org.clojure/clojure "1.10.1"]
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]
                                    [org.clojure/clojurescript "1.10.520" :scope "provided"]]
                     :test-paths ["test/spec"]}
              :1.11 {:dependencies [[org.clojure/clojure "1.11.1"]
@@ -155,7 +155,7 @@
                          {:dependencies [[clj-kondo "2021.12.01"]]}]
 
              :eastwood [:test
-                        {:plugins [[jonase/eastwood "1.2.3"]]
+                        {:plugins [[jonase/eastwood "1.4.0"]]
                          :eastwood {:config-files ["eastwood.clj"]
                                     :exclude-namespaces [cider.nrepl.middleware.test-filter-tests]
                                     :ignored-faults {:unused-ret-vals-in-try {cider.nrepl.middleware.profile-test [{:line 25}]}

--- a/src/cider/nrepl/middleware/format.clj
+++ b/src/cider/nrepl/middleware/format.clj
@@ -4,13 +4,60 @@
   (:require
    [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
    [cljfmt.core :as fmt]
+   [clojure.set :as set]
    [clojure.string :as str]
    [clojure.tools.reader.edn :as edn]
    [clojure.tools.reader.reader-types :as readers]
    [clojure.walk :as walk]
    [nrepl.middleware.print :as print])
   (:import
-   (java.io StringWriter)))
+   (java.io StringWriter)
+   (java.util List)))
+
+(defn symbolize [x]
+  (case x
+    & '&
+    '_))
+
+(defn structure= [candidate reference]
+  (set/subset? (->> candidate (map (partial mapv symbolize)) set)
+               (->> reference (map (partial mapv symbolize)) set)))
+
+(defn compute-style-indent [^String macro-name arglists]
+  (let [result (cond
+                 ;; TODO add more clojure.core stuff besides from defprotocol
+                 (-> macro-name (str/includes? "defprotocol"))
+                 (when (structure= arglists (-> #'defprotocol meta :arglists))
+                   ;; per clojure-mode
+                   [1 [:defn]])
+
+                 (-> macro-name (str/includes? "defrecord"))
+                 (when (structure= arglists (-> #'defrecord meta :arglists))
+                   [2 nil nil [:defn]])
+
+                 (and (-> arglists count (= 1))
+                      (->> arglists first (some #{'&})))
+                 (let [^List arglist (first arglists)]
+                   (.indexOf arglist '&))
+
+                 (not-any? (partial some #{'&}) arglists)
+                 (let [[i :as indices] (map (fn [^List arglist]
+                                              (or (.indexOf arglist 'body)
+                                                  (.indexOf arglist 'forms)))
+                                            arglists)]
+                   (when (apply = indices)
+                     i)))]
+    (if (= result -1) ;; not found from .indexOf
+      nil
+      result)))
+
+(defn infer-style-indent [{:keys [arglists]
+                           macro-name :name
+                           :as metadata}]
+  (let [result (compute-style-indent (str macro-name)
+                                     arglists)]
+    (cond-> metadata
+      result (assoc :style/indent result))))
 
 ;;; Code formatting
 (defn- keyword->symbol [kw]

--- a/src/cider/nrepl/middleware/track_state.clj
+++ b/src/cider/nrepl/middleware/track_state.clj
@@ -2,33 +2,45 @@
   "State tracker for client sessions."
   {:author "Artur Malabarba"}
   (:require
+   [cider.nrepl.middleware.format :as format]
    [cider.nrepl.middleware.util :as util]
    [cider.nrepl.middleware.util.cljs :as cljs]
    [cider.nrepl.middleware.util.meta :as um]
-   [orchard.cljs.analysis :as cljs-ana]
    [clojure.java.io :as io]
    [clojure.tools.namespace.find :as ns-find]
    [nrepl.misc :refer [response-for]]
    [nrepl.transport :as transport]
+   [orchard.cljs.analysis :as cljs-ana]
    [orchard.java.classpath :as cp]
    [orchard.misc :as misc])
   (:import
-   (clojure.lang Namespace MultiFn)
-   java.net.SocketException
-   java.util.jar.JarFile
-   nrepl.transport.Transport))
+   (clojure.lang MultiFn Namespace)
+   (java.net SocketException)
+   (java.util.jar JarFile)
+   (nrepl.transport Transport)))
 
 (def clojure-core (try (find-ns 'clojure.core)
                        (catch Exception _e nil)))
 
 ;;; Auxiliary
 
-(defn- var-meta-with-fn
-  "Like clojure.core/meta but adds {:fn true} for functions and macros.
+(defn- enriched-meta
+  "Like `clojure.core/meta` but adds {:fn true} for functions, multimethods and macros,
+  and `:style/indent` when missing and inferrable.
+
   Should only be used for vars."
   [the-var]
-  (cond-> (meta the-var)
-    (or (fn? @the-var) (instance? MultiFn @the-var)) (assoc :fn true)))
+  (let [m (meta the-var)]
+    (cond-> m
+      (or (fn? @the-var)
+          (instance? MultiFn @the-var))
+      (assoc :fn true)
+
+      (and (:macro m)
+           (:arglists m)
+           (not (:style/indent m))
+           (not (:indent m)))
+      format/infer-style-indent)))
 
 (defn filter-core-and-get-meta
   "Remove keys whose values are vars in the core namespace."
@@ -36,7 +48,7 @@
   (->> refers
        (into {} (keep (fn [[sym the-var]]
                         (when (var? the-var)
-                          (let [{the-ns :ns :as the-meta} (var-meta-with-fn the-var)]
+                          (let [{the-ns :ns :as the-meta} (enriched-meta the-var)]
                             (when-not (identical? the-ns clojure-core)
                               [sym (um/relevant-meta the-meta)]))))))))
 
@@ -81,7 +93,7 @@
     {:aliases {}
      :interns (->> (ns-map clojure-core)
                    (filter #(var? (second %)))
-                   (misc/update-vals #(um/relevant-meta (var-meta-with-fn %))))}))
+                   (misc/update-vals #(um/relevant-meta (enriched-meta %))))}))
 
 (defn calculate-changed-ns-map
   "Return a map of namespaces that changed between new-map and old-map.
@@ -159,13 +171,13 @@
 (defn update-and-send-cache
   "Send a reply to msg with state information assoc'ed.
   old-data is the ns-cache that needs to be updated (the one
-  associated with msg's session). Return the updated value for it.
+  associated with `msg`'s session). Return the updated value for it.
   This function has side-effects (sending the message)!
 
-  Two extra entries are sent in the reply. One is the :repl-type,
-  which is either :clj or :cljs.
+  Two extra entries are sent in the reply. One is the `:repl-type`,
+  which is either `:clj` or `:cljs`.
 
-  The other is :changed-namespaces, which is a map from namespace
+  The other is `:changed-namespaces`, which is a map from namespace
   names to namespace data (as returned by `ns-as-map`). This contains
   only namespaces which have changed since we last notified the
   client.

--- a/test/clj/cider/nrepl/middleware/track_state_test.clj
+++ b/test/clj/cider/nrepl/middleware/track_state_test.clj
@@ -75,6 +75,7 @@
          '{c {:macro "true"
               :arglists "([name & body])"
               :fn "true"
+              :style/indent "1"
               :doc "\"Defines a test function with no arguments.  Test functions may call\\n  other tests, so tests may be composed.  If you compose tests, you\\n  should also define a function named test-ns-hook; run-tests will\\n  call test-ns-hook instead of testing all vars.\\n\\n  Note: Actually, the test body goes in the :test metadata on the var,\\n  and the real function (the value of the var) calls test-var on\\n  itself.\\n\\n  When *load-tests* is false, deftest is ignored.\""}}))
   (is (= [nil "true" "true" "true"]
          (map (comp :fn


### PR DESCRIPTION
A working proposal for #777.

I saw that `style/indent` is ultimately analysed here https://github.com/clojure-emacs/cider/blob/02802a8cd5a6ac0b7c48685d892d49bf7059b966/cider-mode.el#L589-L590

That var info is in turn returned by the `track-state` middleware. So we are quite free to add extra metadata there, i.e. it will not be visible by users if they enter `(meta  #'foo)` into their repls.

LMK what you think. After that I can move most code to Orchard.

Cheers - V