### PR TITLE
Introduce `inspect-last-stacktrace-exception` op

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [cider#3565](https://github.com/clojure-emacs/cider/issues/3565): Add new [`inspect-last-exception`](https://docs.cider.mx/cider-nrepl/nrepl-api/ops.html#inspect-last-exception) op.
+
 ### Changes
 
 * [#828](https://github.com/clojure-emacs/cider-nrepl/issues/828): Warmup Orchard caches for exceptions in advance.

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -312,7 +312,6 @@ Optional parameters::
 * `:class` A Java class. If ``:ns`` is passed, it will be used for fully-qualifiying the class, if necessary.
 * `:context` A Compliment completion context, just like the ones already passed for the "complete" op,
 with the difference that the symbol at point should be entirely replaced by "\__prefix__".
-
 For Java interop queries, it helps inferring the precise type of the object the ``:sym`` or ``:member`` refers to,
 making the results more accurate (and less numerous).
 * `:member` A Java class member.
@@ -447,7 +446,6 @@ Optional parameters::
 * `:class` A Java class. If ``:ns`` is passed, it will be used for fully-qualifiying the class, if necessary.
 * `:context` A Compliment completion context, just like the ones already passed for the "complete" op,
 with the difference that the symbol at point should be entirely replaced by "\__prefix__".
-
 For Java interop queries, it helps inferring the precise type of the object the ``:sym`` or ``:member`` refers to,
 making the results more accurate (and less numerous).
 * `:member` A Java class member.
@@ -525,6 +523,24 @@ Optional parameters::
 
 Returns::
 * `:status` "done"
+
+
+
+=== `inspect-last-exception`
+
+Returns an Inspector response for the last exception that has been processed through ``analyze-last-stacktrace`` for the current nrepl session.
+Assumes that ``analyze-last-stacktrace`` has been called first, returning "no-error" otherwise.
+
+Required parameters::
+* `:index` 0 for inspecting the top-level exception, 1 for its ex-cause, 2 for its ex-cause's ex-cause, and so on.
+
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:status` "done", or "no-error" if ``analyze-last-stacktrace`` wasn't called beforehand (or the ``index`` was out of bounds).
+* `:value` A value, as produced by the Inspector middleware.
 
 
 

--- a/maint/cider/nrepl/impl/docs.clj
+++ b/maint/cider/nrepl/impl/docs.clj
@@ -157,4 +157,5 @@ use in e.g. wiki pages, github, etc."
             docs (format-response format resp)]
         (if (= *out* file) (println docs)
             (do (spit file docs)
-                (println (str "Regenerated " (.getAbsolutePath file)))))))))
+                (println (str "Regenerated " (.getAbsolutePath file)))))))
+    (shutdown-agents)))

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -245,7 +245,6 @@ Depending on the type of the return value of the evaluation this middleware may 
    "ns"      "The current namespace"
    "context" "A Compliment completion context, just like the ones already passed for the \"complete\" op,
 with the difference that the symbol at point should be entirely replaced by \"__prefix__\".
-
 For Java interop queries, it helps inferring the precise type of the object the `:sym` or `:member` refers to,
 making the results more accurate (and less numerous)."
    "class"  "A Java class. If `:ns` is passed, it will be used for fully-qualifiying the class, if necessary."

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -627,6 +627,11 @@ if applicable, and re-render the updated value."
     :handles {"analyze-last-stacktrace" {:doc "Return messages describing each cause and stack frame of the most recent exception."
                                          :optional wrap-print-optional-arguments
                                          :returns {"status" "\"done\", or \"no-error\" if `*e` is nil"}}
+              "inspect-last-exception" {:doc "Returns an Inspector response for the last exception that has been processed through `analyze-last-stacktrace` for the current nrepl session.
+Assumes that `analyze-last-stacktrace` has been called first, returning \"no-error\" otherwise."
+                                        :requires {"index" "0 for inspecting the top-level exception, 1 for its ex-cause, 2 for its ex-cause's ex-cause, and so on."}
+                                        :returns {"status" "\"done\", or \"no-error\" if `analyze-last-stacktrace` wasn't called beforehand (or the `index` was out of bounds)."
+                                                  "value" "A value, as produced by the Inspector middleware."}}
               "analyze-stacktrace" {:doc "Parse and analyze the `:stacktrace`
 parameter and return messages describing each cause and stack frame. The
 stacktrace must be a string formatted in one of the following formats:

--- a/src/cider/nrepl/middleware/inspect.clj
+++ b/src/cider/nrepl/middleware/inspect.clj
@@ -24,16 +24,21 @@
                  (pr-str rendered))]
      (response-for msg resp {:value value}))))
 
-(defn inspect-reply
-  [{:keys [page-size transport max-atom-length max-coll-size] :as msg} eval-response]
-  (let [value (cljs/response-value msg eval-response)
-        page-size (or page-size 32)
+(defn inspect-reply*
+  [{:keys [page-size max-atom-length max-coll-size] :as msg} value]
+  (let [page-size (or page-size 32)
         inspector (swap-inspector! msg #(-> %
                                             (assoc :page-size page-size
                                                    :max-atom-length max-atom-length
                                                    :max-coll-size max-coll-size)
                                             (inspect/start value)))]
-    (transport/send transport (inspector-response msg inspector {}))))
+    (inspector-response msg inspector {})))
+
+(defn inspect-reply
+  [msg eval-response]
+  (let [value (cljs/response-value msg eval-response)]
+    (transport/send (:transport msg)
+                    (inspect-reply* msg value))))
 
 (defn inspector-transport
   [{:keys [^Transport transport] :as msg}]

--- a/test/clj/cider/nrepl/middleware/stacktrace_test.clj
+++ b/test/clj/cider/nrepl/middleware/stacktrace_test.clj
@@ -36,7 +36,27 @@
       (testing "returns the exception message"
         (is (= "Don't know how to create ISeq from: java.lang.Long" (:message response))))
       (testing "returns done status"
-        (is (= #{"done"} (:status response)))))))
+        (is (= #{"done"} (:status response)))))
+
+    (testing "`inspect-last-exception` op"
+      (testing "Index 0 for an exception without extra causes"
+        (let [{[^String first-value] :value} (session/message  {:op "inspect-last-exception" :index 0})]
+          (is (.startsWith first-value "(\"Class\" \": \" (:value")
+              "Returns an Inspector response")))
+      (testing "Index out of bounds"
+        (is (nil? (:value (session/message {:op "inspect-last-exception" :index 1})))))
+      (testing "Indices 0, 1, 2 for an exception with one extra cause"
+        (session/message {:op "eval" :code "(deref (future (/ 2 0)))"})
+        (session/message {:op "analyze-last-stacktrace"})
+        (is (seq (:value (session/message  {:op "inspect-last-exception" :index 0}))))
+        (let [{[^String first-value] :value} (session/message  {:op "inspect-last-exception" :index 0})]
+          (is (.startsWith first-value "(\"Class\" \": \" (:value \"java.util.concurrent.ExecutionException")
+              "Returns an Inspector response for index 0"))
+        (let [{[^String first-value] :value} (session/message  {:op "inspect-last-exception" :index 1})]
+          (is (.startsWith first-value "(\"Class\" \": \" (:value \"java.lang.ArithmeticException")
+              "Returns a different Inspector response for index 1"))
+        (is (nil? (:value (session/message {:op "inspect-last-exception" :index 2})))
+            "Doesn't return a value past the last index")))))
 
 (deftest analyze-last-stacktrace-unbound-test
   (testing "stacktrace op with most recent exception unbound"


### PR DESCRIPTION
* Avoid problematic newline in docs
  * See https://docs.cider.mx/cider-nrepl/nrepl-api/ops.html#info
* Introduce `inspect-last-stacktrace-exception` op
  * Part of https://github.com/clojure-emacs/cider/issues/3565
* `lein docs`: Add missing `shutdown-agents` call

Cheers - V