### PR TITLE
Inspector: include `:doc-fragments` for all responses which `:value` is a Class, Field or Method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [cider#3565](https://github.com/clojure-emacs/cider/issues/3565): Add new [`inspect-last-exception`](https://docs.cider.mx/cider-nrepl/nrepl-api/ops.html#inspect-last-exception) op.
+* Inspector: include [`:doc-fragments`](https://docs.cider.mx/cider-nrepl/nrepl-api/ops.html#inspect-push) for all responses which `:value` is a Class, Field or Method.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * [#828](https://github.com/clojure-emacs/cider-nrepl/issues/828): Warmup Orchard caches for exceptions in advance.
   * This noticeably improves the first-time performance of exception-related ops, e.g. `analyze-last-stacktrace`.
+* Bump `orchard` to [0.19.0](https://github.com/clojure-emacs/orchard/blob/v0.19.0/CHANGELOG.md#0190-2023-11-04).
 
 ## 0.42.1 (2023-10-31)
 

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -488,7 +488,11 @@ Optional parameters::
 {blank}
 
 Returns::
+* `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:status` "done"
+* `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
 
 
@@ -506,7 +510,11 @@ Optional parameters::
 {blank}
 
 Returns::
+* `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:status` "done"
+* `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
 
 
@@ -522,7 +530,11 @@ Optional parameters::
 {blank}
 
 Returns::
+* `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:status` "done"
+* `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
 
 
@@ -556,7 +568,11 @@ Optional parameters::
 {blank}
 
 Returns::
+* `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:status` "done"
+* `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
 
 
@@ -573,7 +589,11 @@ Optional parameters::
 {blank}
 
 Returns::
+* `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:status` "done"
+* `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
 
 
@@ -589,7 +609,11 @@ Optional parameters::
 {blank}
 
 Returns::
+* `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:status` "done"
+* `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
 
 
@@ -605,7 +629,11 @@ Optional parameters::
 {blank}
 
 Returns::
+* `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:status` "done"
+* `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
 
 
@@ -622,7 +650,11 @@ Optional parameters::
 {blank}
 
 Returns::
+* `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:status` "done"
+* `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
 
 
@@ -639,7 +671,11 @@ Optional parameters::
 {blank}
 
 Returns::
+* `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:status` "done"
+* `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
 
 
@@ -655,7 +691,11 @@ Optional parameters::
 {blank}
 
 Returns::
+* `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:status` "done"
+* `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
 
 
@@ -672,7 +712,11 @@ Optional parameters::
 {blank}
 
 Returns::
+* `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:status` "done"
+* `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
 
 
@@ -689,7 +733,11 @@ Optional parameters::
 {blank}
 
 Returns::
+* `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:status` "done"
+* `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
 
 
@@ -706,7 +754,11 @@ Optional parameters::
 {blank}
 
 Returns::
+* `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:status` "done"
+* `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
 
 
@@ -722,7 +774,11 @@ Optional parameters::
 {blank}
 
 Returns::
+* `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:status` "done"
+* `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
 
 

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/clojure-emacs/cider-nrepl"}
   :dependencies [[nrepl "1.0.0"]
-                 [cider/orchard "0.18.0"]
+                 [cider/orchard "0.19.0"]
                  ^:inline-dep [mx.cider/haystack "0.3.1" :exclusions [cider/orchard]]
                  ^:inline-dep [thunknyc/profile "0.5.2"]
                  ^:inline-dep [mvxcvi/puget "1.3.4"]

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -267,6 +267,10 @@ making the results more accurate (and less numerous)."
                           "ns" "The current namespace"}
                :returns {"status" "done"}}}}))
 
+(def inspector-returns (merge {"status" "\"done\""
+                               "value" "The inspector result. Contains a specially-formatted string that can be `read` and then rendered client-side."}
+                              fragments-doc))
+
 (def-wrapper wrap-inspect cider.nrepl.middleware.inspect/handle-inspect
   #{"eval"}
   (cljs/expects-piggieback
@@ -279,67 +283,67 @@ making the results more accurate (and less numerous)."
     :handles {"inspect-pop"
               {:doc "Moves one level up in the inspector stack."
                :requires {"session" "The current session"}
-               :returns {"status" "\"done\""}}
+               :returns inspector-returns}
               "inspect-push"
               {:doc "Inspects the inside value specified by index."
                :requires {"idx" "Index of the internal value currently rendered."
                           "session" "The current session"}
-               :returns {"status" "\"done\""}}
+               :returns inspector-returns}
               "inspect-next-sibling"
               {:doc "Increment the index of the last 'nth in the path by 1,
 if applicable, and re-render the updated value."
                :requires {"session" "The current session"}
-               :returns {"status" "\"done\""}}
+               :returns inspector-returns}
               "inspect-previous-sibling"
               {:doc "Decrement the index of the last 'nth in the path by 1,
 if applicable, and re-render the updated value."
                :requires {"session" "The current session"}
-               :returns {"status" "\"done\""}}
+               :returns inspector-returns}
               "inspect-refresh"
               {:doc "Re-renders the currently inspected value."
                :requires {"session" "The current session"}
-               :returns {"status" "\"done\""}}
+               :returns inspector-returns}
               "inspect-get-path"
               {:doc "Returns the path to the current position in the inspected value."
                :requires {"session" "The current session"}
-               :returns {"status" "\"done\""}}
+               :returns inspector-returns}
               "inspect-next-page"
               {:doc "Jumps to the next page in paginated collection view."
                :requires {"session" "The current session"}
-               :returns {"status" "\"done\""}}
+               :returns inspector-returns}
               "inspect-prev-page"
               {:doc "Jumps to the previous page in paginated collection view."
                :requires {"session" "The current session"}
-               :returns {"status" "\"done\""}}
+               :returns inspector-returns}
               "inspect-set-page-size"
               {:doc "Sets the page size in paginated view to specified value."
                :requires {"page-size" "New page size."
                           "session" "The current session"}
-               :returns {"status" "\"done\""}}
+               :returns inspector-returns}
               "inspect-set-max-atom-length"
               {:doc "Set the max length of nested atoms to specified value."
                :requires {"max-atom-length" "New max length."
                           "session" "The current session"}
-               :returns {"status" "\"done\""}}
+               :returns inspector-returns}
               "inspect-set-max-coll-size"
               {:doc "Set the number of nested collection members to display before truncating."
                :requires {"max-coll-size" "New collection size."
                           "session" "The current session"}
-               :returns {"status" "\"done\""}}
+               :returns inspector-returns}
               "inspect-clear"
               {:doc "Clears the state state of the inspector."
                :requires {"session" "The current session"}
-               :returns {"status" "\"done\""}}
+               :returns inspector-returns}
               "inspect-def-current-value"
               {:doc "Define the currently inspected value as a var with the given var-name in the provided namespace."
                :requires {"session" "The current session"
                           "ns" "Namespace to define var on"
                           "var-name" "The var name"}
-               :returns {"status" "\"done\""}}
+               :returns inspector-returns}
               "inspect-tap-current-value"
               {:doc "Send the currently inspected value to the Clojure tap>."
                :requires {"session" "The current session"}
-               :returns {"status" "\"done\""}}}}))
+               :returns inspector-returns}}}))
 
 (def-wrapper wrap-log cider.nrepl.middleware.log/handle-log
   {:doc "Middleware that captures log events and makes them inspect-able."

--- a/test/clj/cider/nrepl/middleware/inspect_test.clj
+++ b/test/clj/cider/nrepl/middleware/inspect_test.clj
@@ -4,7 +4,8 @@
    [cider.nrepl.test-session :as session]
    [clojure.edn :as edn]
    [clojure.string :as string]
-   [clojure.test :refer :all]))
+   [clojure.test :refer :all]
+   [orchard.info :as info]))
 
 (def inspect-tap-current-value-test-atom (atom nil))
 
@@ -540,3 +541,28 @@
           (recur (inc i)))))
 
     (is (= 7 @inspect-tap-current-value-test-atom))))
+
+(deftest doc-fragments-test
+  (when (contains? (info/info 'user `Thread/sleep)
+                   :doc-fragments) ;; this test is only runnable with enrich-classpath active
+    (testing "Responses for classes, methods and fields contain `:doc-fragments` attributes"
+      (doseq [code ["java.lang.Thread"
+                    "(-> java.lang.Thread .getMethods first)"
+                    "(-> java.lang.Thread .getFields first)"]]
+        (let [response (session/message {:op      "eval"
+                                         :inspect "true"
+                                         :code    code})]
+          (is (contains? response :doc-fragments))
+          (is (contains? response :doc-first-sentence-fragments))
+          (is (contains? response :doc-block-tags-fragments))))))
+
+  (testing "Responses for other objects do not contain `:doc-fragments` attributes"
+    (doseq [code ["1"
+                  "{}"
+                  "true"]]
+      (let [response (session/message {:op      "eval"
+                                       :inspect "true"
+                                       :code    code})]
+        (is (not (contains? response :doc-fragments)))
+        (is (not (contains? response :doc-first-sentence-fragments)))
+        (is (not (contains? response :doc-block-tags-fragments)))))))


### PR DESCRIPTION
> Closes https://github.com/clojure-emacs/orchard/issues/207

I was on the fence about doing this in cider-nrepl (vs. in Orchard). Finally cider-nrepl seemed a better choice, so that `orchard.inspect` can keep doing one thing only.

In the end, the :doc-fragments stuff is dramatically different (schema-wise) from the Inspector `:value` stuff, so putting it all under the same map in Orchard might be confusing.

Cheers - V