### PR TITLE
Fix the debugger in case of a local shadows a var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+## Bugs fixed
+
+*  [#846](https://github.com/clojure-emacs/cider-nrepl/issues/846): `middleware.debug`: use `resolve` with `&env` to fix debugging in case of a local shadows a var.
+
 ## 0.45.0 (2024-01-14)
 
 ## Changes

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -447,7 +447,9 @@ this map (identified by a key), and will `dissoc` it afterwards."}
 
 (defn looks-step-innable?
   "Decide whether a form looks like a call to a function that we could
-  instrument and step into."
+  instrument and step into.
+  You should prefer the second arity with the `&env` argument
+  to handle a local shadowing correctly."
   ([form]
    (looks-step-innable? nil form))
   ([&env form]

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -448,16 +448,18 @@ this map (identified by a key), and will `dissoc` it afterwards."}
 (defn looks-step-innable?
   "Decide whether a form looks like a call to a function that we could
   instrument and step into."
-  [form]
-  (when (and (seq? form) (symbol? (first form)))
-    (let [v (resolve (first form)) ; Note: special forms resolve to nil
-          m (meta v)]
-      ;; We do not go so far as to actually try to read the code of the function
-      ;; at this point, which is at macroexpansion time.
-      (and v
-           (safe-to-debug? (:ns m))
-           (not (:macro m))
-           (not (:inline m))))))
+  ([form]
+   (looks-step-innable? nil form))
+  ([&env form]
+   (when (and (seq? form) (symbol? (first form)))
+     (let [v (resolve &env (first form)) ; Note: special forms resolve to nil
+           m (meta v)]
+       ;; We do not go so far as to actually try to read the code of the function
+       ;; at this point, which is at macroexpansion time.
+       (and v
+            (safe-to-debug? (:ns m))
+            (not (:macro m))
+            (not (:inline m)))))))
 
 ;;;  ## Breakpoint logic
 
@@ -547,7 +549,7 @@ this map (identified by a key), and will `dissoc` it afterwards."}
 (defmacro expand-break
   "Internal macro to avoid code repetition in `breakpoint-if-interesting`."
   [form {:keys [coor]} original-form]
-  (let [val-form (if (looks-step-innable? form)
+  (let [val-form (if (looks-step-innable? &env form)
                    (let [[fn-sym & args] form]
                      `(apply-instrumented-maybe (var ~fn-sym) [~@args] ~coor ~'STATE__))
                    form)

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -572,9 +572,8 @@ this map (identified by a key), and will `dissoc` it afterwards."}
   `irrelevant-return-value-forms`."
   [&env form]
   (or (and (symbol? form)
-           (not (contains? &env form))
            (try
-             (-> (resolve form) meta :ns
+             (-> (resolve &env form) meta :ns
                  ns-name #{'clojure.core 'schema.core})
              (catch Exception _ nil)))
       (and (seq? form)


### PR DESCRIPTION
Fixes #846

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] You've updated the README
- [x] Middleware documentation is up to date
  * Please check out and modify the `cider.nrepl` ns which has all middleware documentation.
  * Run `lein docs` afterwards, and commit the results.

**Note:** If you're just starting out to hack on `cider-nrepl` you might find
[nREPL's documentation](https://nrepl.org) and the
"Design" section of the README extremely useful.*

Thanks!

***

1. `resolve` have an extra arity for `&env`
2. I added arity for `looks-step-innable?` for backwards compatibility

```clojure
(defn ns-resolve
  "Returns the var or Class to which a symbol will be resolved in the
  namespace (unless found in the environment), else nil.  Note that
  if the symbol is fully qualified, the var/Class to which it resolves
  need not be present in the namespace."
  {:added "1.0"
   :static true}
  ([ns sym]
    (ns-resolve ns nil sym))
  ([ns env sym]
    (when-not (contains? env sym)
      (clojure.lang.Compiler/maybeResolveIn (the-ns ns) sym))))

(defn resolve
  "same as (ns-resolve *ns* symbol) or (ns-resolve *ns* &env symbol)"
  {:added "1.0"
   :static true}
  ([sym] (ns-resolve *ns* sym))
  ([env sym] (ns-resolve *ns* env sym)))
```
