### PR TITLE
Use new Orchard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 * Bump `clj-reload` to [0.4.3](https://github.com/tonsky/clj-reload/blob/main/CHANGELOG.md#043---mar-21-2024).
 * Bump `tools.trace` to 0.8.0 (no changes in source code).
 * Bump `tools.reader` to [1.4.1](https://github.com/clojure/tools.reader/blob/master/CHANGELOG.md).
+* Bump `orchard` to [0.24.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0240-2024-04-30).
+  * Bring many improvements to CIDER Inspector (see Orchard CHANGELOG).
+* Add `inspect-set-max-nested-depth` op that customizes how many nested levels the Inspector will print before abridging.
+* [#826](https://github.com/clojure-emacs/cider-nrepl/pull/826): Remove broken `inspect-get-path` middleware op, return path in every inspector middleware op instead.
+* Reduce the print length of values that CIDER debugger produces for overlay.
 
 ## 0.47.1 (2024-03-24)
 

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -747,6 +747,27 @@ Returns::
 
 
 
+=== `inspect-set-max-nested-depth`
+
+Set the maximum nested levels to display before truncating.
+
+Required parameters::
+* `:max-nested-depth` New nested depth.
+* `:session` The current session
+
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:status` "done"
+* `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
+
+
+
 === `inspect-set-page-size`
 
 Sets the page size in paginated view to specified value.

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -497,6 +497,7 @@ Returns::
 * `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:path` Printed representation of current inspector path.
 * `:status` "done"
 * `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
@@ -519,26 +520,7 @@ Returns::
 * `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
-* `:status` "done"
-* `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
-
-
-
-=== `inspect-get-path`
-
-Returns the path to the current position in the inspected value.
-
-Required parameters::
-* `:session` The current session
-
-
-Optional parameters::
-{blank}
-
-Returns::
-* `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
-* `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
-* `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:path` Printed representation of current inspector path.
 * `:status` "done"
 * `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
@@ -577,6 +559,7 @@ Returns::
 * `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:path` Printed representation of current inspector path.
 * `:status` "done"
 * `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
@@ -598,6 +581,7 @@ Returns::
 * `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:path` Printed representation of current inspector path.
 * `:status` "done"
 * `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
@@ -618,6 +602,7 @@ Returns::
 * `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:path` Printed representation of current inspector path.
 * `:status` "done"
 * `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
@@ -638,6 +623,7 @@ Returns::
 * `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:path` Printed representation of current inspector path.
 * `:status` "done"
 * `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
@@ -659,6 +645,7 @@ Returns::
 * `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:path` Printed representation of current inspector path.
 * `:status` "done"
 * `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
@@ -680,6 +667,7 @@ Returns::
 * `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:path` Printed representation of current inspector path.
 * `:status` "done"
 * `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
@@ -700,6 +688,7 @@ Returns::
 * `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:path` Printed representation of current inspector path.
 * `:status` "done"
 * `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
@@ -721,6 +710,7 @@ Returns::
 * `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:path` Printed representation of current inspector path.
 * `:status` "done"
 * `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
@@ -742,6 +732,7 @@ Returns::
 * `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:path` Printed representation of current inspector path.
 * `:status` "done"
 * `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
@@ -763,6 +754,7 @@ Returns::
 * `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:path` Printed representation of current inspector path.
 * `:status` "done"
 * `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
@@ -784,6 +776,7 @@ Returns::
 * `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:path` Printed representation of current inspector path.
 * `:status` "done"
 * `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
@@ -804,6 +797,7 @@ Returns::
 * `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:path` Printed representation of current inspector path.
 * `:status` "done"
 * `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 
@@ -825,6 +819,7 @@ Returns::
 * `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:path` Printed representation of current inspector path.
 * `:status` "done"
 * `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
 

--- a/doc/modules/ROOT/pages/nrepl-api/supplied_middleware.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/supplied_middleware.adoc
@@ -54,7 +54,7 @@
 | `wrap-inspect`
 | -
 | No
-| `inspect-(start/refresh/pop/push/reset/get-path)`
+| `inspect-(start/refresh/pop/push)`
 | Inspect a Clojure expression.
 
 | `wrap-log`

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/clojure-emacs/cider-nrepl"}
   :dependencies [[nrepl "1.1.1" :exclusions [org.clojure/clojure]]
-                 [cider/orchard "0.23.3" :exclusions [org.clojure/clojure]]
+                 [cider/orchard "0.24.0" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [mx.cider/haystack "0.3.3" :exclusions [cider/orchard]]
                  ^:inline-dep [thunknyc/profile "0.5.2"]
                  ^:inline-dep [mvxcvi/puget "1.3.4" :exclusions [org.clojure/clojure]]

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -364,6 +364,11 @@ if applicable, and re-render the updated value."
                :requires {"max-coll-size" "New collection size."
                           "session" "The current session"}
                :returns inspector-returns}
+              "inspect-set-max-nested-depth"
+              {:doc "Set the maximum nested levels to display before truncating."
+               :requires {"max-nested-depth" "New nested depth."
+                          "session" "The current session"}
+               :returns inspector-returns}
               "inspect-clear"
               {:doc "Clears the state state of the inspector."
                :requires {"session" "The current session"}

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -302,7 +302,8 @@ If specified, the value will be concatenated to that of `orchard.meta/var-meta-a
                :returns {"status" "done"}}}}))
 
 (def inspector-returns (merge {"status" "\"done\""
-                               "value" "The inspector result. Contains a specially-formatted string that can be `read` and then rendered client-side."}
+                               "value" "The inspector result. Contains a specially-formatted string that can be `read` and then rendered client-side."
+                               "path" "Printed representation of current inspector path."}
                               fragments-doc))
 
 (def-wrapper wrap-inspect cider.nrepl.middleware.inspect/handle-inspect
@@ -335,10 +336,6 @@ if applicable, and re-render the updated value."
                :returns inspector-returns}
               "inspect-refresh"
               {:doc "Re-renders the currently inspected value."
-               :requires {"session" "The current session"}
-               :returns inspector-returns}
-              "inspect-get-path"
-              {:doc "Returns the path to the current position in the inspected value."
                :requires {"session" "The current session"}
                :returns inspector-returns}
               "inspect-next-page"

--- a/src/cider/nrepl/middleware/inspect.clj
+++ b/src/cider/nrepl/middleware/inspect.clj
@@ -63,7 +63,8 @@
 
 (defn inspect-reply*
   [msg value]
-  (let [config (select-keys msg [:page-size :max-atom-length :max-coll-size])
+  (let [config (select-keys msg [:page-size :max-atom-length :max-coll-size
+                                 :max-value-length :max-nested-depth])
         inspector (swap-inspector! msg #(inspect/start (merge % config) value))]
     (warmup-javadoc-cache (class (:value inspector)))
     (inspector-response msg inspector {})))
@@ -144,6 +145,10 @@
   (inspector-response msg (swap-inspector! msg inspect/set-max-coll-size
                                            (:max-coll-size msg))))
 
+(defn set-max-nested-depth-reply [msg]
+  (inspector-response msg (swap-inspector! msg inspect/set-max-nested-depth
+                                           (:max-nested-depth msg))))
+
 (defn clear-reply [msg]
   (inspector-response msg (swap-inspector! msg (constantly (inspect/start nil)))))
 
@@ -172,6 +177,7 @@
       "inspect-set-page-size" set-page-size-reply
       "inspect-set-max-atom-length" set-max-atom-length-reply
       "inspect-set-max-coll-size" set-max-coll-size-reply
+      "inspect-set-max-nested-depth" set-max-nested-depth-reply
       "inspect-clear" clear-reply
       "inspect-def-current-value" def-current-value
       "inspect-tap-current-value" tap-current-value

--- a/src/cider/nrepl/middleware/inspect.clj
+++ b/src/cider/nrepl/middleware/inspect.clj
@@ -28,7 +28,7 @@
   ([msg inspector]
    (inspector-response msg inspector {:status :done}))
 
-  ([msg {:keys [rendered value]} resp]
+  ([msg {:keys [rendered value path]} resp]
    (let [class-sym (when (class? value)
                      (-> ^Class value .getCanonicalName symbol))
          method-sym (when (instance? java.lang.reflect.Method value)
@@ -45,8 +45,9 @@
                                                   [:doc-fragments
                                                    :doc-first-sentence-fragments
                                                    :doc-block-tags-fragments]))
-                                   {:value (binding [*print-length* nil]
-                                             (pr-str rendered))})))))
+                                   (binding [*print-length* nil]
+                                     {:value (pr-str (seq rendered))
+                                      :path (pr-str (seq path))}))))))
 
 (defn- warmup-javadoc-cache [^Class clazz]
   (when-let [class-sym (some-> clazz .getCanonicalName symbol)]
@@ -125,9 +126,6 @@
 (defn refresh-reply [msg]
   (inspector-response msg (swap-inspector! msg inspect/inspect-render)))
 
-(defn get-path-reply [{:keys [session]}]
-  (get-in (meta session) [::inspector :path]))
-
 (defn next-page-reply [msg]
   (inspector-response msg (swap-inspector! msg inspect/next-page)))
 
@@ -171,7 +169,6 @@
       "inspect-next-sibling" next-sibling-reply
       "inspect-previous-sibling" previous-sibling-reply
       "inspect-refresh" refresh-reply
-      "inspect-get-path" get-path-reply
       "inspect-next-page" next-page-reply
       "inspect-prev-page" prev-page-reply
       "inspect-set-page-size" set-page-size-reply

--- a/src/cider/nrepl/middleware/log.clj
+++ b/src/cider/nrepl/middleware/log.clj
@@ -53,18 +53,10 @@
     (instance? Throwable exception)
     (update :exception select-exception)))
 
-;; TODO: Double check this! Sometimes inspecting a log event works only after
-;; inspecting something else with the Cider inspector.
 (defn- inspect-value
   "Show `value` in the Cider inspector"
-  [{:keys [page-size max-atom-length max-coll-size] :as msg} value]
-  (let [inspector (middleware.inspect/swap-inspector!
-                   msg #(-> (assoc % :page-size (or page-size 32)
-                                   :indentation 0
-                                   :max-atom-length max-atom-length
-                                   :max-coll-size max-coll-size)
-                            (orchard.inspect/start value)))]
-    (#'middleware.inspect/inspector-response msg inspector)))
+  [msg value]
+  (middleware.inspect/inspect-reply* msg value))
 
 (defn- framework
   "Lookup the framework from the :framework key of the nREPL message."

--- a/test/clj/cider/nrepl/middleware/debug_test.clj
+++ b/test/clj/cider/nrepl/middleware/debug_test.clj
@@ -194,7 +194,9 @@
   (is (< (count (d/pr-short [[[1 2 3 4]]]))
          (count (pr-str [[[1 2 3 4]]]))))
   (is (= (d/pr-short [1 2 3 4])
-         (pr-str [1 2 3 4]))))
+         (pr-str [1 2 3 4])))
+  (reset! d/print-options {})
+  (is (= 2003 (count (d/pr-short (range))))))
 
 (deftest breakpoint
   ;; Map merging

--- a/test/cljs/cider/nrepl/middleware/cljs_inspect_test.clj
+++ b/test/cljs/cider/nrepl/middleware/cljs_inspect_test.clj
@@ -27,6 +27,9 @@
   '("Class"
     ": " (:value "clojure.lang.PersistentArrayMap" 0)
     (:newline)
+    "Count: "
+    "4"
+    (:newline)
     (:newline)
     "--- Contents:"
     (:newline)
@@ -43,6 +46,8 @@
   '("Class"
     ": " (:value "clojure.lang.PersistentArrayMap" 0)
     (:newline)
+    "Count: " "1"
+    (:newline)
     (:newline)
     "--- Contents:"
     (:newline)
@@ -56,6 +61,8 @@
 (def next-page-result
   '("Class"
     ": " (:value "clojure.lang.PersistentList" 0)
+    (:newline)
+    "Count: " "35"
     (:newline)
     (:newline)
     "--- Contents:"
@@ -71,11 +78,14 @@
     (:newline)
     "--- Page Info:"
     (:newline)
-    "  " "Page size: 32, showing page: 2 of 2"))
+    "  " "Page size: 32, showing page: 2 of 2"
+    (:newline)))
 
 (def first-page-result
   '("Class"
     ": " (:value "clojure.lang.PersistentList" 0)
+    (:newline)
+    "Count: " "35"
     (:newline)
     (:newline)
     "--- Contents:"
@@ -95,7 +105,8 @@
     (:newline)
     "--- Page Info:"
     (:newline)
-    "  " "Page size: 5, showing page: 1 of 7"))
+    "  " "Page size: 5, showing page: 1 of 7"
+    (:newline)))
 
 (defn value [{:keys [value]}]
   (edn/read-string (first value)))
@@ -336,6 +347,7 @@
                    (extract-text small-page-2)))))
 
   (testing "page size can be changed via the inspect-set-page-size op"
+    (session/message {:op "inspect-clear"})
     (let [normal-page-size (session/message {:op "eval"
                                              :inspect "true"
                                              :code "(range 100)"})


### PR DESCRIPTION
Update Orchard to the latest version. This gets all latest inspector updates and new `orchard.print` namespace.

- [x] Adapt inspector middleware to updated `orchard.inspect`
  - [x] Fix tests
  - [x] Remove deprecated calls
  - [x] Handle nil inspector/empty config
  - [x] Add middleware opts for new printing options
  - [x] Fix some old bugs
- [x] Use new printing in cider debugger

- [x] You've added tests to cover your change(s)
- [x] You've updated the README
- [x] Middleware documentation is up to date
  * [x] Please check out and modify the `cider.nrepl` ns which has all middleware documentation.
  * [x]  Run `lein docs` afterwards, and commit the results.