### PR TITLE
0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+## 0.35.0 (2023-08-09)
+
 ### New features
 
 * Make the `track-state` middleware invokeable directly, by requesting the new `"cider/get-state"` op.

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ cljfmt:
 kondo:
 	lein with-profile -user,-dev,+clj-kondo run -m clj-kondo.main --lint src .circleci/deploy
 
+PROJECT_VERSION=0.35.0 make install
 install: check-install-env .inline-deps
 	lein with-profile -user,-dev,+$(CLOJURE_VERSION),+plugin.mranderson/config install
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ lein with-profile plugin.mranderson/config install
 ...Or you can use the `Makefile` as:
 
 ```
-PROJECT_VERSION=0.34.0 make install
+PROJECT_VERSION=0.35.0 make install
 ```
 
 ## Releasing to Clojars
@@ -107,7 +107,7 @@ before cutting a new release.
 Release to [clojars](https://clojars.org/) by tagging a new release:
 
 ```
-git tag -a v0.34.0 -m "Release 0.34.0"
+git tag -a v0.35.0 -m "Release 0.35.0"
 git push --tags
 ```
 

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -15,14 +15,14 @@ Use the convenient plugin for defaults, either in your project's
 
 [source,clojure]
 ----
-:plugins [[cider/cider-nrepl "0.34.0"]]
+:plugins [[cider/cider-nrepl "0.35.0"]]
 ----
 
 A minimal `profiles.clj` for CIDER would be:
 
 [source,clojure]
 ----
-{:user {:plugins [[cider/cider-nrepl "0.34.0"]]}}
+{:user {:plugins [[cider/cider-nrepl "0.35.0"]]}}
 ----
 
 Or (if you know what you're doing) add `cider-nrepl` to your `:dev
@@ -31,7 +31,7 @@ under `:repl-options`.
 
 [source,clojure]
 ----
-:dependencies [[cider/cider-nrepl "0.34.0"]]
+:dependencies [[cider/cider-nrepl "0.35.0"]]
 :repl-options {:nrepl-middleware
                  [cider.nrepl/wrap-apropos
                   cider.nrepl/wrap-classpath
@@ -65,7 +65,7 @@ it on the command line through the `cider.tasks/add-middleware` task
 functionality):
 
 ----
-boot -d nrepl:1.0.0 -d cider/cider-nrepl:0.34.0 -i "(require 'cider.tasks)" cider.tasks/add-middleware -m cider.nrepl.middleware.apropos/wrap-apropos -m cider.nrepl.middleware.version/wrap-version repl --server wait
+boot -d nrepl:1.0.0 -d cider/cider-nrepl:0.35.0 -i "(require 'cider.tasks)" cider.tasks/add-middleware -m cider.nrepl.middleware.apropos/wrap-apropos -m cider.nrepl.middleware.version/wrap-version repl --server wait
 ----
 
 Or for all of their projects by adding a `~/.boot/profile.boot` file like so:
@@ -73,7 +73,7 @@ Or for all of their projects by adding a `~/.boot/profile.boot` file like so:
 [source,clojure]
 ----
 (set-env! :dependencies '[[nrepl "1.0.0"]
-                          [cider/cider-nrepl "0.34.0"]])
+                          [cider/cider-nrepl "0.35.0"]])
 
 (require '[cider.tasks :refer [add-middleware]])
 
@@ -95,7 +95,7 @@ You can easily boot an nREPL server with the CIDER middleware loaded
 with the following "magic" incantation:
 
 ----
-clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.34.0"} }}' -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
+clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.35.0"} }}' -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
 ----
 
 There are also two convenient aliases you can employ:
@@ -105,12 +105,12 @@ There are also two convenient aliases you can employ:
 {...
  :aliases
  {:cider-clj {:extra-deps {org.clojure/clojure {:mvn/version "1.10.1"}
-                           cider/cider-nrepl {:mvn/version "0.34.0"}}
+                           cider/cider-nrepl {:mvn/version "0.35.0"}}
               :main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"]}
 
   :cider-cljs {:extra-deps {org.clojure/clojure {:mvn/version "1.10.1"}
                             org.clojure/clojurescript {:mvn/version "1.10.339"}
-                            cider/cider-nrepl {:mvn/version "0.34.0"}
+                            cider/cider-nrepl {:mvn/version "0.35.0"}
                             cider/piggieback {:mvn/version "0.5.2"}}
                :main-opts ["-m" "nrepl.cmdline" "--middleware"
                            "[cider.nrepl/cider-middleware,cider.piggieback/wrap-cljs-repl]"]}}}


### PR DESCRIPTION
### New features

* Make the `track-state` middleware invokeable directly, by requesting the new `"cider/get-state"` op.
  * This makes it possible to access `:changed-namespaces` info on demand, which can be necessary for: * non-Piggieback based clojurescript repls * re-computing the ns info responding to external (non-nREPL triggered) events.

### Changes

* [#796](https://github.com/clojure-emacs/cider-nrepl/issues/796): `fn-refs` and `fn-deps` middleware: add new `:file-url` field.
  * these are absolute and prefixed by `file:` or `file:jar:`, whenever possible.
* `fn-refs` and `fn-deps` middleware: sort the results by file, line and column.
* Bump `orchard` to [1.4.2](https://github.com/clojure-emacs/orchard/blob/v0.14.2/CHANGELOG.md#0142-2023-08-09).