### PR TITLE
`info` and `eldoc` ops: fix regression for the special form `..`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs Fixed
+
+* `info` and `eldoc` ops: fix regression for the special form `..`.
+
 ## 0.38.1 (2023-09-21)
 
 * Bump `orchard` to [1.5.1](https://github.com/clojure-emacs/orchard/blob/v0.15.1/CHANGELOG.md#0151-2023-09-21).

--- a/src/cider/nrepl/middleware/info.clj
+++ b/src/cider/nrepl/middleware/info.clj
@@ -88,7 +88,9 @@
                                                  (symbol class))
                               .getName))
                     (not-empty class)
-                    (when (some-> sym (str/starts-with? "."))
+                    (when (and (some-> sym (str/starts-with? "."))
+                               ;; .. cannot be a class member, so class inference doesn't make sense here:
+                               (not= sym ".."))
                       (extract-class-from-compliment ns context)))
                 (catch Exception e
                   nil))

--- a/test/clj/cider/nrepl/middleware/info_test.clj
+++ b/test/clj/cider/nrepl/middleware/info_test.clj
@@ -96,13 +96,17 @@
   (testing "A `:context` can disambiguate input, reducing the `:candidates` to just one"
     (let [base {:ns (str *ns*)
                 :symbol ".codePointCount"}
+          base-with-context (assoc base :context "(let [v \"\"] \n (__prefix__ v))")
           response-without-context (info/info base)
-          response-with-context (info/info (assoc base :context "(let [v \"\"] \n (__prefix__ v))"))]
+          response-with-context (info/info base-with-context)]
       (is (= '[java.lang.String java.lang.StringBuffer java.lang.Character java.lang.StringBuilder]
              (-> response-without-context :candidates keys)))
       (is (not (:candidates response-with-context)))
       (is (= `String
-             (:class response-with-context))))))
+             (:class response-with-context)))
+      (is (= {:added "1.0", :ns 'clojure.core, :name '.., :file "clojure/core.clj"}
+             (-> base-with-context (assoc :symbol "..") info/info (select-keys [:class :added :ns :name :file])))
+          "The context is ignored for the special form `..`"))))
 
 ;; Used below in an integration test
 (def ^{:protocol #'clojure.data/Diff} junk-protocol-client nil)


### PR DESCRIPTION
Documentation wasn't showing up for `..` when providing a context.