### PR TITLE
Don't inline orchard anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* Bump `orchard` to [0.15.2](https://github.com/clojure-emacs/orchard/blob/v0.15.2/CHANGELOG.md#0152-2023-10-05).
 * Bump `haystack` to [0.3.1](https://github.com/clojure-emacs/haystack/blob/v0.3.1/CHANGELOG.md#031-2023-09-29).
 * Cache the last result of internal Haystack (exception analysis) calls.
 
@@ -13,7 +14,7 @@
 
 ## 0.38.1 (2023-09-21)
 
-* Bump `orchard` to [1.5.1](https://github.com/clojure-emacs/orchard/blob/v0.15.1/CHANGELOG.md#0151-2023-09-21).
+* Bump `orchard` to [0.15.1](https://github.com/clojure-emacs/orchard/blob/v0.15.1/CHANGELOG.md#0151-2023-09-21).
 
 ## 0.38.0 (2023-09-21)
 

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/clojure-emacs/cider-nrepl"}
   :dependencies [[nrepl "1.0.0"]
-                 [cider/orchard "0.15.1"]
+                 [cider/orchard "0.15.2"]
                  ^:inline-dep [mx.cider/haystack "0.3.1" :exclusions [cider/orchard]]
                  ^:inline-dep [thunknyc/profile "0.5.2"]
                  ^:inline-dep [mvxcvi/puget "1.3.4"]

--- a/project.clj
+++ b/project.clj
@@ -8,10 +8,8 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/clojure-emacs/cider-nrepl"}
   :dependencies [[nrepl "1.0.0"]
-                 ~(with-meta '[cider/orchard "0.15.1" :exclusions [com.google.code.findbugs/jsr305 com.google.errorprone/error_prone_annotations]]
-                    ;; orchard is used in a test, so we cannot inline it while running tests.
-                    {:inline-dep (not= "true" (System/getenv "SKIP_INLINING_TEST_DEPS"))})
-                 ^:inline-dep [mx.cider/haystack "0.3.1"]
+                 [cider/orchard "0.15.1"]
+                 ^:inline-dep [mx.cider/haystack "0.3.1" :exclusions [cider/orchard]]
                  ^:inline-dep [thunknyc/profile "0.5.2"]
                  ^:inline-dep [mvxcvi/puget "1.3.4"]
                  ^:inline-dep [fipp ~fipp-version] ; can be removed in unresolved-tree mode


### PR DESCRIPTION
I encountered the following locally:

    Caused by: java.lang.ClassNotFoundException: cidernrepl0381.mx.cider.orchard.LruMap

which is caused by the .java file bundled by Orchard - mranderson is struggling to inline it.

I propose to un-inline this dep, just like we do for logjam, based on the following considerations:

* cider-nrepl, being its main consumer, will always pull _latest_
  * (more recent versions are more likely to be chosen by dependency resolution algos)
* orchard is dependency-free.
* orchard tries hard not to inflict breaking changes.

We could eventually inline Orchard (and logjam) again some day, but I sense mranderson would need some attention first.

Cheers - V