### PR TITLE
`middleware.inspect:` add new `inspect-previous-sibling`, `inspect-next-sibling` ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+## 0.41.0 (2023-10-24)
+
 ### New features
 
 * `middleware.inspect:` add new `inspect-tap-current-value` op.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * `middleware.inspect:` add new `inspect-tap-current-value` op.
+* `middleware.inspect:` add new `inspect-previous-sibling`, `inspect-next-sibling` ops.
 
 ## 0.40.0 (2023-10-15)
 

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ light-kondo: clean
 
 lint: kondo cljfmt eastwood
 
-# PROJECT_VERSION=0.40.0 make install
+# PROJECT_VERSION=0.41.0 make install
 install: dump-version check-install-env .inline-deps
 	rm -f .no-mranderson
 	touch .no-pedantic
@@ -115,7 +115,7 @@ install: dump-version check-install-env .inline-deps
 	make clean
 	git checkout resources/cider/nrepl/version.edn
 
-# PROJECT_VERSION=0.40.0 make fast-install
+# PROJECT_VERSION=0.41.0 make fast-install
 fast-install: dump-version check-install-env
 	lein with-profile -user,-dev,+$(CLOJURE_VERSION) install
 	make clean

--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ PARSER_TARGET=parser-next make fast-test
 # Install the project in your local ~/.m2 directory, using mranderson (recommended)
 # The JVM flag is a temporary workaround.
 export LEIN_JVM_OPTS="-Dmranderson.internal.no-parallelism=true"
-PROJECT_VERSION=0.40.0 make install
+PROJECT_VERSION=0.41.0 make install
 
 # Install the project in your local ~/.m2 directory, without using mranderson
 # (it's faster, but please only use when you repeatedly need to install cider-nrepl)
 # The JVM flag is a temporary workaround.
 export LEIN_JVM_OPTS="-Dmranderson.internal.no-parallelism=true"
-PROJECT_VERSION=0.40.0 make fast-install
+PROJECT_VERSION=0.41.0 make fast-install
 
 # Runs clj-kondo, cljfmt and Eastwood (in that order, with fail-fast).
 # Please try to run this before pushing commits.
@@ -107,7 +107,7 @@ before cutting a new release.
 Release to [clojars](https://clojars.org/) by tagging a new release:
 
 ```
-git tag -a v0.40.0 -m "Release 0.40.0"
+git tag -a v0.41.0 -m "Release 0.41.0"
 git push --tags
 ```
 

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -544,6 +544,23 @@ Returns::
 
 
 
+=== `inspect-next-sibling`
+
+Increment the index of the last 'nth in the path by 1,
+if applicable, and re-render the updated value.
+
+Required parameters::
+* `:session` The current session
+
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:status` "done"
+
+
+
 === `inspect-pop`
 
 Moves one level up in the inspector stack.
@@ -563,6 +580,23 @@ Returns::
 === `inspect-prev-page`
 
 Jumps to the previous page in paginated collection view.
+
+Required parameters::
+* `:session` The current session
+
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:status` "done"
+
+
+
+=== `inspect-previous-sibling`
+
+Decrement the index of the last 'nth in the path by 1,
+if applicable, and re-render the updated value.
 
 Required parameters::
 * `:session` The current session

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -15,14 +15,14 @@ Use the convenient plugin for defaults, either in your project's
 
 [source,clojure]
 ----
-:plugins [[cider/cider-nrepl "0.40.0"]]
+:plugins [[cider/cider-nrepl "0.41.0"]]
 ----
 
 A minimal `profiles.clj` for CIDER would be:
 
 [source,clojure]
 ----
-{:user {:plugins [[cider/cider-nrepl "0.40.0"]]}}
+{:user {:plugins [[cider/cider-nrepl "0.41.0"]]}}
 ----
 
 Or (if you know what you're doing) add `cider-nrepl` to your `:dev
@@ -31,7 +31,7 @@ under `:repl-options`.
 
 [source,clojure]
 ----
-:dependencies [[cider/cider-nrepl "0.40.0"]]
+:dependencies [[cider/cider-nrepl "0.41.0"]]
 :repl-options {:nrepl-middleware
                  [cider.nrepl/wrap-apropos
                   cider.nrepl/wrap-classpath
@@ -65,7 +65,7 @@ it on the command line through the `cider.tasks/add-middleware` task
 functionality):
 
 ----
-boot -d nrepl:1.0.0 -d cider/cider-nrepl:0.40.0 -i "(require 'cider.tasks)" cider.tasks/add-middleware -m cider.nrepl.middleware.apropos/wrap-apropos -m cider.nrepl.middleware.version/wrap-version repl --server wait
+boot -d nrepl:1.0.0 -d cider/cider-nrepl:0.41.0 -i "(require 'cider.tasks)" cider.tasks/add-middleware -m cider.nrepl.middleware.apropos/wrap-apropos -m cider.nrepl.middleware.version/wrap-version repl --server wait
 ----
 
 Or for all of their projects by adding a `~/.boot/profile.boot` file like so:
@@ -73,7 +73,7 @@ Or for all of their projects by adding a `~/.boot/profile.boot` file like so:
 [source,clojure]
 ----
 (set-env! :dependencies '[[nrepl "1.0.0"]
-                          [cider/cider-nrepl "0.40.0"]])
+                          [cider/cider-nrepl "0.41.0"]])
 
 (require '[cider.tasks :refer [add-middleware]])
 
@@ -95,7 +95,7 @@ You can easily boot an nREPL server with the CIDER middleware loaded
 with the following "magic" incantation:
 
 ----
-clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.40.0"} }}' -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
+clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.41.0"} }}' -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
 ----
 
 There are also two convenient aliases you can employ:
@@ -105,12 +105,12 @@ There are also two convenient aliases you can employ:
 {...
  :aliases
  {:cider-clj {:extra-deps {org.clojure/clojure {:mvn/version "1.10.1"}
-                           cider/cider-nrepl {:mvn/version "0.40.0"}}
+                           cider/cider-nrepl {:mvn/version "0.41.0"}}
               :main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"]}
 
   :cider-cljs {:extra-deps {org.clojure/clojure {:mvn/version "1.10.1"}
                             org.clojure/clojurescript {:mvn/version "1.10.339"}
-                            cider/cider-nrepl {:mvn/version "0.40.0"}
+                            cider/cider-nrepl {:mvn/version "0.41.0"}
                             cider/piggieback {:mvn/version "0.5.2"}}
                :main-opts ["-m" "nrepl.cmdline" "--middleware"
                            "[cider.nrepl/cider-middleware,cider.piggieback/wrap-cljs-repl]"]}}}

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/clojure-emacs/cider-nrepl"}
   :dependencies [[nrepl "1.0.0"]
-                 [cider/orchard "0.16.1"]
+                 [cider/orchard "0.17.0"]
                  ^:inline-dep [mx.cider/haystack "0.3.1" :exclusions [cider/orchard]]
                  ^:inline-dep [thunknyc/profile "0.5.2"]
                  ^:inline-dep [mvxcvi/puget "1.3.4"]

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -259,6 +259,16 @@ making the results more accurate (and less numerous)."
                :requires {"idx" "Index of the internal value currently rendered."
                           "session" "The current session"}
                :returns {"status" "\"done\""}}
+              "inspect-next-sibling"
+              {:doc "Increment the index of the last 'nth in the path by 1,
+if applicable, and re-render the updated value."
+               :requires {"session" "The current session"}
+               :returns {"status" "\"done\""}}
+              "inspect-previous-sibling"
+              {:doc "Decrement the index of the last 'nth in the path by 1,
+if applicable, and re-render the updated value."
+               :requires {"session" "The current session"}
+               :returns {"status" "\"done\""}}
               "inspect-refresh"
               {:doc "Re-renders the currently inspected value."
                :requires {"session" "The current session"}

--- a/src/cider/nrepl/middleware/inspect.clj
+++ b/src/cider/nrepl/middleware/inspect.clj
@@ -76,6 +76,12 @@
 (defn push-reply [msg]
   (inspector-response msg (swap-inspector! msg inspect/down (:idx msg))))
 
+(defn next-sibling-reply [msg]
+  (inspector-response msg (swap-inspector! msg inspect/next-sibling)))
+
+(defn previous-sibling-reply [msg]
+  (inspector-response msg (swap-inspector! msg inspect/previous-sibling)))
+
 (defn refresh-reply [msg]
   (inspector-response msg (swap-inspector! msg #(or % (inspect/fresh)))))
 
@@ -115,6 +121,8 @@
     (with-safe-transport handler msg
       "inspect-pop" pop-reply
       "inspect-push" push-reply
+      "inspect-next-sibling" next-sibling-reply
+      "inspect-previous-sibling" previous-sibling-reply
       "inspect-refresh" refresh-reply
       "inspect-get-path" get-path-reply
       "inspect-next-page" next-page-reply

--- a/test/clj/cider/nrepl/middleware/inspect_test.clj
+++ b/test/clj/cider/nrepl/middleware/inspect_test.clj
@@ -534,9 +534,9 @@
           ms 50
           iterations (long (/ max-time ms))]
       (loop [i 0]
-        (when (and (not= "7" @inspect-tap-current-value-test-atom)
+        (when (and (not= 7 @inspect-tap-current-value-test-atom)
                    (< i iterations))
           (Thread/sleep ms)
           (recur (inc i)))))
 
-    (is (= "7" @inspect-tap-current-value-test-atom))))
+    (is (= 7 @inspect-tap-current-value-test-atom))))


### PR DESCRIPTION
> Part of https://github.com/clojure-emacs/cider/issues/3529