### PR TITLE
[inspect] Introduce support for :view-mode config and inspect-toggle-view-mode op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#877](https://github.com/clojure-emacs/cider-nrepl/pull/877): `inspect-refresh` middleware is now capable of setting all config options that `orchard.inspect` supports.
 * [#877](https://github.com/clojure-emacs/cider-nrepl/pull/877): Deprecate all `inspect-set-*` middleware ops.
+* [#879](https://github.com/clojure-emacs/cider-nrepl/pull/879): Add support for `:view-mode` inspector config and `inspect-toggle-view-mode` op.
 * Bump `orchard` to [0.26.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0260-2024-06-30).
 
 ## 0.48.0 (2024-05-13)

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -686,6 +686,7 @@ Optional parameters::
 * `:max-coll-size` New max size of rendered collection
 * `:max-nested-depth` New max nested depth of rendered collection
 * `:page-size` New page size
+* `:view-mode` Mode of viewing the value - either ``:normal`` or ``:object``
 
 
 Returns::
@@ -813,6 +814,27 @@ Send the currently inspected sub-value at ``idx`` to the Clojure tap>.
 
 Required parameters::
 * `:idx` Index of the internal value to be tapped
+* `:session` The current session
+
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:path` Printed representation of current inspector path.
+* `:status` "done"
+* `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
+
+
+
+=== `inspect-toggle-view-mode`
+
+Toggles the viewing mode of the inspector. This influences the way how inspector is rendering the current value. ``:normal`` is the default. When view mode is ``:object``, any value will be rendered as a Java object (fields shown as is).
+
+Required parameters::
 * `:session` The current session
 
 

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -340,7 +340,12 @@ if applicable, and re-render the updated value."
                :optional {"page-size" "New page size"
                           "max-atom-length" "New max length of single rendered value"
                           "max-coll-size" "New max size of rendered collection"
-                          "max-nested-depth" "New max nested depth of rendered collection"}
+                          "max-nested-depth" "New max nested depth of rendered collection"
+                          "view-mode" "Mode of viewing the value - either `:normal` or `:object`"}
+               :returns inspector-returns}
+              "inspect-toggle-view-mode"
+              {:doc "Toggles the viewing mode of the inspector. This influences the way how inspector is rendering the current value. `:normal` is the default. When view mode is `:object`, any value will be rendered as a Java object (fields shown as is)."
+               :requires {"session" "The current session"}
                :returns inspector-returns}
               "inspect-next-page"
               {:doc "Jumps to the next page in paginated collection view."


### PR DESCRIPTION
1. Adding `:view-mode` as a supported config options passed from CIDER to Orchard. This part is straightforward.
2. Given that I wanted the view-mode to be a toggle, the best place for toggling logic is here. Adding it on CIDER side would require CIDER to know what is the current view-mode of the inspector which is extra work. cider-nrepl has that information though, so it's easy to do it here.