### PR TITLE
Update usage.adoc: Use clj -M to avoid warnings

### DIFF
--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -95,7 +95,7 @@ You can easily boot an nREPL server with the CIDER middleware loaded
 with the following "magic" incantation:
 
 ----
-clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.44.0"} }}' -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
+clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.44.0"} }}' -M -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
 ----
 
 There are also two convenient aliases you can employ:
@@ -119,7 +119,7 @@ There are also two convenient aliases you can employ:
 Which then allow you to simply run:
 
 ----
-clj -A:cider-clj
+clj -M:cider-clj
 ----
 
 == Via embedding nREPL in your application


### PR DESCRIPTION
Use -M to avoid warnings

WARNING: Use of :main-opts with -A is deprecated. Use -M instead.
WARNING: Implicit use of clojure.main with options is deprecated, use -M

Before submitting a PR make sure the following things have been done:

- [*] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [*] You've added tests to cover your change(s)
- [*] All tests are passing
- [*] You've updated the README
- [*] Middleware documentation is up to date
  * Please check out and modify the `cider.nrepl` ns which has all middleware documentation.
  * Run `lein docs` afterwards, and commit the results.

**Note:** If you're just starting out to hack on `cider-nrepl` you might find
[nREPL's documentation](https://nrepl.org) and the
"Design" section of the README extremely useful.*

Thanks!
