### PR TITLE
Bump `orchard` to 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* Bump `orchard` to [1.5.1](https://github.com/clojure-emacs/orchard/blob/v0.15.1/CHANGELOG.md#0151-2023-09-21).
+
 ## 0.38.0 (2023-09-21)
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+## 0.38.1 (2023-09-21)
+
 * Bump `orchard` to [1.5.1](https://github.com/clojure-emacs/orchard/blob/v0.15.1/CHANGELOG.md#0151-2023-09-21).
 
 ## 0.38.0 (2023-09-21)

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ light-kondo: clean
 
 lint: kondo cljfmt eastwood
 
-# PROJECT_VERSION=0.38.0 make install
+# PROJECT_VERSION=0.38.1 make install
 install: dump-version check-install-env .inline-deps
 	rm -f .no-mranderson
 	touch .no-pedantic
@@ -75,7 +75,7 @@ install: dump-version check-install-env .inline-deps
 	make clean
 	git checkout resources/cider/nrepl/version.edn
 
-# PROJECT_VERSION=0.38.0 make fast-install
+# PROJECT_VERSION=0.38.1 make fast-install
 fast-install: dump-version check-install-env
 	lein with-profile -user,-dev,+$(CLOJURE_VERSION) install
 	make clean

--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ make fast-test
 # Install the project in your local ~/.m2 directory, using mranderson (recommended)
 # The JVM flag is a temporary workaround.
 export LEIN_JVM_OPTS="-Dmranderson.internal.no-parallelism=true"
-PROJECT_VERSION=0.38.0 make install
+PROJECT_VERSION=0.38.1 make install
 
 # Install the project in your local ~/.m2 directory, without using mranderson
 # (it's faster, but please only use when you repeatedly need to install cider-nrepl)
 # The JVM flag is a temporary workaround.
 export LEIN_JVM_OPTS="-Dmranderson.internal.no-parallelism=true"
-PROJECT_VERSION=0.38.0 make fast-install
+PROJECT_VERSION=0.38.1 make fast-install
 
 # Runs clj-kondo, cljfmt and Eastwood (in that order, with fail-fast).
 # Please try to run this before pushing commits.
@@ -107,7 +107,7 @@ before cutting a new release.
 Release to [clojars](https://clojars.org/) by tagging a new release:
 
 ```
-git tag -a v0.38.0 -m "Release 0.38.0"
+git tag -a v0.38.1 -m "Release 0.38.1"
 git push --tags
 ```
 

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -15,14 +15,14 @@ Use the convenient plugin for defaults, either in your project's
 
 [source,clojure]
 ----
-:plugins [[cider/cider-nrepl "0.38.0"]]
+:plugins [[cider/cider-nrepl "0.38.1"]]
 ----
 
 A minimal `profiles.clj` for CIDER would be:
 
 [source,clojure]
 ----
-{:user {:plugins [[cider/cider-nrepl "0.38.0"]]}}
+{:user {:plugins [[cider/cider-nrepl "0.38.1"]]}}
 ----
 
 Or (if you know what you're doing) add `cider-nrepl` to your `:dev
@@ -31,7 +31,7 @@ under `:repl-options`.
 
 [source,clojure]
 ----
-:dependencies [[cider/cider-nrepl "0.38.0"]]
+:dependencies [[cider/cider-nrepl "0.38.1"]]
 :repl-options {:nrepl-middleware
                  [cider.nrepl/wrap-apropos
                   cider.nrepl/wrap-classpath
@@ -65,7 +65,7 @@ it on the command line through the `cider.tasks/add-middleware` task
 functionality):
 
 ----
-boot -d nrepl:1.0.0 -d cider/cider-nrepl:0.38.0 -i "(require 'cider.tasks)" cider.tasks/add-middleware -m cider.nrepl.middleware.apropos/wrap-apropos -m cider.nrepl.middleware.version/wrap-version repl --server wait
+boot -d nrepl:1.0.0 -d cider/cider-nrepl:0.38.1 -i "(require 'cider.tasks)" cider.tasks/add-middleware -m cider.nrepl.middleware.apropos/wrap-apropos -m cider.nrepl.middleware.version/wrap-version repl --server wait
 ----
 
 Or for all of their projects by adding a `~/.boot/profile.boot` file like so:
@@ -73,7 +73,7 @@ Or for all of their projects by adding a `~/.boot/profile.boot` file like so:
 [source,clojure]
 ----
 (set-env! :dependencies '[[nrepl "1.0.0"]
-                          [cider/cider-nrepl "0.38.0"]])
+                          [cider/cider-nrepl "0.38.1"]])
 
 (require '[cider.tasks :refer [add-middleware]])
 
@@ -95,7 +95,7 @@ You can easily boot an nREPL server with the CIDER middleware loaded
 with the following "magic" incantation:
 
 ----
-clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.38.0"} }}' -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
+clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.38.1"} }}' -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
 ----
 
 There are also two convenient aliases you can employ:
@@ -105,12 +105,12 @@ There are also two convenient aliases you can employ:
 {...
  :aliases
  {:cider-clj {:extra-deps {org.clojure/clojure {:mvn/version "1.10.1"}
-                           cider/cider-nrepl {:mvn/version "0.38.0"}}
+                           cider/cider-nrepl {:mvn/version "0.38.1"}}
               :main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"]}
 
   :cider-cljs {:extra-deps {org.clojure/clojure {:mvn/version "1.10.1"}
                             org.clojure/clojurescript {:mvn/version "1.10.339"}
-                            cider/cider-nrepl {:mvn/version "0.38.0"}
+                            cider/cider-nrepl {:mvn/version "0.38.1"}
                             cider/piggieback {:mvn/version "0.5.2"}}
                :main-opts ["-m" "nrepl.cmdline" "--middleware"
                            "[cider.nrepl/cider-middleware,cider.piggieback/wrap-cljs-repl]"]}}}

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/clojure-emacs/cider-nrepl"}
   :dependencies [[nrepl "1.0.0"]
-                 ^:inline-dep [cider/orchard "0.15.0" :exclusions [com.google.code.findbugs/jsr305 com.google.errorprone/error_prone_annotations]]
+                 ^:inline-dep [cider/orchard "0.15.1" :exclusions [com.google.code.findbugs/jsr305 com.google.errorprone/error_prone_annotations]]
                  ^:inline-dep [mx.cider/haystack "0.2.0"]
                  ^:inline-dep [thunknyc/profile "0.5.2"]
                  ^:inline-dep [mvxcvi/puget "1.3.4"]


### PR DESCRIPTION
*  Bump `orchard` to 1.5.1
* 0.38.1

https://github.com/clojure-emacs/orchard/blob/v0.15.1/CHANGELOG.md#0151-2023-09-21
https://clojars.org/cider/orchard/versions/0.15.1