### PR TITLE
Fix `"inspect-refresh"` op

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -7,7 +7,9 @@
                                              (cider.nrepl.middleware.util.instrument/with-break)
                                              (cider.nrepl.middleware.util.instrument/instrument-special-form)
                                              (cider.nrepl.middleware.util.instrument/instrument-coll)
-                                             (cider.nrepl.print-method/def-print-method)]}
+                                             (cider.nrepl.print-method/def-print-method)
+                                             (cljs.test/is [match? thrown-match?])
+                                             (clojure.test/is [match? thrown-match?])]}
            :unused-import         {:level :off}
            :unresolved-var        {:level :off}
            :unused-binding        {:level :off}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Bump `suitable` to [0.6.0](https://github.com/clojure-emacs/clj-suitable/blob/v0.6.0/CHANGELOG.md#060-2023-11-05).
 
+## Bugs fixed
+
+* Make `"inspect-refresh"` op work again.
+
 ## 0.43.0 (2023-11-04)
 
 ### New features

--- a/project.clj
+++ b/project.clj
@@ -123,7 +123,8 @@
                                    [leiningen-core "2.9.10" :exclusions [org.clojure/clojure
                                                                          commons-codec
                                                                          com.google.code.findbugs/jsr305]]
-                                   [cider/piggieback "0.5.3"]]}
+                                   [cider/piggieback "0.5.3"]
+                                   [nubank/matcher-combinators "3.8.8"]]}
 
              ;; Running the tests with enrich-classpath doing its thing isn't compatible with `lein test`
              ;; (because there's no such thing as "run `lein test` using this specific classpath"),

--- a/src/cider/nrepl/middleware/inspect.clj
+++ b/src/cider/nrepl/middleware/inspect.clj
@@ -115,7 +115,9 @@
   (inspector-response msg (swap-inspector! msg inspect/previous-sibling)))
 
 (defn refresh-reply [msg]
-  (inspector-response msg (swap-inspector! msg #(or % (inspect/fresh)))))
+  (inspector-response msg (swap-inspector! msg #(or (some-> %
+                                                            inspect/inspect-render)
+                                                    (inspect/fresh)))))
 
 (defn get-path-reply [{:keys [session]}]
   (get-in (meta session) [::inspector :path]))

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -90,8 +90,10 @@
                                        :matcher-combinators.clj-test/mismatch)
         print-fn (if matcher-combinators-result?
                    println
-                   pp/pprint)]
-    (with-out-str (print-fn object))))
+                   pp/pprint)
+        result (with-out-str (print-fn object))]
+    ;; Replace extra newlines at the end, as sometimes returned by matchers-combinators:
+    (str/replace result #"\n\n+$" "\n")))
 
 (def ^:dynamic *test-error-handler*
   "A function you can override via `binding`, or safely via `alter-var-root`.

--- a/test/clj/cider/nrepl/middleware/test_test.clj
+++ b/test/clj/cider/nrepl/middleware/test_test.clj
@@ -1,13 +1,15 @@
 (ns cider.nrepl.middleware.test-test
   (:require
    [cider.nrepl.middleware.test :as test]
-   ;; Ensure tested tests are loaded:
-   cider.nrepl.middleware.test-filter-tests
    [cider.nrepl.test-session :as session]
    [clojure.string :as string]
-   [clojure.test :refer :all])
+   [clojure.test :refer :all]
+   [matcher-combinators.clj-test])
   (:import
    (clojure.lang ExceptionInfo)))
+
+;; Ensure tested tests are loaded:
+(require 'cider.nrepl.middleware.test-filter-tests)
 
 (use-fixtures :each session/session-fixture)
 
@@ -261,7 +263,9 @@ The `988` value reflects that it times things correctly for a slow test.")
 (deftest print-object-test
   (testing "uses println for matcher-combinators results, otherwise invokes pprint"
     (is (= "{no quotes}\n"
-           (#'test/print-object (with-meta {"no" "quotes"} {:type :matcher-combinators.clj-test/mismatch})))
+           (#'test/print-object (matcher-combinators.clj-test/tagged-for-pretty-printing
+                                 '(not (match? 1 2))
+                                 {:matcher-combinators.result/value {"no" "quotes"}})))
         "println is chosen, as indicated by strings printed without quotes")
     (is (= "{:a\n (\"a-sufficiently-long-string\"\n  \"a-sufficiently-long-string\"\n  \"a-sufficiently-long-string\")}\n"
            (#'test/print-object {:a (repeat 3 "a-sufficiently-long-string")}))


### PR DESCRIPTION
It broke at some point, possibly long ago, as it was showing the same inspector instead of a refreshed one.

Cheers - V