### PR TITLE
`middleware.track-state`: handle non-existing .jar files that may be in the classpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs Fixed
+
+* `middleware.track-state`: handle non-existing .jar files that may be in the classpath.
+
 ## 0.37.0 (2023-08-27)
 
 ### Changes

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ test/resources/cider/nrepl/clojuredocs/export.edn:
 	curl -o $@ https://github.com/clojure-emacs/clojuredocs-export-edn/raw/master/exports/export.compact.edn
 
 .inline-deps: clean
+	echo '"$(PROJECT_VERSION)"' > resources/cider/nrepl/version.edn
 	lein with-profile -user,-dev inline-deps
 	touch .inline-deps
 
@@ -35,6 +36,7 @@ kondo:
 # PROJECT_VERSION=0.37.0 make install
 install: check-install-env .inline-deps
 	lein with-profile -user,-dev,+$(CLOJURE_VERSION),+plugin.mranderson/config install
+	make clean
 
 smoketest: install
 	cd test/smoketest && \
@@ -73,3 +75,4 @@ clean:
 	lein clean
 	cd test/smoketest && lein clean
 	rm -f .inline-deps
+	git checkout resources/cider/nrepl/version.edn

--- a/src/cider/nrepl/middleware/track_state.clj
+++ b/src/cider/nrepl/middleware/track_state.clj
@@ -16,6 +16,7 @@
    [orchard.misc :as misc])
   (:import
    (clojure.lang MultiFn Namespace)
+   (java.io File)
    (java.net SocketException)
    (java.util.jar JarFile)
    (nrepl.transport Transport)))
@@ -237,7 +238,10 @@
   (future
     (into #{}
           (comp (filter misc/jar-file?)
-                (map #(JarFile. (io/as-file %)))
+                (keep (fn [url]
+                        (let [^File file (io/as-file url)]
+                          (when (.exists file)
+                            (JarFile. file)))))
                 (mapcat ns-find/find-namespaces-in-jarfile))
           (cp/classpath))))
 


### PR DESCRIPTION
I was perceiving  this stacktrace:

```
Exception updating the ns-cache #error {
 :cause /Users/vemv/orchard/does-not-exist.jar
 :via
 [{:type java.util.concurrent.ExecutionException
   :message java.nio.file.NoSuchFileException: /Users/vemv/orchard/does-not-exist.jar
   :at [java.util.concurrent.FutureTask report FutureTask.java 122]}
  {:type java.nio.file.NoSuchFileException
   :message /Users/vemv/orchard/does-not-exist.jar
   :at [sun.nio.fs.UnixException translateToIOException UnixException.java 92]}]
 :trace
 [[sun.nio.fs.UnixException translateToIOException UnixException.java 92]
  [sun.nio.fs.UnixException rethrowAsIOException UnixException.java 106]
  [sun.nio.fs.UnixException rethrowAsIOException UnixException.java 111]
  [sun.nio.fs.UnixFileAttributeViews$Basic readAttributes UnixFileAttributeViews.java 55]
  [sun.nio.fs.UnixFileSystemProvider readAttributes UnixFileSystemProvider.java 149]
  [java.nio.file.Files readAttributes Files.java 1843]
  [java.util.zip.ZipFile$Source get ZipFile.java 1212]
  [java.util.zip.ZipFile$CleanableResource <init> ZipFile.java 706]
  [java.util.zip.ZipFile <init> ZipFile.java 240]
  [java.util.zip.ZipFile <init> ZipFile.java 171]
  [java.util.jar.JarFile <init> JarFile.java 348]
  [java.util.jar.JarFile <init> JarFile.java 319]
  [java.util.jar.JarFile <init> JarFile.java 285]
  [cider.nrepl.middleware.track_state$fn__1357287$fn__1357288 invoke track_state.clj 240]
  [clojure.core$map$fn__5945$fn__5946 invoke core.clj 2759]
  [clojure.core$filter$fn__5972$fn__5973 invoke core.clj 2823]
  [clojure.core.protocols$fn__8265 invokeStatic protocols.clj 168]
  [clojure.core.protocols$fn__8265 invoke protocols.clj 124]
  [clojure.core.protocols$fn__8220$G__8215__8229 invoke protocols.clj 19]
  [clojure.core.protocols$seq_reduce invokeStatic protocols.clj 31]
  [clojure.core.protocols$fn__8252 invokeStatic protocols.clj 75]
  [clojure.core.protocols$fn__8252 invoke protocols.clj 75]
  [clojure.core.protocols$fn__8194$G__8189__8207 invoke protocols.clj 13]
  [clojure.core$transduce invokeStatic core.clj 6956]
  [clojure.core$into invokeStatic core.clj 6971]
  [clojure.core$into invoke core.clj 6959]
  [cider.nrepl.middleware.track_state$fn__1357287 invokeStatic track_state.clj 238]
  [cider.nrepl.middleware.track_state$fn__1357287 invoke track_state.clj 237]
  [clojure.core$binding_conveyor_fn$fn__5837 invoke core.clj 2047]
  [clojure.lang.AFn call AFn.java 18]
  [java.util.concurrent.FutureTask run FutureTask.java 264]
  [java.util.concurrent.ThreadPoolExecutor runWorker ThreadPoolExecutor.java 1130]
  [java.util.concurrent.ThreadPoolExecutor$Worker run ThreadPoolExecutor.java 630]
  [java.lang.Thread run Thread.java 831]]}
```