### PR TITLE
Remove `test-url-content-type`

### DIFF
--- a/test/clj/cider/nrepl/middleware/slurp_test.clj
+++ b/test/clj/cider/nrepl/middleware/slurp_test.clj
@@ -37,9 +37,3 @@
     (t/is (= ["application/octet-stream" {}] (:content-type resp)))
     (t/is (str/starts-with? (:body resp) "#binary[location="))
     (t/is (str/ends-with? (:body resp) ",size=0]"))))
-
-(t/deftest test-url-content-type
-  ;; When a url gives content type as nil, then default content-type should be taken.
-  (let [resp (slurp-url-to-content+body "https://clojure.org/no-such-page")]
-    (t/is (= ["text/html" {}] (:content-type resp)))
-    (t/is (= "" (:body resp)))))


### PR DESCRIPTION
This deftest started failing, following clojure.org changes (now it returns 403 instead of 404, and with a different content-type).

I found it can't be fixed, because the test was giving false negatives to begin with. The `;; When a url gives content type as nil, then default content-type should be taken.` comment describes a behavior that isn't real.

To prove so one can try these changes instead https://github.com/clojure-emacs/cider-nrepl/commit/bd46a9c1642e4c7ea4e9684d533aad592a36a680 (that altered deftest can't pass).

I propose simply removing the test. After all, this should be a slowly changing area. New PRs can add coverage if they change stuff.

Cheers - V