### PR TITLE
[ci] Refactor CI wrt JDK8 and Clojure 1.9 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ workflows:
     jobs:
       - test_code:
           matrix:
-            alias: "plaintest_code_jdk8"
+            alias: "test_code_jdk8"
             parameters:
               # Clojure 1.9 is tested only against JDK8.
               clojure_version: ["1.9", "1.10", "1.11", "master"]
@@ -207,7 +207,7 @@ workflows:
               # It doesn't make sense to exercise the newer Orchard Java parsers against JDK8
               # (given that JDK8 is explicitly excluded by those parsers)
               parser_target: ["legacy-parser"]
-              test_command: ["test"]
+              test_command: ["test", "smoketest"]
           filters:
             branches:
               only: /.*/
@@ -215,41 +215,12 @@ workflows:
               only: /^v\d+\.\d+\.\d+(-alpha\d*)?(-beta\d*)?$/
       - test_code:
           matrix:
-            alias: "plaintest_code"
+            alias: "test_code"
             parameters:
               clojure_version: ["1.10", "1.11", "master"]
               jdk_version: [openjdk11, openjdk16, openjdk17]
               parser_target: ["parser-next", "parser", "legacy-parser"]
-              test_command: ["test"]
-          filters:
-            branches:
-              only: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+(-alpha\d*)?(-beta\d*)?$/
-      - test_code:
-          matrix:
-            alias: "smoketest_code_jdk8"
-            parameters:
-              # Clojure 1.9 is tested only against JDK8.
-              clojure_version: ["1.9", "1.10", "1.11", "master"]
-              jdk_version: [openjdk8]
-              # It doesn't make sense to exercise the newer Orchard Java parsers against JDK8
-              # (given that JDK8 is explicitly excluded by those parsers)
-              parser_target: ["legacy-parser"]
-              test_command: ["smoketest"]
-          filters:
-            branches:
-              only: /.*/
-            tags:
-              only: /^v\d+\.\d+\.\d+(-alpha\d*)?(-beta\d*)?$/
-      - test_code:
-          matrix:
-            alias: "smoketest_code"
-            parameters:
-              clojure_version: ["1.10", "1.11", "master"]
-              jdk_version: [openjdk11, openjdk16, openjdk17]
-              parser_target: ["parser-next", "parser", "legacy-parser"]
-              test_command: ["smoketest"]
+              test_command: ["test", "smoketest"]
           filters:
             branches:
               only: /.*/
@@ -278,10 +249,8 @@ workflows:
                   make eastwood
       - deploy:
           requires:
-            - "plaintest_code"
-            - "smoketest_code"
-            - "plaintest_code_jdk8"
-            - "smoketest_code_jdk8"
+            - "test_code"
+            - "test_code_jdk8"
             - "Code Linting"
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,88 +193,50 @@ jobs:
 #   - Clojure 1.9, 1.10, 1.11, master
 # - linter, eastwood and cljfmt
 
-matrix_excludes: &matrix_excludes
-  exclude:
-    - jdk_version: openjdk8
-      parser_target: "parser-next"
-      clojure_version: "1.9"
-      test_command: "test"
-    - jdk_version: openjdk8
-      parser_target: "parser"
-      clojure_version: "1.9"
-      test_command: "test"
-    - jdk_version: openjdk8
-      parser_target: "parser-next"
-      clojure_version: "1.10"
-      test_command: "test"
-    - jdk_version: openjdk8
-      parser_target: "parser"
-      clojure_version: "1.10"
-      test_command: "test"
-    - jdk_version: openjdk8
-      parser_target: "parser-next"
-      clojure_version: "1.11"
-      test_command: "test"
-    - jdk_version: openjdk8
-      parser_target: "parser"
-      clojure_version: "1.11"
-      test_command: "test"
-    - jdk_version: openjdk8
-      parser_target: "parser-next"
-      clojure_version: "master"
-      test_command: "test"
-    - jdk_version: openjdk8
-      parser_target: "parser"
-      clojure_version: "master"
-      test_command: "test"
-    - jdk_version: openjdk8
-      parser_target: "parser-next"
-      clojure_version: "1.9"
-      test_command: "smoketest"
-    - jdk_version: openjdk8
-      parser_target: "parser"
-      clojure_version: "1.9"
-      test_command: "smoketest"
-    - jdk_version: openjdk8
-      parser_target: "parser-next"
-      clojure_version: "1.10"
-      test_command: "smoketest"
-    - jdk_version: openjdk8
-      parser_target: "parser"
-      clojure_version: "1.10"
-      test_command: "smoketest"
-    - jdk_version: openjdk8
-      parser_target: "parser-next"
-      clojure_version: "1.11"
-      test_command: "smoketest"
-    - jdk_version: openjdk8
-      parser_target: "parser"
-      clojure_version: "1.11"
-      test_command: "smoketest"
-    - jdk_version: openjdk8
-      parser_target: "parser-next"
-      clojure_version: "master"
-      test_command: "smoketest"
-    - jdk_version: openjdk8
-      parser_target: "parser"
-      clojure_version: "master"
-      test_command: "smoketest"
-
 workflows:
   version: 2.1
   ci-test-matrix:
     jobs:
       - test_code:
           matrix:
+            alias: "plaintest_code_jdk8"
+            parameters:
+              # Clojure 1.9 is tested only against JDK8.
+              clojure_version: ["1.9", "1.10", "1.11", "master"]
+              jdk_version: [openjdk8]
+              # It doesn't make sense to exercise the newer Orchard Java parsers against JDK8
+              # (given that JDK8 is explicitly excluded by those parsers)
+              parser_target: ["legacy-parser"]
+              test_command: ["test"]
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /^v\d+\.\d+\.\d+(-alpha\d*)?(-beta\d*)?$/
+      - test_code:
+          matrix:
             alias: "plaintest_code"
             parameters:
-              clojure_version: ["1.9", "1.10", "1.11", "master"]
-              jdk_version: [openjdk8, openjdk11, openjdk16, openjdk17]
+              clojure_version: ["1.10", "1.11", "master"]
+              jdk_version: [openjdk11, openjdk16, openjdk17]
               parser_target: ["parser-next", "parser", "legacy-parser"]
               test_command: ["test"]
-            # It doesn't make sense to exercise the newer Orchard Java parsers against JDK8
-            # (given that JDK8 is explicitly excluded by those parsers), so we exclude those combinations from the CI matrix:
-            <<: *matrix_excludes
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /^v\d+\.\d+\.\d+(-alpha\d*)?(-beta\d*)?$/
+      - test_code:
+          matrix:
+            alias: "smoketest_code_jdk8"
+            parameters:
+              # Clojure 1.9 is tested only against JDK8.
+              clojure_version: ["1.9", "1.10", "1.11", "master"]
+              jdk_version: [openjdk8]
+              # It doesn't make sense to exercise the newer Orchard Java parsers against JDK8
+              # (given that JDK8 is explicitly excluded by those parsers)
+              parser_target: ["legacy-parser"]
+              test_command: ["smoketest"]
           filters:
             branches:
               only: /.*/
@@ -284,13 +246,10 @@ workflows:
           matrix:
             alias: "smoketest_code"
             parameters:
-              clojure_version: ["1.9", "1.10", "1.11", "master"]
-              jdk_version: [openjdk8, openjdk11, openjdk16, openjdk17]
+              clojure_version: ["1.10", "1.11", "master"]
+              jdk_version: [openjdk11, openjdk16, openjdk17]
               parser_target: ["parser-next", "parser", "legacy-parser"]
               test_command: ["smoketest"]
-            # It doesn't make sense to exercise the newer Orchard Java parsers against JDK8
-            # (given that JDK8 is explicitly excluded by those parsers), so we exclude those combinations from the CI matrix:
-            <<: *matrix_excludes
           filters:
             branches:
               only: /.*/
@@ -321,6 +280,8 @@ workflows:
           requires:
             - "plaintest_code"
             - "smoketest_code"
+            - "plaintest_code_jdk8"
+            - "smoketest_code_jdk8"
             - "Code Linting"
           filters:
             branches:


### PR DESCRIPTION
Similar to https://github.com/nrepl/nrepl/pull/305

1. Replaced exclusions with more precise matrix sets. 
2. Removed clj 1.9 together with JDK higher than 8. The motivation for it is that Clojure 1.10 contains important fixes for compatibility with Java9+ (see https://github.com/clojure/clojure/blob/master/changes.md#11-java). Anyone who cares enough about using newer JDKs must eventually upgrade Clojure as well.