### PR TITLE
`test`: provide timing information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#773](https://github.com/clojure-emacs/cider-nrepl/pull/773) Add middleware to capture, debug, inspect and view log events emitted by Java logging frameworks.
+* [#755](https://github.com/clojure-emacs/cider-nrepl/pull/755) `middleware.test`: now timing information is returned at var and ns level under the `:took-ms`/`:took-ms-humanized` keys. 
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### New features
 
 * [#773](https://github.com/clojure-emacs/cider-nrepl/pull/773) Add middleware to capture, debug, inspect and view log events emitted by Java logging frameworks.
-* [#755](https://github.com/clojure-emacs/cider-nrepl/pull/755) `middleware.test`: now timing information is returned at var and ns level under the `:took-ms`/`:took-ms-humanized` keys. 
+* [#755](https://github.com/clojure-emacs/cider-nrepl/pull/755) `middleware.test`: now timing information is returned at var and ns level under the `:ms`/`:humanized` keys. 
 
 ### Changes
 

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -1,5 +1,5 @@
 ////
-This file is _generated_ by #'cider.nrepl.impl.docs/-main
+This file was _generated_ with `lein docs`
    *Do not edit!*
 ////
 = Supported nREPL operations
@@ -955,7 +955,7 @@ Returns::
 
 === `retest`
 
-Return exception cause and stack frame info for an erring test via the ``stacktrace`` middleware. The error to be retrieved is referenced by namespace, var name, and assertion index within the var.
+[DEPRECATED - ``use test-var-query`` instead] Run all tests in the project. If ``load?`` is truthy, all project namespaces are loaded; otherwise, only tests in presently loaded namespaces are run. Results are cached for exception retrieval and to enable re-running of failed/erring tests.
 
 Required parameters::
 {blank}
@@ -970,7 +970,10 @@ Optional parameters::
 
 
 Returns::
-{blank}
+* `:ns-elapsed-time` a report of the elapsed time spent running the given namespaces. The structure is ``:ns-elapsed-time {<ns as keyword> {:ms <integer> :humanized <string>}}``.
+* `:results` Misc information about the test result. The structure is ``:results {<ns as keyword> {<test var as keyword> [{,,, :elapsed-time {:ms <integer> :humanized <string>}}]}}``
+* `:status` Either done or indication of an error
+
 
 
 === `set-max-samples`
@@ -1083,7 +1086,7 @@ Returns::
 
 === `test`
 
-[DEPRECATED] Run tests in the specified namespace and return results. This accepts a set of ``tests`` to be run; if nil, runs all tests. Results are cached for exception retrieval and to enable re-running of failed/erring tests.
+[DEPRECATED - ``use test-var-query`` instead] Run tests in the specified namespace and return results. This accepts a set of ``tests`` to be run; if nil, runs all tests. Results are cached for exception retrieval and to enable re-running of failed/erring tests.
 
 Required parameters::
 {blank}
@@ -1098,12 +1101,15 @@ Optional parameters::
 
 
 Returns::
-{blank}
+* `:ns-elapsed-time` a report of the elapsed time spent running the given namespaces. The structure is ``:ns-elapsed-time {<ns as keyword> {:ms <integer> :humanized <string>}}``.
+* `:results` Misc information about the test result. The structure is ``:results {<ns as keyword> {<test var as keyword> [{,,, :elapsed-time {:ms <integer> :humanized <string>}}]}}``
+* `:status` Either done or indication of an error
+
 
 
 === `test-all`
 
-[DEPRECATED] Run all tests in the project. If ``load?`` is truthy, all project namespaces are loaded; otherwise, only tests in presently loaded namespaces are run. Results are cached for exception retrieval and to enable re-running of failed/erring tests.
+Return exception cause and stack frame info for an erring test via the ``stacktrace`` middleware. The error to be retrieved is referenced by namespace, var name, and assertion index within the var.
 
 Required parameters::
 {blank}
@@ -1118,7 +1124,10 @@ Optional parameters::
 
 
 Returns::
-{blank}
+* `:ns-elapsed-time` a report of the elapsed time spent running the given namespaces. The structure is ``:ns-elapsed-time {<ns as keyword> {:ms <integer> :humanized <string>}}``.
+* `:results` Misc information about the test result. The structure is ``:results {<ns as keyword> {<test var as keyword> [{,,, :elapsed-time {:ms <integer> :humanized <string>}}]}}``
+* `:status` Either done or indication of an error
+
 
 
 === `test-stacktrace`
@@ -1159,7 +1168,8 @@ Optional parameters::
 
 
 Returns::
-* `:results` A map of test run data.
+* `:ns-elapsed-time` a report of the elapsed time spent running the given namespaces. The structure is ``:ns-elapsed-time {<ns as keyword> {:ms <integer> :humanized <string>}}``.
+* `:results` Misc information about the test result. The structure is ``:results {<ns as keyword> {<test var as keyword> [{,,, :elapsed-time {:ms <integer> :humanized <string>}}]}}``
 * `:status` Either done or indication of an error
 
 
@@ -1277,4 +1287,311 @@ Optional parameters::
 
 Returns::
 * `:status` done
+
+
+
+=== `log-add-appender`
+
+Add an appender to a log framework.
+
+Required parameters::
+* `:appender` The name of the appender.
+* `:filters` A map from filter name to filter condition.
+* `:framework` The id of the log framework.
+* `:size` The number of events the appender keeps in memory.
+* `:threshold` The threshold in percent used to cleanup events.
+
+
+Optional parameters::
+* `:logger` The name of the logger to attach to.
+
+
+Returns::
+* `:status` done
+* `:cider/log-add-appender` The appender that was added.
+
+
+
+=== `log-add-consumer`
+
+Add a consumer to an appender of a log framework.
+
+Required parameters::
+* `:appender` The name of the appender.
+* `:filters` A map from filter name to filter condition.
+* `:framework` The id of the log framework.
+
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:status` done
+* `:cider/log-add-consumer` The consumer that was added.
+
+
+
+=== `log-analyze-stacktrace`
+
+Analyze the stacktrace of a log event.
+
+Required parameters::
+* `:appender` The name of the appender.
+* `:event` The id of the event to inspect.
+* `:framework` The id of the log framework.
+
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:status` done
+
+
+
+=== `log-clear-appender`
+
+Clear all events of a log appender.
+
+Required parameters::
+* `:appender` The name of the appender.
+* `:framework` The id of the log framework.
+
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:status` done
+* `:cider/log-clear-appender` The appender that was cleared.
+
+
+
+=== `log-exceptions`
+
+Return the exceptions and their frequencies for the given framework and appender.
+
+Required parameters::
+* `:appender` The name of the appender.
+* `:framework` The id of the log framework.
+
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:status` done
+* `:cider/log-exceptions` A map from exception name to event frequency.
+
+
+
+=== `log-format-event`
+
+Format a log event.
+
+Required parameters::
+* `:appender` The name of the log appender.
+* `:event` The id of the log event.
+* `:framework` The id of the log framework.
+
+
+Optional parameters::
+* `:nrepl.middleware.print/buffer-size` The size of the buffer to use when streaming results. Defaults to 1024.
+* `:nrepl.middleware.print/keys` A seq of the keys in the response whose values should be printed.
+* `:nrepl.middleware.print/options` A map of options to pass to the printing function. Defaults to ``nil``.
+* `:nrepl.middleware.print/print` A fully-qualified symbol naming a var whose function to use for printing. Must point to a function with signature [value writer options].
+* `:nrepl.middleware.print/quota` A hard limit on the number of bytes printed for each value.
+* `:nrepl.middleware.print/stream?` If logical true, the result of printing each value will be streamed to the client over one or more messages.
+
+
+Returns::
+* `:status` done
+* `:cider/log-format-event` The formatted log event.
+
+
+
+=== `log-frameworks`
+
+Return the available log frameworks.
+
+Required parameters::
+{blank}
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:status` done
+* `:cider/log-frameworks` A list of log frameworks.
+
+
+
+=== `log-inspect-event`
+
+Inspect a log event.
+
+Required parameters::
+* `:appender` The name of the appender.
+* `:event` The id of the event to inspect.
+* `:framework` The id of the log framework.
+
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:status` done
+* `:value` The inspection result.
+
+
+
+=== `log-levels`
+
+Return the log levels and their frequencies for the given framework and appender.
+
+Required parameters::
+* `:appender` The name of the appender.
+* `:framework` The id of the log framework.
+
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:status` done
+* `:cider/log-levels` A map from log level to event frequency.
+
+
+
+=== `log-loggers`
+
+Return the loggers and their frequencies for the given framework and appender.
+
+Required parameters::
+* `:appender` The name of the appender.
+* `:framework` The id of the log framework.
+
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:status` done
+* `:cider/log-loggers` A map from logger name to event frequency.
+
+
+
+=== `log-remove-appender`
+
+Remove an appender from a log framework.
+
+Required parameters::
+* `:appender` The name of the appender.
+* `:framework` The id of the log framework.
+
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:status` done
+* `:cider/log-remove-appender` The removed appender.
+
+
+
+=== `log-remove-consumer`
+
+Remove a consumer from the appender of a log framework.
+
+Required parameters::
+* `:appender` The name of the appender.
+* `:consumer` The name of the consumer.
+* `:framework` The id of the log framework.
+
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:status` done
+* `:cider/log-add-consumer` The removed consumer.
+
+
+
+=== `log-search`
+
+Search the log events of an appender.
+
+Required parameters::
+* `:appender` The name of the appender.
+* `:framework` The id of the log framework.
+
+
+Optional parameters::
+* `:filters` A map from filter name to filter condition.
+* `:limit` Number of log events to return.
+
+
+Returns::
+* `:status` done
+* `:cider/log-search` The list of log events matching the search.
+
+
+
+=== `log-threads`
+
+Return the threads and their frequencies for the given framework and appender.
+
+Required parameters::
+* `:appender` The name of the appender.
+* `:framework` The id of the log framework.
+
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:status` done
+* `:cider/log-threads` A map from thread name to event frequency.
+
+
+
+=== `log-update-appender`
+
+Update the appender of a log framework.
+
+Required parameters::
+* `:appender` The name of the appender.
+* `:filters` A map from filter name to filter condition.
+* `:framework` The id of the log framework.
+* `:size` The number of events the appender keeps in memory.
+* `:threshold` The threshold in percent used to cleanup events.
+
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:status` done
+* `:cider/log-update-appender` The updated appender.
+
+
+
+=== `log-update-consumer`
+
+Update the consumer of a log appender.
+
+Required parameters::
+* `:appender` The name of the appender.
+* `:consumer` The name of the consumer.
+* `:filters` A map from filter name to filter condition.
+* `:framework` The id of the log framework.
+
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:status` done
+* `:cider/log-update-consumer` The consumer that was updated.
 

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -970,7 +970,8 @@ Optional parameters::
 
 
 Returns::
-* `:ns-elapsed-time` a report of the elapsed time spent running the given namespaces. The structure is ``:ns-elapsed-time {<ns as keyword> {:ms <integer> :humanized <string>}}``.
+* `:elapsed-time` a report of the elapsed time spent running all the given namespaces. The structure is ``:elapsed-time {:ms <integer> :humanized <string>}``.
+* `:ns-elapsed-time` a report of the elapsed time spent running each namespace. The structure is ``:ns-elapsed-time {<ns as keyword> {:ms <integer> :humanized <string>}}``.
 * `:results` Misc information about the test result. The structure is ``:results {<ns as keyword> {<test var as keyword> [{,,, :elapsed-time {:ms <integer> :humanized <string>}}]}}``
 * `:status` Either done or indication of an error
 
@@ -1101,7 +1102,8 @@ Optional parameters::
 
 
 Returns::
-* `:ns-elapsed-time` a report of the elapsed time spent running the given namespaces. The structure is ``:ns-elapsed-time {<ns as keyword> {:ms <integer> :humanized <string>}}``.
+* `:elapsed-time` a report of the elapsed time spent running all the given namespaces. The structure is ``:elapsed-time {:ms <integer> :humanized <string>}``.
+* `:ns-elapsed-time` a report of the elapsed time spent running each namespace. The structure is ``:ns-elapsed-time {<ns as keyword> {:ms <integer> :humanized <string>}}``.
 * `:results` Misc information about the test result. The structure is ``:results {<ns as keyword> {<test var as keyword> [{,,, :elapsed-time {:ms <integer> :humanized <string>}}]}}``
 * `:status` Either done or indication of an error
 
@@ -1124,7 +1126,8 @@ Optional parameters::
 
 
 Returns::
-* `:ns-elapsed-time` a report of the elapsed time spent running the given namespaces. The structure is ``:ns-elapsed-time {<ns as keyword> {:ms <integer> :humanized <string>}}``.
+* `:elapsed-time` a report of the elapsed time spent running all the given namespaces. The structure is ``:elapsed-time {:ms <integer> :humanized <string>}``.
+* `:ns-elapsed-time` a report of the elapsed time spent running each namespace. The structure is ``:ns-elapsed-time {<ns as keyword> {:ms <integer> :humanized <string>}}``.
 * `:results` Misc information about the test result. The structure is ``:results {<ns as keyword> {<test var as keyword> [{,,, :elapsed-time {:ms <integer> :humanized <string>}}]}}``
 * `:status` Either done or indication of an error
 
@@ -1168,7 +1171,8 @@ Optional parameters::
 
 
 Returns::
-* `:ns-elapsed-time` a report of the elapsed time spent running the given namespaces. The structure is ``:ns-elapsed-time {<ns as keyword> {:ms <integer> :humanized <string>}}``.
+* `:elapsed-time` a report of the elapsed time spent running all the given namespaces. The structure is ``:elapsed-time {:ms <integer> :humanized <string>}``.
+* `:ns-elapsed-time` a report of the elapsed time spent running each namespace. The structure is ``:ns-elapsed-time {<ns as keyword> {:ms <integer> :humanized <string>}}``.
 * `:results` Misc information about the test result. The structure is ``:results {<ns as keyword> {<test var as keyword> [{,,, :elapsed-time {:ms <integer> :humanized <string>}}]}}``
 * `:status` Either done or indication of an error
 

--- a/maint/cider/nrepl/impl/docs.clj
+++ b/maint/cider/nrepl/impl/docs.clj
@@ -121,7 +121,7 @@ use in e.g. wiki pages, github, etc."
                              "\n   **Do not edit!** -->\n"
                              (describe-markdown resp))
         (= format "adoc") (str "////\n"
-                               "This file is _generated_ by " #'-main
+                               "This file was _generated_ with `lein docs`"
                                "\n   *Do not edit!*\n"
                                "////\n"
                                (describe-adoc resp))))

--- a/project.clj
+++ b/project.clj
@@ -103,7 +103,8 @@
              :test {:global-vars {*assert* true}
                     :source-paths ["test/src"]
                     :java-source-paths ["test/java"]
-                    :jvm-opts ["-Djava.util.logging.config.file=test/resources/logging.properties"]
+                    :jvm-opts ["-Djava.util.logging.config.file=test/resources/logging.properties"
+                               "-Dcider.internal.testing=true"]
                     :resource-paths ["test/resources"]
                     :dependencies [[boot/base "2.8.3"]
                                    [boot/core "2.8.3"]
@@ -147,6 +148,7 @@
                       {:plugins [[lein-cljfmt "0.9.2"]]
                        :cljfmt {:indents {as-> [[:inner 0]]
                                           delay [[:inner 0]]
+                                          timing [[:inner 0]]
                                           with-debug-bindings [[:inner 0]]
                                           merge-meta [[:inner 0]]
                                           try-if-let [[:block 1]]}}}]

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -608,7 +608,8 @@ stack frame of the most recent exception. This op is deprecated, please use the
                             :returns {"status" "\"done\", or \"no-error\" if `*e` is nil"}}}}))
 
 (def timing-info-return-doc {"status" "Either done or indication of an error"
-                             "ns-elapsed-time" "a report of the elapsed time spent running the given namespaces. The structure is `:ns-elapsed-time {<ns as keyword> {:ms <integer> :humanized <string>}}`."
+                             "elapsed-time" "a report of the elapsed time spent running all the given namespaces. The structure is `:elapsed-time {:ms <integer> :humanized <string>}`."
+                             "ns-elapsed-time" "a report of the elapsed time spent running each namespace. The structure is `:ns-elapsed-time {<ns as keyword> {:ms <integer> :humanized <string>}}`."
                              "results" "Misc information about the test result. The structure is `:results {<ns as keyword> {<test var as keyword> [{,,, :elapsed-time {:ms <integer> :humanized <string>}}]}}`"})
 
 (def-wrapper wrap-test cider.nrepl.middleware.test/handle-test

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -607,6 +607,10 @@ stack frame of the most recent exception. This op is deprecated, please use the
                             :optional wrap-print-optional-arguments
                             :returns {"status" "\"done\", or \"no-error\" if `*e` is nil"}}}}))
 
+(def timing-info-return-doc {"status" "Either done or indication of an error"
+                             "ns-elapsed-time" "a report of the elapsed time spent running the given namespaces. The structure is `:ns-elapsed-time {<ns as keyword> {:ms <integer> :humanized <string>}}`."
+                             "results" "Misc information about the test result. The structure is `:results {<ns as keyword> {<test var as keyword> [{,,, :elapsed-time {:ms <integer> :humanized <string>}}]}}`"})
+
 (def-wrapper wrap-test cider.nrepl.middleware.test/handle-test
   {:doc "Middleware that handles testing requests."
    :requires #{#'session #'wrap-print}
@@ -614,20 +618,22 @@ stack frame of the most recent exception. This op is deprecated, please use the
              {:doc "Run tests specified by the `var-query` and return results. Results are cached for exception retrieval and to enable re-running of failed/erring tests."
               :requires {"var-query" "A search query specifying the test vars to execute. See Orchard's var query documentation for more details."}
               :optional wrap-print-optional-arguments
-              :returns {"results" "A map of test run data."
-                        "status" "Either done or indication of an error"}}
+              :returns timing-info-return-doc}
              "test"
-             {:doc "[DEPRECATED] Run tests in the specified namespace and return results. This accepts a set of `tests` to be run; if nil, runs all tests. Results are cached for exception retrieval and to enable re-running of failed/erring tests."
-              :optional wrap-print-optional-arguments}
+             {:doc "[DEPRECATED - `use test-var-query` instead] Run tests in the specified namespace and return results. This accepts a set of `tests` to be run; if nil, runs all tests. Results are cached for exception retrieval and to enable re-running of failed/erring tests."
+              :optional wrap-print-optional-arguments
+              :returns timing-info-return-doc}
              "test-all"
-             {:doc "[DEPRECATED] Run all tests in the project. If `load?` is truthy, all project namespaces are loaded; otherwise, only tests in presently loaded namespaces are run. Results are cached for exception retrieval and to enable re-running of failed/erring tests."
-              :optional wrap-print-optional-arguments}
+             {:doc "Return exception cause and stack frame info for an erring test via the `stacktrace` middleware. The error to be retrieved is referenced by namespace, var name, and assertion index within the var."
+              :optional wrap-print-optional-arguments
+              :returns timing-info-return-doc}
              "test-stacktrace"
              {:doc "Rerun all tests that did not pass when last run. Results are cached for exception retrieval and to enable re-running of failed/erring tests."
               :optional wrap-print-optional-arguments}
              "retest"
-             {:doc "Return exception cause and stack frame info for an erring test via the `stacktrace` middleware. The error to be retrieved is referenced by namespace, var name, and assertion index within the var."
-              :optional wrap-print-optional-arguments}}})
+             {:doc "[DEPRECATED - `use test-var-query` instead] Run all tests in the project. If `load?` is truthy, all project namespaces are loaded; otherwise, only tests in presently loaded namespaces are run. Results are cached for exception retrieval and to enable re-running of failed/erring tests."
+              :optional wrap-print-optional-arguments
+              :returns timing-info-return-doc}}})
 
 (def-wrapper wrap-trace cider.nrepl.middleware.trace/handle-trace
   {:doc     "Toggle tracing of a given var."

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -342,11 +342,13 @@
   "Call `test-ns` for each var found via var-query."
   [var-query]
   (report-reset!)
-  (doseq [[ns vars] (group-by
-                     (comp :ns meta)
-                     (query/vars var-query))]
-    (test-ns ns vars))
-  @current-report)
+  (let [elapsed-time (atom nil)]
+    (timing elapsed-time
+      (doseq [[ns vars] (group-by
+                         (comp :ns meta)
+                         (query/vars var-query))]
+        (test-ns ns vars)))
+    (assoc @current-report :elapsed-time @elapsed-time)))
 
 (defn test-nss
   "Call `test-ns` for each entry in map `m`, in which keys are namespace
@@ -355,11 +357,13 @@
   objects."
   [m]
   (report-reset!)
-  (doseq [[ns vars] m]
-    (->> (map (partial ns-resolve ns) vars)
-         (filter identity)
-         (test-ns (the-ns ns))))
-  @current-report)
+  (let [elapsed-time (atom nil)]
+    (timing elapsed-time
+      (doseq [[ns vars] m]
+        (->> (map (partial ns-resolve ns) vars)
+             (filter identity)
+             (test-ns (the-ns ns)))))
+    (assoc @current-report :elapsed-time @elapsed-time)))
 
 ;;; ## Middleware
 

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -450,9 +450,12 @@
 
 (defn handle-test [handler msg & _configuration]
   (case (:op msg)
-    "test-var-query"  (handle-test-var-query-op msg)
+    ;; (NOTE: deprecated)
     "test"            (handle-test-op msg)
+    ;; (NOTE: deprecated)
     "test-all"        (handle-test-all-op msg)
+
+    "test-var-query"  (handle-test-var-query-op msg)
     "test-stacktrace" (handle-stacktrace-op msg)
     "retest"          (handle-retest-op msg)
     (handler msg)))

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -184,7 +184,7 @@
                 (assoc :gen-input nil)))))
 
 (defmethod report :end-test-var
-  [{:keys [var-timing]
+  [{:keys [var-elapsed-time]
     var-ref :var}]
   (let [n (or (some-> var-ref meta :ns ns-name)
               (:testing-ns @current-report))
@@ -196,17 +196,17 @@
               dec)]
     (swap! current-report
            assoc-in
-           [:results n v i :timing]
-           var-timing)))
+           [:results n v i :elapsed-time]
+           var-elapsed-time)))
 
 (defmethod report :end-test-ns
-  [{:keys [ns-ref ns-timing]}]
+  [{:keys [ns-ref ns-elapsed-time]}]
   (let [n (or (some-> ns-ref ns-name)
               (:testing-ns @current-report))]
     (swap! current-report
            assoc-in
-           [:ns-timings n]
-           ns-timing)))
+           [:ns-elapsed-time n]
+           ns-elapsed-time)))
 
 (defmethod report :pass
   [m]
@@ -269,8 +269,8 @@
               ~@body)
          took# (- (System/currentTimeMillis)
                   then#)]
-     (reset! ~time-atom {:took-ms took#
-                         :took-humanized (str "Completed in " took# " ms")})
+     (reset! ~time-atom {:ms took#
+                         :humanized (str "Completed in " took# " ms")})
      v#))
 
 ;;; ## Test Execution
@@ -302,7 +302,7 @@
                       :expected nil
                       :actual result
                       :message "Uncaught exception, not in assertion"})]
-        (test/do-report (assoc report :var-timing @time-info))))))
+        (test/do-report (assoc report :var-elapsed-time @time-info))))))
 
 (defn test-vars
   "Call `test-var` on each var, with the fixtures defined for namespace object
@@ -335,7 +335,7 @@
           (test-vars ns vars)))
       (test/do-report {:type :end-test-ns
                        :ns ns
-                       :ns-timing @time-info})
+                       :ns-elapsed-time @time-info})
       @current-report)))
 
 (defn test-var-query

--- a/test/clj/cider/nrepl/middleware/test_test.clj
+++ b/test/clj/cider/nrepl/middleware/test_test.clj
@@ -187,6 +187,12 @@ The `988` value reflects that it times things correctly for a slow test.")
       (is (> ms 998)
           "Reports the elapsed time for the entire ns")
       (is (= (str "Completed in " ms " ms")
+             humanized)))
+
+    (let [{:keys [humanized ms]} (-> test-result :elapsed-time)]
+      (is (> ms 998)
+          "Reports the elapsed time for the entire run, across namespaces")
+      (is (= (str "Completed in " ms " ms")
              humanized)))))
 
 (deftest print-object-test

--- a/test/clj/cider/nrepl/middleware/test_test.clj
+++ b/test/clj/cider/nrepl/middleware/test_test.clj
@@ -5,8 +5,7 @@
    cider.nrepl.middleware.test-filter-tests
    [cider.nrepl.test-session :as session]
    [clojure.string :as string]
-   [clojure.test :refer :all]
-   [clojure.java.io :as io])
+   [clojure.test :refer :all])
   (:import
    (clojure.lang ExceptionInfo)))
 
@@ -162,12 +161,6 @@
                                     :message))))))
 
 (deftest timing-test
-  (require 'cider.nrepl.middleware.test-filter-tests)
-  (let [{:keys [results] :as test-result}
-        (session/message {:op "test"
-                          :ns "cider.nrepl.middleware.test-filter-tests"
-                          :tests ["test-with-map-as-message"]})])
-
   (require 'failing-test-ns)
   (let [test-result (session/message {:op "test"
                                       :ns "failing-test-ns"})

--- a/test/clj/cider/nrepl/middleware/test_test.clj
+++ b/test/clj/cider/nrepl/middleware/test_test.clj
@@ -160,34 +160,34 @@
                                     first
                                     :message))))))
 
-(deftest timing-test
+(deftest elapsed-time-test
   (require 'failing-test-ns)
-  (let [test-result (session/message {:op "test"
-                                      :ns "failing-test-ns"})
-        [[var1 timing1]
-         [var2 timing2]]
+  (let [test-result (session/message {:op "test-var-query"
+                                      :var-query {:ns-query {:exactly ["failing-test-ns"]}}})
+        [[var1 elapsed-time1]
+         [var2 elapsed-time2]]
         (->> test-result
              :results
              :failing-test-ns
              ((juxt :fast-failing-test :slow-failing-test))
              (map (fn [[{:keys [var]
-                         {:keys [took-ms]} :timing}]]
-                    [var took-ms])))]
+                         {:keys [ms]} :elapsed-time}]]
+                    [var ms])))]
     (is (= "fast-failing-test" var1))
-    (is (< timing1 50)
-        "Reports the timing under :timing :took-ms, as integer.
+    (is (< elapsed-time1 50)
+        "Reports the elapsed time under [:elapsed-time :ms], as integer.
 The `10` value reflects that it times things correctly for a fast test.")
 
     (is (= "slow-failing-test" var2))
-    (is (> timing2 998)
-        "Reports the timing under :timing :took-ms, as integer.
+    (is (> elapsed-time2 998)
+        "Reports the elapsed time under [:elapsed-time :ms], as integer.
 The `988` value reflects that it times things correctly for a slow test.")
 
-    (let [{:keys [took-humanized took-ms]} (-> test-result :ns-timings :failing-test-ns)]
-      (is (> took-ms 998)
-          "Reports the timing for the entire ns")
-      (is (= (str "Completed in " took-ms " ms")
-             took-humanized)))))
+    (let [{:keys [humanized ms]} (-> test-result :ns-elapsed-time :failing-test-ns)]
+      (is (> ms 998)
+          "Reports the elapsed time for the entire ns")
+      (is (= (str "Completed in " ms " ms")
+             humanized)))))
 
 (deftest print-object-test
   (testing "uses println for matcher-combinators results, otherwise invokes pprint"

--- a/test/clj/cider/nrepl/middleware/test_test.clj
+++ b/test/clj/cider/nrepl/middleware/test_test.clj
@@ -193,7 +193,15 @@ The `988` value reflects that it times things correctly for a slow test.")
       (is (> ms 998)
           "Reports the elapsed time for the entire run, across namespaces")
       (is (= (str "Completed in " ms " ms")
-             humanized)))))
+             humanized))))
+
+  (let [test-result (session/message {:op "retest"})]
+    (is (string? (:humanized (:elapsed-time test-result)))
+        "Timing also works for the `retest` op (global level)")
+    (is (-> test-result :ns-elapsed-time :failing-test-ns :humanized string?)
+        "Timing also works for the `retest` op (ns level)")
+    (is (-> test-result :results :failing-test-ns :fast-failing-test (get 0) :elapsed-time :humanized string?)
+        "Timing also works for the `retest` op (var level)")))
 
 (deftest print-object-test
   (testing "uses println for matcher-combinators results, otherwise invokes pprint"

--- a/test/resources/failing_test_ns.clj
+++ b/test/resources/failing_test_ns.clj
@@ -1,0 +1,9 @@
+(ns failing-test-ns
+  (:require [clojure.test :refer :all]))
+
+(deftest fast-failing-test
+  (is (= 0 1)))
+
+(deftest slow-failing-test
+  (Thread/sleep 1000)
+  (is (= 0 1)))


### PR DESCRIPTION
> Fixes https://github.com/clojure-emacs/cider-nrepl/issues/755

With these changes, responses are now enhanced with the following structural changes:

```diff
+{:elapsed-time {:humanized "Completed in 1028 ms", :ms 1028},
+ :ns-elapsed-time
+ {:failing-test-ns {:humanized "Completed in 1026 ms", :ms 1026}},
 :summary {:error 0, :fail 2, :ns 1, :pass 0, :test 2, :var 2},
 :testing-ns "failing-test-ns",
 :gen-input [],
 :status #{"done"},
 :id "52816a02-86cc-457a-a9fa-b287e90da189",
 :session #{"e3b12907-d64e-4e6d-902a-ab63fef9c811"},
 :results
 {:failing-test-ns
  {:fast-failing-test
   [{:index 0,
     :ns "failing-test-ns",
     :file "failing_test_ns.clj",
     :type "fail",
     :diffs [["1\n" ["0\n" "1\n"]]],
     :line 5,
     :var "fast-failing-test",
     :expected "0\n",
     :context [],
+    :elapsed-time {:humanized "Completed in 20 ms", :ms 20},
     :actual "1\n",
     :message ""}],
   :slow-failing-test
   [{:index 0,
     :ns "failing-test-ns",
     :file "failing_test_ns.clj",
     :type "fail",
     :diffs [["1\n" ["0\n" "1\n"]]],
     :line 9,
     :var "slow-failing-test",
     :expected "0\n",
     :context [],
+    :elapsed-time {:humanized "Completed in 1006 ms", :ms 1006},
     :actual "1\n",
     :message ""}]}}}
```

Cheers - V