### PR TITLE
Introduce CI task to validate antora.yml

### DIFF
--- a/.circleci/check_antora.clj
+++ b/.circleci/check_antora.clj
@@ -1,0 +1,41 @@
+;; This script checks if the version declared in CHANGELOG matches that declared in antora.yml.
+;; Which ensures that our generated docs will properly work.
+
+(require '[clojure.string :as string])
+
+(defn extract-readme-version [line]
+  (when-let [[_ match] (re-find #"## (\d+\.\d+)\.\d+\s\(" line)]
+    match))
+
+(defn extract-antora-version [line]
+  (when-let [[_ match] (re-find #"version: \"([0-9]+\.[0-9]+)\"" line)]
+    match))
+
+(def version-per-changelog
+  (->> "CHANGELOG.md"
+       slurp
+       (string/split-lines)
+       (some extract-readme-version)))
+
+(def version-per-antora
+  (->> "doc/antora.yml"
+       slurp
+       (string/split-lines)
+       (some extract-antora-version)))
+
+(assert (not (string/blank? version-per-changelog)))
+
+(assert (not (string/blank? version-per-antora)))
+
+(def ok?
+  (= version-per-changelog version-per-antora))
+
+(when-not ok?
+  (printf "Version is not updated in doc/antora.yml. CHANGELOG.md version: %s Antora version: %s"
+          version-per-changelog
+          version-per-antora)
+  (println))
+
+(System/exit (if ok?
+               0
+               1))

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,6 +213,10 @@ workflows:
               only: /^v\d+\.\d+\.\d+(-alpha\d*)?(-beta\d*)?$/
           steps:
             - run:
+                name: Linting antora documentation
+                command: |
+                  make check_antora
+            - run:
                 name: Running cljfmt
                 command: |
                   make cljfmt

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test eastwood cljfmt install smoketest deploy clean detect_timeout
+.PHONY: test eastwood cljfmt install smoketest deploy clean detect_timeout check_antora
 .DEFAULT_GOAL := quick-test
 
 CLOJURE_VERSION ?= 1.10
@@ -73,3 +73,6 @@ clean:
 	lein clean
 	cd test/smoketest && lein clean
 	rm -f .inline-deps
+
+check_antora:
+	lein run -m clojure.main -- .circleci/check_antora.clj

--- a/doc/antora.yml
+++ b/doc/antora.yml
@@ -2,6 +2,6 @@ name: cider-nrepl
 title: CIDER nREPL
 # The version should be in the format major.minor (e.g. 0.28).
 # Don't include patch in the version (e.g. 0.28.7).
-version: "0.31"
+version: "0.37"
 nav:
 - modules/ROOT/nav.adoc


### PR DESCRIPTION
A simple script to ensure it never gets left behind.

It works as intended, as shown in this rightfully failed build: https://app.circleci.com/pipelines/github/clojure-emacs/cider-nrepl/819/workflows/a4c9dbae-3406-4869-9ac1-10ecac31f28e/jobs/10566

Cheers - V