### PR TITLE
Use Compliment 0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * [#868](https://github.com/clojure-emacs/cider-nrepl/pull/868): Drop support for Clojure 1.9.
 * Refine `ops-that-can-eval` internals, adapting them to the new `cider.nrepl.middleware.reload` ops.
 * Bump `nrepl` to [1.1.1](https://github.com/nrepl/nrepl/blob/master/CHANGELOG.md#111-2024-02-20).
-* Bump `compliment` to [0.5.3](https://github.com/alexander-yakushev/compliment/blob/14329344/CHANGELOG.md#053-2024-04-11).
+* Bump `compliment` to [0.5.5](https://github.com/alexander-yakushev/compliment/blob/master/CHANGELOG.md#055-2024-05-06).
 * Bump `clj-reload` to [0.6.0](https://github.com/tonsky/clj-reload/blob/0.6.0/CHANGELOG.md#060---may-3-2024).
 * Bump `tools.trace` to 0.8.0 (no changes in source code).
 * Bump `tools.reader` to [1.4.1](https://github.com/clojure/tools.reader/blob/master/CHANGELOG.md).

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
                  ^:inline-dep [thunknyc/profile "0.5.2"]
                  ^:inline-dep [mvxcvi/puget "1.3.4" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [fipp ~fipp-version] ; can be removed in unresolved-tree mode
-                 ^:inline-dep [compliment "0.5.3"]
+                 ^:inline-dep [compliment "0.5.5"]
                  ^:inline-dep [org.rksm/suitable "0.6.2" :exclusions [org.clojure/clojure
                                                                       org.clojure/clojurescript]]
                  ^:inline-dep [cljfmt "0.9.2" :exclusions [org.clojure/clojurescript]]


### PR DESCRIPTION
Since the last update:
- Fix fuzzy matching logic (`rema` didn't match re-matches).
- Optimize the way how cached values are looked up.
- Reduce the memory footprint of the cache.
- Deprecate `:plain-candidates` in `complliment.core/completions`.
