### PR TITLE
Restore 1.9 compat, drop 1.8 compat

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
         type: steps
     executor: openjdk11
     environment:
-      VERSION: "1.10"
+      CLOJURE_VERSION: "1.10"
     steps:
       - checkout
       - with_cache:
@@ -156,7 +156,7 @@ jobs:
         type: string
     executor: << parameters.jdk_version >>
     environment:
-      VERSION: << parameters.clojure_version >>
+      CLOJURE_VERSION: << parameters.clojure_version >>
       PROJECT_VERSION: 999.99.9
     steps:
       - checkout
@@ -190,21 +190,13 @@ jobs:
 #
 # - run tests against the target matrix
 #   - Java 8/11/16/...
-#   - Clojure 1.8, 1.9, 1.10, master
+#   - Clojure 1.9, 1.10, 1.11, master
 # - linter, eastwood and cljfmt
 
 matrix_excludes: &matrix_excludes
   exclude:
     - jdk_version: openjdk8
       parser_target: "parser-next"
-      clojure_version: "1.8"
-      test_command: "test"
-    - jdk_version: openjdk8
-      parser_target: "parser"
-      clojure_version: "1.8"
-      test_command: "test"
-    - jdk_version: openjdk8
-      parser_target: "parser-next"
       clojure_version: "1.9"
       test_command: "test"
     - jdk_version: openjdk8
@@ -235,14 +227,6 @@ matrix_excludes: &matrix_excludes
       parser_target: "parser"
       clojure_version: "master"
       test_command: "test"
-    - jdk_version: openjdk8
-      parser_target: "parser-next"
-      clojure_version: "1.8"
-      test_command: "smoketest"
-    - jdk_version: openjdk8
-      parser_target: "parser"
-      clojure_version: "1.8"
-      test_command: "smoketest"
     - jdk_version: openjdk8
       parser_target: "parser-next"
       clojure_version: "1.9"
@@ -284,7 +268,7 @@ workflows:
           matrix:
             alias: "plaintest_code"
             parameters:
-              clojure_version: ["1.8", "1.9", "1.10", "1.11", "master"]
+              clojure_version: ["1.9", "1.10", "1.11", "master"]
               jdk_version: [openjdk8, openjdk11, openjdk16, openjdk17]
               parser_target: ["parser-next", "parser", "legacy-parser"]
               test_command: ["test"]
@@ -300,7 +284,7 @@ workflows:
           matrix:
             alias: "smoketest_code"
             parameters:
-              clojure_version: ["1.8", "1.9", "1.10", "1.11", "master"]
+              clojure_version: ["1.9", "1.10", "1.11", "master"]
               jdk_version: [openjdk8, openjdk11, openjdk16, openjdk17]
               parser_target: ["parser-next", "parser", "legacy-parser"]
               test_command: ["smoketest"]

--- a/doc/modules/ROOT/pages/compatibility.adoc
+++ b/doc/modules/ROOT/pages/compatibility.adoc
@@ -9,7 +9,7 @@ by Oracle.
 
 == Clojure
 
-`cider-nrepl` targets Clojure 1.8+. As Clojure doesn't have the concept of supported releases
+`cider-nrepl` targets Clojure 1.9+. As Clojure doesn't have the concept of supported releases
 we have to get a bit creative to determine the minimum version to target.
 
 The minimum required Clojure version is currently derived using data
@@ -79,6 +79,11 @@ requirements were bumped to nREPL 0.6 in recent versions.
 | 8
 | 1.8
 | 0.6
+
+| 0.45.0
+| 8
+| 1.9
+| 1.0.0
 
 |===
 

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -2,7 +2,7 @@
 
 == Prerequisites
 
-`cider-nrepl` supports only Clojure(Script) 1.8+ and Java 8+.
+`cider-nrepl` supports only Clojure(Script) 1.9+ and Java 8+.
 
 Leiningen users will need to have version 2.8.3 or newer installed.
 Boot users will need to have version 2.8.2 or newer installed.

--- a/project.clj
+++ b/project.clj
@@ -85,15 +85,10 @@
                                        [com.google.errorprone/error_prone_annotations "2.11.0"]
                                        [com.google.code.findbugs/jsr305 "3.0.2"]]
                         :test-paths ["test/spec"]}
-
-             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]
-                                  [org.clojure/clojurescript "1.10.520" :scope "provided"]
-                                  [javax.xml.bind/jaxb-api "2.3.1" :scope "provided"]]}
-             :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]
-                                  [org.clojure/clojurescript "1.10.520" :scope "provided"]
-                                  [javax.xml.bind/jaxb-api "2.3.1" :scope "provided"]]
-                   ;; TODO: Merge the tests in this dir in to test/clj once we
-                   ;; drop support for Clojure 1.8
+             :1.9 {:dependencies [[commons-logging/commons-logging "1.3.0"]
+                                  [org.clojure/clojure "1.9.0"]
+                                  [org.clojure/clojurescript "1.10.520" :scope "provided"]]
+                   ;; TODO: Merge the tests in this dir in to test/clj
                    :test-paths ["test/spec"]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]
                                    [org.clojure/clojurescript "1.10.520" :scope "provided"]]

--- a/src/cider/nrepl/middleware/stacktrace.clj
+++ b/src/cider/nrepl/middleware/stacktrace.clj
@@ -81,7 +81,7 @@
                     cause
                     (when cause
                       (recur (inc n)
-                             (ex-cause cause))))))]
+                             (some-> ^Throwable cause .getCause))))))]
     (if cause
       (t/send transport (middleware.inspect/inspect-reply* msg cause))
       (no-error msg))

--- a/src/cider_nrepl/plugin.clj
+++ b/src/cider_nrepl/plugin.clj
@@ -7,7 +7,7 @@
    [leiningen.core.main :as lein]))
 
 (def minimum-versions {:lein    "2.8.3"
-                       :clojure "1.8.0"})
+                       :clojure "1.9.0"})
 
 (defn valid-version? [kind version] (lein/version-satisfies? version (minimum-versions kind)))
 (def valid-lein-version? (partial valid-version? :lein))
@@ -46,9 +46,9 @@
     (when-not lein-version-ok?
       (lein/warn "Warning: cider-nrepl requires Leiningen 2.8.3 or greater."))
     (when-not clojure-version-ok?
-      (lein/warn "Warning: cider-nrepl requires Clojure 1.8 or greater."))
+      (lein/warn "Warning: cider-nrepl requires Clojure 1.9 or greater."))
     (when clojure-excluded?
-      (lein/warn "Warning: Clojure is excluded, assuming an appropriate fork (Clojure 1.8 or later) is provided."))
+      (lein/warn "Warning: Clojure is excluded, assuming an appropriate fork (Clojure 1.9 or later) is provided."))
     (when-not (and lein-version-ok? clojure-version-ok?)
       (lein/warn "Warning: cider-nrepl will not be included in your project."))
 

--- a/test/common/cider_nrepl/plugin_test.clj
+++ b/test/common/cider_nrepl/plugin_test.clj
@@ -17,7 +17,7 @@
   (binding [lein/*info* false]
     (with-redefs [lein/leiningen-version (constantly (plugin/minimum-versions :lein))]
       (testing "Valid Lein version; valid Clojure version"
-        (let [project (plugin/middleware '{:dependencies [[org.clojure/clojure "1.8.0"]]})]
+        (let [project (plugin/middleware '{:dependencies [[org.clojure/clojure "1.9.0"]]})]
           (is (contains-cider-nrepl-dep? project))
           (is (contains-cider-nrepl-middleware? project))))
 
@@ -39,7 +39,7 @@
 
     (with-redefs [lein/leiningen-version (constantly "2.5.1")]
       (testing "Invalid Lein version; valid Clojure version"
-        (let [project (plugin/middleware '{:dependencies [[org.clojure/clojure "1.8.0"]]})]
+        (let [project (plugin/middleware '{:dependencies [[org.clojure/clojure "1.9.0"]]})]
           (is (not (contains-cider-nrepl-dep? project)))
           (is (not (contains-cider-nrepl-middleware? project)))))
 

--- a/test/smoketest/project.clj
+++ b/test/smoketest/project.clj
@@ -2,9 +2,7 @@
   :dependencies [[nrepl "1.0.0"]
                  [cider/cider-nrepl "RELEASE"]]
   :exclusions [org.clojure/clojure]
-  :profiles {:1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
-             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
-             :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
+  :profiles {:1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.1"]]}
              :1.11 {:dependencies [[org.clojure/clojure "1.11.1"]]}
              :master {:repositories [["snapshots" "https://oss.sonatype.org/content/repositories/snapshots"]]


### PR DESCRIPTION
> Closes https://github.com/clojure-emacs/cider-nrepl/issues/836

1.8 compat, while it was intended to be, was broken for a possibly very long time.

The reason being, the CI matrix as introduced in 1016f61754c5bcf58ed745a88620381f4afc749d was broken: CircleCI set `VERSION`, while the Makefile expected `CLOJURE_VERSION`.

So, surely, progressively factual support degraded.

This commits fixes 1.9 compatibility and ensures that the CI matrix runs as intended.

I deem 1.8 not worth fixing, given that:

* it was broken already;
* nobody complained;
* we planned to drop it; and most importantly
* it was hard to restore, since it would mean running an older Leiningen (Lein has used 1.9+ features for over 5 years, which means that the CCI images would have to be replaced with something else)
  * In particular, I was hitting `Unable to resolve var: *print-namespace-maps* in this context, compiling:(leiningen/core/main.clj:342:5)` while running the `cider-nrepl.plugin-test`.