### PR TITLE
Expand `ops-that-can-eval`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* Refine `ops-that-can-eval` internals, adapting them to the new `cider.nrepl.middleware.reload` ops.
+
 ## 0.47.1 (2024-03-24)
 
 ### Changes

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -785,7 +785,9 @@ stack frame of the most recent exception. This op is deprecated, please use the
 
 (def ops-that-can-eval
   "Set of nREPL ops that can lead to code being evaluated."
-  #{"eval" "load-file" "refresh" "refresh-all" "refresh-clear"
+  #{"eval" "load-file"
+    "refresh" "refresh-all" "refresh-clear"
+    "cider.clj-reload/reload" "cider.clj-reload/reload-all" "cider.clj-reload/reload-clear"
     "toggle-trace-var" "toggle-trace-ns" "undef" "undef-all"})
 
 (def-wrapper wrap-tracker cider.nrepl.middleware.track-state/handle-tracker


### PR DESCRIPTION
Adapting it to the new `cider.nrepl.middleware.reload` ops.