### PR TITLE
[inspector] Use orchard.inspect/refresh instead of individual setters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* Bump `orchard` to [0.26.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0260-2024-06-30).
+
 ## 0.48.0 (2024-05-13)
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changes
 
+* [#877](https://github.com/clojure-emacs/cider-nrepl/pull/877): `inspect-refresh` middleware is now capable of setting all config options that `orchard.inspect` supports.
+* [#877](https://github.com/clojure-emacs/cider-nrepl/pull/877): Deprecate all `inspect-set-*` middleware ops.
 * Bump `orchard` to [0.26.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0260-2024-06-30).
 
 ## 0.48.0 (2024-05-13)

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -675,14 +675,18 @@ Returns::
 
 === `inspect-refresh`
 
-Re-renders the currently inspected value.
+Updates inspector with the provided config and re-renders the current value.
 
 Required parameters::
 * `:session` The current session
 
 
 Optional parameters::
-{blank}
+* `:max-atom-length` New max length of single rendered value
+* `:max-coll-size` New max size of rendered collection
+* `:max-nested-depth` New max nested depth of rendered collection
+* `:page-size` New page size
+
 
 Returns::
 * `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
@@ -696,7 +700,7 @@ Returns::
 
 === `inspect-set-max-atom-length`
 
-Set the max length of nested atoms to specified value.
+[DEPRECATED - use ``inspect-refresh`` instead] Set the max length of nested atoms to specified value.
 
 Required parameters::
 * `:max-atom-length` New max length.
@@ -718,7 +722,7 @@ Returns::
 
 === `inspect-set-max-coll-size`
 
-Set the number of nested collection members to display before truncating.
+[DEPRECATED - use ``inspect-refresh`` instead] Set the number of nested collection members to display before truncating.
 
 Required parameters::
 * `:max-coll-size` New collection size.
@@ -740,7 +744,7 @@ Returns::
 
 === `inspect-set-max-nested-depth`
 
-Set the maximum nested levels to display before truncating.
+[DEPRECATED - use ``inspect-refresh`` instead] Set the maximum nested levels to display before truncating.
 
 Required parameters::
 * `:max-nested-depth` New nested depth.
@@ -762,7 +766,7 @@ Returns::
 
 === `inspect-set-page-size`
 
-Sets the page size in paginated view to specified value.
+[DEPRECATED - use ``inspect-refresh`` instead] Sets the page size in paginated view to specified value.
 
 Required parameters::
 * `:page-size` New page size.
@@ -1147,7 +1151,7 @@ Returns::
 
 === `retest`
 
-[DEPRECATED - ``use test-var-query`` instead] Run all tests in the project. If ``load?`` is truthy, all project namespaces are loaded; otherwise, only tests in presently loaded namespaces are run. Results are cached for exception retrieval and to enable re-running of failed/erring tests.
+[DEPRECATED - use ``test-var-query`` instead] Run all tests in the project. If ``load?`` is truthy, all project namespaces are loaded; otherwise, only tests in presently loaded namespaces are run. Results are cached for exception retrieval and to enable re-running of failed/erring tests.
 
 Required parameters::
 {blank}
@@ -1281,7 +1285,7 @@ Returns::
 
 === `test`
 
-[DEPRECATED - ``use test-var-query`` instead] Run tests in the specified namespace and return results. This accepts a set of ``tests`` to be run; if nil, runs all tests. Results are cached for exception retrieval and to enable re-running of failed/erring tests.
+[DEPRECATED - use ``test-var-query`` instead] Run tests in the specified namespace and return results. This accepts a set of ``tests`` to be run; if nil, runs all tests. Results are cached for exception retrieval and to enable re-running of failed/erring tests.
 
 Required parameters::
 {blank}

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/clojure-emacs/cider-nrepl"}
   :dependencies [[nrepl "1.1.1" :exclusions [org.clojure/clojure]]
-                 [cider/orchard "0.25.0" :exclusions [org.clojure/clojure]]
+                 [cider/orchard "0.26.0" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [mx.cider/haystack "0.3.3" :exclusions [cider/orchard]]
                  ^:inline-dep [thunknyc/profile "0.5.2"]
                  ^:inline-dep [mvxcvi/puget "1.3.4" :exclusions [org.clojure/clojure]]

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -335,8 +335,12 @@ if applicable, and re-render the updated value."
                :requires {"session" "The current session"}
                :returns inspector-returns}
               "inspect-refresh"
-              {:doc "Re-renders the currently inspected value."
+              {:doc "Updates inspector with the provided config and re-renders the current value."
                :requires {"session" "The current session"}
+               :optional {"page-size" "New page size"
+                          "max-atom-length" "New max length of single rendered value"
+                          "max-coll-size" "New max size of rendered collection"
+                          "max-nested-depth" "New max nested depth of rendered collection"}
                :returns inspector-returns}
               "inspect-next-page"
               {:doc "Jumps to the next page in paginated collection view."
@@ -347,22 +351,22 @@ if applicable, and re-render the updated value."
                :requires {"session" "The current session"}
                :returns inspector-returns}
               "inspect-set-page-size"
-              {:doc "Sets the page size in paginated view to specified value."
+              {:doc "[DEPRECATED - use `inspect-refresh` instead] Sets the page size in paginated view to specified value."
                :requires {"page-size" "New page size."
                           "session" "The current session"}
                :returns inspector-returns}
               "inspect-set-max-atom-length"
-              {:doc "Set the max length of nested atoms to specified value."
+              {:doc "[DEPRECATED - use `inspect-refresh` instead] Set the max length of nested atoms to specified value."
                :requires {"max-atom-length" "New max length."
                           "session" "The current session"}
                :returns inspector-returns}
               "inspect-set-max-coll-size"
-              {:doc "Set the number of nested collection members to display before truncating."
+              {:doc "[DEPRECATED - use `inspect-refresh` instead] Set the number of nested collection members to display before truncating."
                :requires {"max-coll-size" "New collection size."
                           "session" "The current session"}
                :returns inspector-returns}
               "inspect-set-max-nested-depth"
-              {:doc "Set the maximum nested levels to display before truncating."
+              {:doc "[DEPRECATED - use `inspect-refresh` instead] Set the maximum nested levels to display before truncating."
                :requires {"max-nested-depth" "New nested depth."
                           "session" "The current session"}
                :returns inspector-returns}
@@ -757,7 +761,7 @@ stack frame of the most recent exception. This op is deprecated, please use the
               :optional (merge wrap-print-optional-arguments)
               :returns (merge fail-fast-doc timing-info-return-doc)}
              "test"
-             {:doc "[DEPRECATED - `use test-var-query` instead] Run tests in the specified namespace and return results. This accepts a set of `tests` to be run; if nil, runs all tests. Results are cached for exception retrieval and to enable re-running of failed/erring tests."
+             {:doc "[DEPRECATED - use `test-var-query` instead] Run tests in the specified namespace and return results. This accepts a set of `tests` to be run; if nil, runs all tests. Results are cached for exception retrieval and to enable re-running of failed/erring tests."
               :optional wrap-print-optional-arguments
               :returns (merge fail-fast-doc timing-info-return-doc)}
              "test-all"
@@ -768,7 +772,7 @@ stack frame of the most recent exception. This op is deprecated, please use the
              {:doc "Rerun all tests that did not pass when last run. Results are cached for exception retrieval and to enable re-running of failed/erring tests."
               :optional wrap-print-optional-arguments}
              "retest"
-             {:doc "[DEPRECATED - `use test-var-query` instead] Run all tests in the project. If `load?` is truthy, all project namespaces are loaded; otherwise, only tests in presently loaded namespaces are run. Results are cached for exception retrieval and to enable re-running of failed/erring tests."
+             {:doc "[DEPRECATED - use `test-var-query` instead] Run all tests in the project. If `load?` is truthy, all project namespaces are loaded; otherwise, only tests in presently loaded namespaces are run. Results are cached for exception retrieval and to enable re-running of failed/erring tests."
               :optional wrap-print-optional-arguments
               :returns (merge fail-fast-doc timing-info-return-doc)}}})
 


### PR DESCRIPTION
Sister to clojure-emacs/orchard#269. This is how it would look like on the cider-nrepl side. Old ops are retained for compatibility and marked as deprecated.