### PR TITLE
`cider.nrepl.middleware.reload`: support `:before` / `:after` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 
 ## Bugs fixed
 
-* [#854](https://github.com/clojure-emacs/cider-nrepl/pull/854): fix cider.clj-reload/reload-all and improve its test
+* [#854](https://github.com/clojure-emacs/cider-nrepl/pull/854): Fix `cider.nrepl.middleware.reload/reload-all`.
+* `cider.nrepl.middleware.reload`: support `:before` / `:after` functions.
 
 ## 0.46.0 (2024-0305)
 

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -1796,7 +1796,9 @@ Required parameters::
 {blank}
 
 Optional parameters::
-{blank}
+* `:after` The namespace-qualified name of a zero-arity function to call after reloading.
+* `:before` The namespace-qualified name of a zero-arity function to call before reloading.
+
 
 Returns::
 * `:error` A sequence of all causes of the thrown exception when ``status`` is ``:error``.
@@ -1813,7 +1815,9 @@ Required parameters::
 {blank}
 
 Optional parameters::
-{blank}
+* `:after` The namespace-qualified name of a zero-arity function to call after reloading.
+* `:before` The namespace-qualified name of a zero-arity function to call before reloading.
+
 
 Returns::
 * `:error` A sequence of all causes of the thrown exception when ``status`` is ``:error``.

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -609,15 +609,18 @@ if applicable, and re-render the updated value."
                                     :requires {}
                                     :returns  {"status" "Done"}}}})
 
+(def code-reloading-before-after-opts
+  {"before" "The namespace-qualified name of a zero-arity function to call before reloading."
+   "after" "The namespace-qualified name of a zero-arity function to call after reloading."})
+
 (def-wrapper wrap-refresh cider.nrepl.middleware.refresh/handle-refresh
   {:doc "Refresh middleware."
    :requires #{"clone" #'wrap-print}
    :handles {"refresh"
              {:doc "Reloads all changed files in dependency order."
               :optional (merge wrap-print-optional-arguments
-                               {"dirs" "List of directories to scan. If no directories given, defaults to all directories on the classpath."
-                                "before" "The namespace-qualified name of a zero-arity function to call before reloading."
-                                "after" "The namespace-qualified name of a zero-arity function to call after reloading."})
+                               {"dirs" "List of directories to scan. If no directories given, defaults to all directories on the classpath."}
+                               code-reloading-before-after-opts)
               :returns {"reloading" "List of namespaces that will be reloaded."
                         "status" "`:ok` if reloading was successful; otherwise `:error`."
                         "error" "A sequence of all causes of the thrown exception when `status` is `:error`."
@@ -643,11 +646,13 @@ if applicable, and re-render the updated value."
 using the io.github.tonsky/clj-reload library. It is bundled with cider-nrepl.
 If that dependency is already in present your project and clj-reload.core/init has been invoked beforehand,
 those configured directories will be honored."
+              :optional code-reloading-before-after-opts
               :returns {"progress" "Description of current namespace being unloaded/loaded."
                         "status" "`:ok` if reloading was successful; otherwise `:error`."
                         "error" "A sequence of all causes of the thrown exception when `status` is `:error`."}}
              "cider.clj-reload/reload-all"
              {:doc "Reloads all files in dependency order."
+              :optional code-reloading-before-after-opts
               :returns {"reloading" "Description of current namespace being unloaded/loaded."
                         "status" "`:ok` if reloading was successful; otherwise `:error`."
                         "error" "A sequence of all causes of the thrown exception when `status` is `:error`."}}

--- a/src/cider/nrepl/middleware/util/reload.clj
+++ b/src/cider/nrepl/middleware/util/reload.clj
@@ -1,0 +1,86 @@
+(ns cider.nrepl.middleware.util.reload
+  "Common parts for the code-reloading middleware namespaces."
+  {:added "0.47.0"}
+  (:require
+   [clojure.main :refer [repl-caught]]
+   [haystack.analyzer :as stacktrace.analyzer]
+   [nrepl.middleware.interruptible-eval :refer [*msg*]]
+   [nrepl.middleware.print :as print]
+   [nrepl.misc :refer [response-for]]
+   [nrepl.transport :as transport]
+   [orchard.misc :as misc]))
+
+(defn error-reply
+  [{:keys [error error-ns]}
+   {:keys [::print/print-fn transport] :as msg}]
+
+  (transport/send
+   transport
+   (response-for msg (cond-> {:status :error}
+                       error (assoc :error (stacktrace.analyzer/analyze error print-fn))
+                       error-ns (assoc :error-ns error-ns))))
+
+  (binding [*msg* msg
+            *err* (print/replying-PrintWriter :err msg {})]
+    (repl-caught error)))
+
+(defn- zero-arity-callable? [func]
+  (and (fn? (if (var? func) @func func))
+       (->> (:arglists (meta func))
+            (some #(or (= [] %) (= '& (first %)))))))
+
+(defn- resolve-and-invoke
+  "Takes a string and tries to coerce a function from it. If that
+  function is a function of possible zero arity (ie, truly a thunk or
+  has optional parameters and can be called with zero args, it is
+  called. Returns whether the function was resolved."
+  [sym {:keys [_session] :as msg}]
+  (let [the-var (some-> sym misc/as-sym resolve)]
+
+    (when (and (var? the-var)
+               (not (zero-arity-callable? the-var)))
+      (throw (IllegalArgumentException.
+              (format "%s is not a function of no arguments" sym))))
+
+    (binding [*msg* msg
+              *out* (print/replying-PrintWriter :out msg {})
+              *err* (print/replying-PrintWriter :err msg {})]
+      (when (var? the-var)
+        (@the-var))
+      (var? the-var))))
+
+(defn before-reply [{:keys [before transport] :as msg}]
+  (when before
+    (transport/send
+     transport
+     (response-for msg {:status :invoking-before
+                        :before before}))
+
+    (let [resolved? (resolve-and-invoke before msg)]
+      (transport/send
+       transport
+       (response-for msg
+                     {:status (if resolved?
+                                :invoked-before
+                                :invoked-not-resolved)
+                      :before before})))))
+
+(defn after-reply [error
+                   {:keys [after transport] :as msg}]
+  (when (and (not error) after)
+    (try
+      (transport/send
+       transport
+       (response-for msg {:status :invoking-after
+                          :after after}))
+
+      (let [resolved? (resolve-and-invoke after msg)]
+        (transport/send
+         transport
+         (response-for msg {:status (if resolved?
+                                      :invoked-after
+                                      :invoked-not-resolved)
+                            :after after})))
+
+      (catch Exception e
+        (error-reply {:error e} msg)))))

--- a/test/clj/cider/nrepl/middleware/refresh_test.clj
+++ b/test/clj/cider/nrepl/middleware/refresh_test.clj
@@ -1,6 +1,7 @@
 (ns cider.nrepl.middleware.refresh-test
   (:require
    [cider.nrepl.middleware.refresh :as r]
+   [cider.nrepl.middleware.util.reload :as reload-utils]
    [cider.nrepl.test-session :as session]
    [clojure.test :refer :all]))
 
@@ -24,7 +25,7 @@
 
 (deftest invoking-function-tests
   (testing "invoking named function works"
-    (is (#'r/zero-arity-callable?
+    (is (#'reload-utils/zero-arity-callable?
          (resolve (symbol "cider.nrepl.middleware.refresh-test" "before-fn"))))))
 
 (deftest refresh-op-test


### PR DESCRIPTION
Moves shared code to a new ns.