### PR TITLE
Bump `suitable` to 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Bump `orchard` to [0.22.0](https://github.com/clojure-emacs/orchard/blob/v0.22.0/CHANGELOG.md#0220-2024-01-14).
 * Bump `logjam` to [0.2.0](https://github.com/clojure-emacs/logjam/blob/v0.2.0/CHANGELOG.md#020-2024-01-04).
+* Bump `suitable` to [0.6.2](https://github.com/clojure-emacs/clj-suitable/blob/v0.6.2/CHANGELOG.md#062-2033-01-14).
 * [#842](https://github.com/clojure-emacs/cider-nrepl/issues/842): Initial cache warmup: ensure that no classes' static initializers are run.
 * Forcibly exit the JVM on older (unsupported) Clojure versions.
   * This can help users and maintainers alike diagnose issues more quickly, avoiding problematic code paths in our middleware, and clients like cider.el.

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  ^:inline-dep [mvxcvi/puget "1.3.4"]
                  ^:inline-dep [fipp ~fipp-version] ; can be removed in unresolved-tree mode
                  ^:inline-dep [compliment "0.4.4"]
-                 ^:inline-dep [org.rksm/suitable "0.6.1" :exclusions [org.clojure/clojurescript]]
+                 ^:inline-dep [org.rksm/suitable "0.6.2" :exclusions [org.clojure/clojurescript]]
                  ^:inline-dep [cljfmt "0.9.2" :exclusions [org.clojure/clojurescript]]
                  ~(with-meta '[org.clojure/tools.namespace "1.3.0"]
                     ;; :cognitest uses tools.namespace, so we cannot inline it while running tests.


### PR DESCRIPTION
https://github.com/clojure-emacs/clj-suitable/blob/v0.6.2/CHANGELOG.md#062-2033-01-14