### PR TITLE
`track-state`: include var info for macros defined for ClojureScript namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+## 0.40.0 (2023-10-15)
+
 ### Changes
 
 * `track-state`: include var info for macros defined for ClojureScript namespaces.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+### Changes
+
+* `track-state`: include var info for macros defined for ClojureScript namespaces.
+  * e.g. for `foo.cljs`, now var info for any macros contained in `foo.clj` is also included.  
+
 ## 0.39.1 (2023-10-12)
 
 ### Changes

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ TEST_PROFILES ?= "-user,-dev,+test"
 
 # The enrich-classpath version to be injected.
 # Feel free to upgrade this.
-ENRICH_CLASSPATH_VERSION="1.18.0"
+ENRICH_CLASSPATH_VERSION="1.18.2"
 
 # Set bash instead of sh for the @if [[ conditions,
 # and use the usual safety flags:
@@ -169,7 +169,7 @@ clean:
 # Launches a repl, falling back to vanilla lein repl if something went wrong during classpath calculation.
 lein-repl: .enrich-classpath-lein-repl
 	@if grep --silent " -cp " .enrich-classpath-lein-repl; then \
-		export YOURKIT_SESSION_NAME="$(basename $(PWD))";
+		export YOURKIT_SESSION_NAME="$(basename $(PWD))"; \
 		eval "$$(cat .enrich-classpath-lein-repl) --interactive"; \
 	else \
 		echo "Falling back to lein repl... (you can avoid further falling back by removing .enrich-classpath-lein-repl)"; \

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ light-kondo: clean
 
 lint: kondo cljfmt eastwood
 
-# PROJECT_VERSION=0.39.1 make install
+# PROJECT_VERSION=0.40.0 make install
 install: dump-version check-install-env .inline-deps
 	rm -f .no-mranderson
 	touch .no-pedantic
@@ -115,7 +115,7 @@ install: dump-version check-install-env .inline-deps
 	make clean
 	git checkout resources/cider/nrepl/version.edn
 
-# PROJECT_VERSION=0.39.1 make fast-install
+# PROJECT_VERSION=0.40.0 make fast-install
 fast-install: dump-version check-install-env
 	lein with-profile -user,-dev,+$(CLOJURE_VERSION) install
 	make clean

--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ PARSER_TARGET=parser-next make fast-test
 # Install the project in your local ~/.m2 directory, using mranderson (recommended)
 # The JVM flag is a temporary workaround.
 export LEIN_JVM_OPTS="-Dmranderson.internal.no-parallelism=true"
-PROJECT_VERSION=0.39.1 make install
+PROJECT_VERSION=0.40.0 make install
 
 # Install the project in your local ~/.m2 directory, without using mranderson
 # (it's faster, but please only use when you repeatedly need to install cider-nrepl)
 # The JVM flag is a temporary workaround.
 export LEIN_JVM_OPTS="-Dmranderson.internal.no-parallelism=true"
-PROJECT_VERSION=0.39.1 make fast-install
+PROJECT_VERSION=0.40.0 make fast-install
 
 # Runs clj-kondo, cljfmt and Eastwood (in that order, with fail-fast).
 # Please try to run this before pushing commits.
@@ -107,7 +107,7 @@ before cutting a new release.
 Release to [clojars](https://clojars.org/) by tagging a new release:
 
 ```
-git tag -a v0.39.1 -m "Release 0.39.1"
+git tag -a v0.40.0 -m "Release 0.40.0"
 git push --tags
 ```
 

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -15,14 +15,14 @@ Use the convenient plugin for defaults, either in your project's
 
 [source,clojure]
 ----
-:plugins [[cider/cider-nrepl "0.39.1"]]
+:plugins [[cider/cider-nrepl "0.40.0"]]
 ----
 
 A minimal `profiles.clj` for CIDER would be:
 
 [source,clojure]
 ----
-{:user {:plugins [[cider/cider-nrepl "0.39.1"]]}}
+{:user {:plugins [[cider/cider-nrepl "0.40.0"]]}}
 ----
 
 Or (if you know what you're doing) add `cider-nrepl` to your `:dev
@@ -31,7 +31,7 @@ under `:repl-options`.
 
 [source,clojure]
 ----
-:dependencies [[cider/cider-nrepl "0.39.1"]]
+:dependencies [[cider/cider-nrepl "0.40.0"]]
 :repl-options {:nrepl-middleware
                  [cider.nrepl/wrap-apropos
                   cider.nrepl/wrap-classpath
@@ -65,7 +65,7 @@ it on the command line through the `cider.tasks/add-middleware` task
 functionality):
 
 ----
-boot -d nrepl:1.0.0 -d cider/cider-nrepl:0.39.1 -i "(require 'cider.tasks)" cider.tasks/add-middleware -m cider.nrepl.middleware.apropos/wrap-apropos -m cider.nrepl.middleware.version/wrap-version repl --server wait
+boot -d nrepl:1.0.0 -d cider/cider-nrepl:0.40.0 -i "(require 'cider.tasks)" cider.tasks/add-middleware -m cider.nrepl.middleware.apropos/wrap-apropos -m cider.nrepl.middleware.version/wrap-version repl --server wait
 ----
 
 Or for all of their projects by adding a `~/.boot/profile.boot` file like so:
@@ -73,7 +73,7 @@ Or for all of their projects by adding a `~/.boot/profile.boot` file like so:
 [source,clojure]
 ----
 (set-env! :dependencies '[[nrepl "1.0.0"]
-                          [cider/cider-nrepl "0.39.1"]])
+                          [cider/cider-nrepl "0.40.0"]])
 
 (require '[cider.tasks :refer [add-middleware]])
 
@@ -95,7 +95,7 @@ You can easily boot an nREPL server with the CIDER middleware loaded
 with the following "magic" incantation:
 
 ----
-clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.39.1"} }}' -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
+clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.40.0"} }}' -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
 ----
 
 There are also two convenient aliases you can employ:
@@ -105,12 +105,12 @@ There are also two convenient aliases you can employ:
 {...
  :aliases
  {:cider-clj {:extra-deps {org.clojure/clojure {:mvn/version "1.10.1"}
-                           cider/cider-nrepl {:mvn/version "0.39.1"}}
+                           cider/cider-nrepl {:mvn/version "0.40.0"}}
               :main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"]}
 
   :cider-cljs {:extra-deps {org.clojure/clojure {:mvn/version "1.10.1"}
                             org.clojure/clojurescript {:mvn/version "1.10.339"}
-                            cider/cider-nrepl {:mvn/version "0.39.1"}
+                            cider/cider-nrepl {:mvn/version "0.40.0"}
                             cider/piggieback {:mvn/version "0.5.2"}}
                :main-opts ["-m" "nrepl.cmdline" "--middleware"
                            "[cider.nrepl/cider-middleware,cider.piggieback/wrap-cljs-repl]"]}}}

--- a/src/cider/nrepl/middleware/out.clj
+++ b/src/cider/nrepl/middleware/out.clj
@@ -9,6 +9,8 @@
   We use an eval message, instead of the clone op, because there's no
   guarantee that the channel that sent the clone message will properly
   handle output replies."
+  {:clojure.tools.namespace.repl/unload false
+   :clojure.tools.namespace.repl/load false}
   (:require
    [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]])
   (:import

--- a/src/cider/nrepl/middleware/track_state.clj
+++ b/src/cider/nrepl/middleware/track_state.clj
@@ -141,7 +141,7 @@
 
     ;; ClojureScript Namespaces
     (associative? object)
-    (let [{:keys [use-macros uses require-macros requires defs]} object
+    (let [{:keys [use-macros uses macros require-macros requires defs]} object
           post-process (fn [result]
                          (misc/update-vals (fn [x]
                                              (cond-> x
@@ -154,7 +154,8 @@
       {:aliases (merge require-macros requires)
        :interns (merge (post-process (misc/update-vals cljs-meta-with-fn defs))
                        (post-process (uses-metadata all-objects uses))
-                       (post-process (use-macros-metadata use-macros)))})
+                       (post-process (use-macros-metadata use-macros))
+                       (post-process macros))})
 
     :else {}))
 

--- a/test/clj/cider/nrepl/middleware/out_test.clj
+++ b/test/clj/cider/nrepl/middleware/out_test.clj
@@ -1,4 +1,6 @@
 (ns cider.nrepl.middleware.out-test
+  {:clojure.tools.namespace.repl/unload false
+   :clojure.tools.namespace.repl/load false}
   (:require
    [cider.nrepl.middleware.out :as o]
    [clojure.string :as str]

--- a/test/clj/cider/nrepl/middleware/track_state_test.clj
+++ b/test/clj/cider/nrepl/middleware/track_state_test.clj
@@ -133,11 +133,29 @@
                         'c-fn {:tag 'cljs.core/MultiFn}
                         'd-fn {}
                         'a-var {:tag 'something}}
+                 :macros '{from-macros-with-style-indent {:arglists ([& args]),
+                                                          :style/indent :defn,
+                                                          :line 387,
+                                                          :column 1,
+                                                          :file "helix/dom.cljc",
+                                                          :name helix.dom/form,
+                                                          :ns helix.dom,
+                                                          :macro true},
+                           from-macros-without-style-indent {:arglists ([& args]),
+                                                             :line 246,
+                                                             :column 1,
+                                                             :file "helix/dom.cljc",
+                                                             :name helix.dom/audio,
+                                                             :ns helix.dom,
+                                                             :macro true}}
                  :require-macros {'sym-2 'some-namespace}
                  :requires {'sym-3 'some-namespace}}
         other-namespaces [{:name 'some-other-cljs-ns
                            :defs {'sym-1 {:meta {:arglists '([] [a] [a b])}}}}]
         {:keys [aliases interns]} (sut/ns-as-map cljs-ns other-namespaces)]
+    (is (any? (sut/ns-as-map (dissoc cljs-ns :macros :require-macros :use-macrps)
+                             other-namespaces))
+        "Doesn't throw exceptions in the absence of optional keys")
     (is (= '{sym-2 some-namespace sym-3 some-namespace} aliases))
     (is (= '{a-fn {:fn "true"},
              b-fn {:fn "true"},
@@ -149,7 +167,11 @@
              ;; fetched by inspecting the JVM clojure environment:
              test-fn {:arglists "([a b] [a] [])", :doc "\"docstring\""}
              ;; adds :style/indent despite it not being originally present:
-             test-macro {:macro "true", :arglists "([a & body])", :style/indent "1"}}
+             test-macro {:macro "true", :arglists "([a & body])", :style/indent "1"}
+             ;; :style/indent is preserved:
+             from-macros-with-style-indent {:macro "true", :arglists "([& args])", :style/indent ":defn"},
+             ;; :style/indent is inferred:
+             from-macros-without-style-indent {:macro "true", :arglists "([& args])", :style/indent "0"}}
            interns))))
 
 (deftest calculate-used-aliases-test


### PR DESCRIPTION
* `track-state`: include var info for macros defined for ClojureScript namespaces.
  * e.g. for `foo.cljs`, now var info for any macros contained in `foo.clj` is also included.
* 0.40.0
