### PR TITLE
`"ns-path"` op: also include a `:url` attribute in the response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* `"ns-path"` op: also include a `:url` attribute in the response.
+
 ## 0.36.1 (2023-08-22)
 
 ### Changes

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -690,7 +690,9 @@ Optional parameters::
 {blank}
 
 Returns::
-{blank}
+* `:ns-aliases` The map of [ns-alias] to [ns-name] in a namespace.
+* `:status` done
+
 
 
 === `ns-list`
@@ -738,7 +740,9 @@ Optional parameters::
 {blank}
 
 Returns::
-{blank}
+* `:loaded-ns` The list of ns that were loaded.
+* `:status` done
+
 
 
 === `ns-path`
@@ -753,7 +757,10 @@ Optional parameters::
 {blank}
 
 Returns::
-{blank}
+* `:path` The path to the file containing ns. Please favor ``:url`` in ClojureScript, but fall back to ``:path``.
+* `:status` done
+* `:url` The Java URL indicating the file containing ns. Please favor this attribute over ``:path`` when possible. If this value is nil, you can fall back to ``:path``.
+
 
 
 === `ns-vars`

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -452,14 +452,16 @@ Depending on the type of the return value of the evaluation this middleware may 
               "ns-path"
               {:doc "Returns the path to the file containing ns."
                :requires {"ns" "The namespace to find."}
-               :return {"status" "done" "path" "The path to the file containing ns."}}
+               :returns {"status" "done"
+                         "path" "The path to the file containing ns. Please favor `:url` in ClojureScript, but fall back to `:path`."
+                         "url" "The Java URL indicating the file containing ns. Please favor this attribute over `:path` when possible. If this value is nil, you can fall back to `:path`."}}
               "ns-load-all"
               {:doc "Loads all project namespaces."
-               :return {"status" "done" "loaded-ns" "The list of ns that were loaded."}}
+               :returns {"status" "done" "loaded-ns" "The list of ns that were loaded."}}
               "ns-aliases"
               {:doc "Returns a map of [ns-alias] to [ns-name] in a namespace."
                :requires {"ns" "The namespace to use."}
-               :return {"status" "done" "ns-aliases" "The map of [ns-alias] to [ns-name] in a namespace."}}}}))
+               :returns {"status" "done" "ns-aliases" "The map of [ns-alias] to [ns-name] in a namespace."}}}}))
 
 (def-wrapper wrap-out cider.nrepl.middleware.out/handle-out
   (cljs/expects-piggieback

--- a/src/cider/nrepl/middleware/ns.clj
+++ b/src/cider/nrepl/middleware/ns.clj
@@ -7,6 +7,7 @@
    [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
    [cider.nrepl.middleware.util.meta :as um]
    [orchard.cljs.analysis :as cljs-analysis]
+   [clojure.java.io :as io]
    [orchard.info :as info]
    [orchard.misc :as misc]
    [orchard.namespace :as ns]
@@ -100,7 +101,13 @@
   {:ns-vars-with-meta (ns-vars-with-meta msg)})
 
 (defn- ns-path-reply [msg]
-  {:path (ns-path msg)})
+  (let [v (ns-path msg)
+        cljs? (cljs/grab-cljs-env msg)]
+    {:path v
+     :url (if cljs?
+            (or (some-> v io/resource str)
+                v)
+            v)}))
 
 (defn- ns-load-all-reply
   [_msg]

--- a/test/clj/cider/nrepl/middleware/ns_test.clj
+++ b/test/clj/cider/nrepl/middleware/ns_test.clj
@@ -96,13 +96,17 @@
              {:arglists "([c])"})))))
 
 (deftest ns-path-integration-test
-  (let [ns-path (:path (session/message {:op "ns-path"
-                                         :ns "cider.nrepl.middleware.ns"}))
-        core-path (:path (session/message {:op "ns-path"
-                                           :ns "clojure.core"}))]
+  (let [{ns-path :path
+         ns-url :url} (session/message {:op "ns-path"
+                                        :ns "cider.nrepl.middleware.ns"})
+        {core-path :path
+         core-url :url} (session/message {:op "ns-path"
+                                          :ns "clojure.core"})]
     (is (.endsWith ^String ns-path "cider/nrepl/middleware/ns.clj"))
     (is (.endsWith ^String core-path "clojure/core.clj"))
-    (is (.startsWith ^String core-path "jar:"))))
+    (is (.startsWith ^String core-path "jar:"))
+    (is (= ns-path ns-url))
+    (is (= core-path core-url))))
 
 (deftest ns-load-all-integration-test
   (let [loaded-ns (:loaded-ns (session/message {:op "ns-load-all"}))]

--- a/test/cljs/cider/nrepl/middleware/cljs_ns_test.clj
+++ b/test/cljs/cider/nrepl/middleware/cljs_ns_test.clj
@@ -47,9 +47,11 @@
              {:arglists "(quote ([e]))"}))))
 
   (testing "ns-path op"
-    (let [{:keys [^String path]} (session/message {:op "ns-path"
-                                                   :ns "cljs.core"})]
-      (is (.endsWith path "cljs/core.cljs")))
+    (let [{:keys [^String path ^String url]} (session/message {:op "ns-path"
+                                                               :ns "cljs.core"})]
+      (is (.endsWith path "cljs/core.cljs"))
+      (is (not= path url))
+      (is (.startsWith url "jar:file:/")))
 
     (let [{:keys [^String path]} (session/message {:op "ns-path"
                                                    :ns "cljs.repl"})]


### PR DESCRIPTION
Previously, `ns-path` could return responses that were often of no use in clojurescript.

For instance, `"conduit/events.cljs"` cannot be open (lacks a src/test component) except if a matching Emacs buffer happened to be open already.

So this PR adds a `:url` attribute, as documented.

Works:

```
(-->
  id         "35"
  op         "ns-path"
  session    "3c26ce70-2c20-4b3a-9d14-017c7497f663"
  time-stamp "2023-08-27 15:57:14.251984000"
  ns         "conduit.events"
)
(<--
  id         "35"
  session    "3c26ce70-2c20-4b3a-9d14-017c7497f663"
  time-stamp "2023-08-27 15:57:14.253630000"
  path       "conduit/events.cljs"
  status     ("done")
  url        "file:/Users/vemv/conduit/src/conduit/events.cljs"
)
```