### PR TITLE
Exercise enrich-classpath and all Orchard Parser variants in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,9 @@ jobs:
       clojure_version:
         description: Version of Clojure to test against
         type: string
+      parser_target:
+        description: The Orchard Java parser to be exercised
+        type: string
     executor: << parameters.jdk_version >>
     environment:
       VERSION: << parameters.clojure_version >>
@@ -159,10 +162,10 @@ jobs:
           steps:
             - run:
                 name: Running tests # Redundant relative to `make test`, however it makes the CI jobs fail faster, given how much time mranderson takes.
-                command: make quick-test
+                command: PARSER_TARGET=<< parameters.parser_target >> make --debug quick-test
             - run:
                 name: Running tests with inlined deps
-                command: make test smoketest
+                command: PARSER_TARGET=<< parameters.parser_target >> make --debug test smoketest
             - run:
                 name: Install the Clojure CLI
                 command: |
@@ -199,6 +202,7 @@ workflows:
             parameters:
               clojure_version: ["1.8", "1.9", "1.10", "1.11", "master"]
               jdk_version: [openjdk8, openjdk11, openjdk16, openjdk17]
+              parser_target: ["parser-next", "parser", "legacy-parser"]
           filters:
             branches:
               only: /.*/

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ out
 .source-deps
 .clj-kondo/.cache
 /.no-mranderson
+/test-runner
+/.test-classpath

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ These are its main tasks for local development:
 make repl
 
 # Run tests, using mranderson (slower but more realistic)
-make test
+PARSER_TARGET=parser-next make test
 
 # Run tests, without using mranderson (considerably faster)
-make fast-test
+PARSER_TARGET=parser-next make fast-test
 
 # Install the project in your local ~/.m2 directory, using mranderson (recommended)
 # The JVM flag is a temporary workaround.

--- a/test/clj/cider/nrepl/middleware/info_test.clj
+++ b/test/clj/cider/nrepl/middleware/info_test.clj
@@ -6,7 +6,8 @@
    [clojure.data]
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [clojure.test :refer :all])
+   [clojure.test :refer :all]
+   [orchard.misc :as misc])
   (:import
    (cider.nrepl.test AnotherTestClass TestClass YetAnotherTest)
    (org.apache.commons.lang3 SystemUtils)))
@@ -19,6 +20,23 @@
   "Is enrich-classpath (or something equivalent) augmenting the classpath?"
   (boolean (or (io/resource "java/lang/Thread.java")
                (io/resource "java.base/java/lang/Thread.java"))))
+
+;; TODO: use `orchard.java/parser-next-available?` after Orchar's next release
+(def parser-next-available?
+  (delay ;; avoid the side-effects at compile-time
+    (atom ;; make the result mutable - this is helpful in case the detection below wasn't sufficient
+     (and (>= misc/java-api-version 9)
+          (try
+            ;; indicates that the classes are available
+            ;; however it does not indicate if necessary `add-opens=...` JVM flag is in place:
+            (and
+             (Class/forName "com.sun.tools.javac.tree.DCTree$DCBlockTag")
+             (Class/forName "com.sun.tools.javac.code.Type$ArrayType")
+             (seq (do
+                    (require 'orchard.java.parser-next)
+                    ((resolve 'orchard.java.parser-next/source-info) `String))))
+            (catch Throwable e
+              false))))))
 
 (deftest format-response-test
   (is (re-find #"^(https?|file|jar|zip):" ; resolved either locally or online
@@ -146,7 +164,7 @@
         (is (= (:doc response) "a macro for testing"))
         (is (nil? (:spec response)))))
 
-    (when enriched-classpath?
+    (when @@parser-next-available?
       (testing "'fragments' attributes are returned"
         (let [{:keys [doc-fragments doc-first-sentence-fragments doc-block-tags-fragments]
                :as response}
@@ -197,7 +215,9 @@
             (pr-str response))
         (is (= (:class response) "cider.nrepl.test.TestClass"))
         (is (= (:member response) "doSomething"))
-        (is (= "[int int java.lang.String]" (:arglists-str response)))
+        (is (#{"[int int java.lang.String]" ;; without enrich-classpath in
+               "[a b c]"} ;; with enrich-classpath in
+             (:arglists-str response)))
         (is (= (:argtypes response) ["int" "int" "java.lang.String"]))
         (is (= (:returns response) "void"))
         (is (= (:modifiers response) "#{:private :static}"))
@@ -382,7 +402,7 @@
             (is (not (contains? response :ns)))
             (is (= "function" (:type response)))))))
 
-    (when enriched-classpath?
+    (when @@parser-next-available?
       (testing "Fragments for java interop method with single class"
         (let [{:keys [doc-fragments doc-first-sentence-fragments doc-block-tags-fragments]
                :as response}
@@ -403,10 +423,16 @@
 
     (testing "java method eldoc lookup, internal testing methods"
       (let [response (session/message {:op "eldoc" :sym "fnWithSameName" :ns "cider.nrepl.middleware.info-test"})]
-        (is (= #{["this"] ;;TestClass
+        (is (#{;; without enrich-classpath in:
+               #{["this"] ;;TestClass
                  ["int" "java.lang.String" "boolean"] ;;AnotherTestClass
                  ["this" "byte[]" "java.lang.Object[]" "java.util.List"]} ;;YetAnotherTest
-               (set (:eldoc response)))
+
+               ;; with enrich-classpath in:
+               #{["this"]
+                 ["a" "b" "c"]
+                 ["this" "prim" "things" "generic"]}}
+             (set (:eldoc response)))
             (pr-str response))
         (is (= "function" (:type response)))))))
 

--- a/test/clj/cider/nrepl/plugin_test.clj
+++ b/test/clj/cider/nrepl/plugin_test.clj
@@ -10,7 +10,7 @@
                   ['cider/cider-nrepl version-string]]
    :repl-options {:nrepl-middleware mw/cider-middleware}})
 
-(deftest version-checks
+(deftest ^:cognitest-exclude version-checks
   (testing "undefined versions work"
     (is (= expected-output
            (middleware {:dependencies [['org.clojure/clojure]]}))))


### PR DESCRIPTION
* Exercise enrich-classpath in CI
* Exercise each of the three Orchard Java parsers
  * This is accomplished by either of
    * excluding enrich-classpath;
    * including it partially (removing the `--add-opens` flags it adds);
    * or including it fully.

It is valuable to check that our usual tests don't fail in presence of Enrich. Just a couple tests had to be adapted (for the better: with enrich in, the assertion is richer).

It's basically the same setup I introduced in https://github.com/clojure-emacs/orchard/pull/192 , with some variations.

Cheers - V