### PR TITLE
Warmup Orchard caches for exceptions in advance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,6 +200,39 @@ workflows:
               clojure_version: ["1.8", "1.9", "1.10", "1.11", "master"]
               jdk_version: [openjdk8, openjdk11, openjdk16, openjdk17]
               parser_target: ["parser-next", "parser", "legacy-parser"]
+            # It doesn't make sense to exercise the newer Orchard Java parsers against JDK8
+            # (given that JDK8 is explicitly excluded by those parsers), so we exclude those combinations from the CI matrix:
+            exclude:
+              - jdk_version: openjdk8
+                parser_target: "parser-next"
+                clojure_version: "1.8"
+              - jdk_version: openjdk8
+                parser_target: "parser"
+                clojure_version: "1.8"
+              - jdk_version: openjdk8
+                parser_target: "parser-next"
+                clojure_version: "1.9"
+              - jdk_version: openjdk8
+                parser_target: "parser"
+                clojure_version: "1.9"
+              - jdk_version: openjdk8
+                parser_target: "parser-next"
+                clojure_version: "1.10"
+              - jdk_version: openjdk8
+                parser_target: "parser"
+                clojure_version: "1.10"
+              - jdk_version: openjdk8
+                parser_target: "parser-next"
+                clojure_version: "1.11"
+              - jdk_version: openjdk8
+                parser_target: "parser"
+                clojure_version: "1.11"
+              - jdk_version: openjdk8
+                parser_target: "parser-next"
+                clojure_version: "master"
+              - jdk_version: openjdk8
+                parser_target: "parser"
+                clojure_version: "master"
           filters:
             branches:
               only: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#828](https://github.com/clojure-emacs/cider-nrepl/issues/828): Warmup Orchard caches for exceptions in advance.
+  * This noticeably improves the first-time performance of exception-related ops, e.g. `analyze-last-stacktrace`.
+
 ## 0.42.1 (2023-10-31)
 
 * Bump `suitable` to [0.5.1](https://github.com/clojure-emacs/clj-suitable/blob/v0.5.1/CHANGELOG.md#051-2023-10-31).

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 A collection of [nREPL](https://github.com/nrepl/nrepl)
 middleware, originally designed to enhance
 [CIDER](https://github.com/clojure-emacs/cider).
-`cider-nrepl` is also used by `vim-fireplace`, `iced-vim`,
-Calva and other Clojure development tools based on nREPL.
+`cider-nrepl` is also used by [fireplace.vim](https://github.com/tpope/vim-fireplace), [vim-iced](https://github.com/liquidz/vim-iced),
+[Calva](https://calva.io/), [Conjure](https://github.com/Olical/conjure) and other Clojure development tools based on nREPL.
 
 If you're just a user trying to get started with CIDER, then you
 probably don't want to read this. You should follow the steps in

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -11,6 +11,7 @@
    [cider.nrepl.middleware :as mw]
    [cider.nrepl.middleware.util.cljs :as cljs]
    [cider.nrepl.print-method] ;; we load this namespace, so it's directly available to clients
+   [haystack.analyzer :as analyzer]
    [nrepl.middleware :refer [set-descriptor!]]
    [nrepl.middleware.caught :refer [wrap-caught]]
    [nrepl.middleware.print :refer [wrap-print wrap-print-optional-arguments]]
@@ -19,15 +20,28 @@
    [nrepl.server :as nrepl-server]
    [orchard.java]))
 
-;; Perform the dynamic `require` asap, and also not within a separate thread:
+;; Perform the underlying dynamic `require`s asap, and also not within a separate thread
+;; (note the `future` used in `#'initializer`),
+;; since `require` is not thread-safe:
 @@orchard.java/parser-next-available?
+@analyzer/spec-abbrev
 
 ;; Warm up this cache, drastically improving the completion and info UX performance for first hits.
-;; (This was our behavior for many years, then had to be disabled for test suite reasons in Orchard 0.15.0 to 0.17.0 / cider-nrepl 0.38.0 to 0.41.0, and now it's restored again)
+;; (This was our behavior for many years,
+;; then had to be disabled for test suite reasons in Orchard 0.15.0 to 0.17.0 / cider-nrepl 0.38.0 to 0.41.0, and now it's restored again)
 ;; Note that this can only be done cider-nrepl side, unlike before when it was done in Orchard itself.
 (def initializer
   (future
+    ;; 1.- Warmup the overall cache for core Java and Clojure stuff
     @orchard.java/cache-initializer
+    ;; 2.- Also cache members involved in a typical exception (which includes stuff from nrepl, clojure.repl, etc)
+    (try
+      @analyzer/ns-common-prefix
+      (/ 2 0) ;; throw an exception for its analysis
+      (catch Exception e
+        ;; This performs a many `orchard.info/info*` calls (one per stacktrace frame).
+        ;; Without analyzing one exception in advance, first-time usages of Haystack will be noticeably slow (#828) - prevent that:
+        (analyzer/analyze e)))
     ;; Leave an indicator that can help up assess the size of a cache in a future:
     (-> orchard.java/cache keys count)))
 


### PR DESCRIPTION
Fixes https://github.com/clojure-emacs/cider-nrepl/issues/828

I verified it works as intended, shaving 12s for the first time `*cider-error*` pops up.