### PR TITLE
Warmup the Orchard cache for project `:import`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Changes
 
+* [#830](https://github.com/clojure-emacs/cider-nrepl/issues/830): Warmup Orchard caches for Java imported classes in advance.
+  * Speculatively improves performance for the classes that users are more likely to use in a given project.
 * [#828](https://github.com/clojure-emacs/cider-nrepl/issues/828): Warmup Orchard caches for exceptions in advance.
   * This noticeably improves the first-time performance of exception-related ops, e.g. `analyze-last-stacktrace`.
 * Bump `orchard` to [0.19.0](https://github.com/clojure-emacs/orchard/blob/v0.19.0/CHANGELOG.md#0190-2023-11-04).

--- a/test/clj/cider/nrepl_test.clj
+++ b/test/clj/cider/nrepl_test.clj
@@ -1,0 +1,10 @@
+(ns cider.nrepl-test
+  (:require
+   [cider.nrepl :as sut]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest warmup-orchard-caches!
+  @sut/initializer ;; Prevent concurrent calls to `sut/warmup-orchard-caches!`
+  (testing "Can be executed without throwing exceptions"
+    (is (pos? (sut/warmup-orchard-caches!))
+        "Returns the keys count of the affected cache")))


### PR DESCRIPTION
* middleware.inspect: optimize `future` usage
* Warmup the Orchard cache for project `:import`s
  * Speculatively improves completion/info performance for the classes that users are more likely to use in a given project.