### PR TITLE
[inspect] Use new stack-based view mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 * [#877](https://github.com/clojure-emacs/cider-nrepl/pull/877): `inspect-refresh` middleware is now capable of setting all config options that `orchard.inspect` supports.
 * [#877](https://github.com/clojure-emacs/cider-nrepl/pull/877): Deprecate all `inspect-set-*` middleware ops.
-* [#879](https://github.com/clojure-emacs/cider-nrepl/pull/879): Add support for `:view-mode` inspector config and `inspect-toggle-view-mode` op.
-* Bump `orchard` to [0.26.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0260-2024-06-30).
+* [#879](https://github.com/clojure-emacs/cider-nrepl/pull/879), [#880](https://github.com/clojure-emacs/cider-nrepl/pull/880): Add `inspect-toggle-view-mode` op.
+* Bump `orchard` to [0.26.1](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0261-2024-06-02)
 
 ## 0.48.0 (2024-05-13)
 

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -832,7 +832,7 @@ Returns::
 
 === `inspect-toggle-view-mode`
 
-Toggles the viewing mode of the inspector. This influences the way how inspector is rendering the current value. ``:normal`` is the default. When view mode is ``:object``, any value will be rendered as a Java object (fields shown as is).
+Toggles the viewing mode of the inspector. This influences the way how inspector is rendering the current value. ``:normal`` is the default. When view mode is ``:object``, any value will be rendered as a Java object (fields shown as is). View mode is automatically reset back to normal when navigating to child values.
 
 Required parameters::
 * `:session` The current session

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/clojure-emacs/cider-nrepl"}
   :dependencies [[nrepl "1.1.1" :exclusions [org.clojure/clojure]]
-                 [cider/orchard "0.26.0" :exclusions [org.clojure/clojure]]
+                 [cider/orchard "0.26.1" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [mx.cider/haystack "0.3.3" :exclusions [cider/orchard]]
                  ^:inline-dep [thunknyc/profile "0.5.2"]
                  ^:inline-dep [mvxcvi/puget "1.3.4" :exclusions [org.clojure/clojure]]

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -344,7 +344,7 @@ if applicable, and re-render the updated value."
                           "view-mode" "Mode of viewing the value - either `:normal` or `:object`"}
                :returns inspector-returns}
               "inspect-toggle-view-mode"
-              {:doc "Toggles the viewing mode of the inspector. This influences the way how inspector is rendering the current value. `:normal` is the default. When view mode is `:object`, any value will be rendered as a Java object (fields shown as is)."
+              {:doc "Toggles the viewing mode of the inspector. This influences the way how inspector is rendering the current value. `:normal` is the default. When view mode is `:object`, any value will be rendered as a Java object (fields shown as is). View mode is automatically reset back to normal when navigating to child values."
                :requires {"session" "The current session"}
                :returns inspector-returns}
               "inspect-next-page"

--- a/src/cider/nrepl/middleware/inspect.clj
+++ b/src/cider/nrepl/middleware/inspect.clj
@@ -150,7 +150,7 @@
 (defn- toggle-view-mode [{:keys [view-mode] :as inspector}]
   (let [toggle-order {:normal :object, :object :normal}
         next-view-mode (toggle-order view-mode :normal)]
-    (inspect/refresh inspector {:view-mode next-view-mode})))
+    (inspect/set-view-mode inspector next-view-mode)))
 
 (defn toggle-view-mode-reply [msg]
   (inspector-response msg (swap-inspector! msg toggle-view-mode)))


### PR DESCRIPTION
After using the new view-mode functionality locally for some time, I concluded that in 99% of cases you only want to toggle `:object` view mode for the currently inspected value. When you subsequently click on one of the fields to inspect further, you'd rather see the normal view mode again. So, in my experience, it looked like `v`, click the field with usually a recognizable data structure, `v` again to toggle back to normal view mode.

I propose to make this behavior the default one. When the user navigates away from the current view, the view-mode will reset. For that, I've introduced a concept of "transient config values".

In this PR, any action other than `toggle-view-mode` will reset the view-mode back to `:normal`. Now that I think of it, some actions make sense to preserve the view mode, e.g. `next-prev/sibling` (if you are viewing the value in `:object` view, it's likely you want to see its sibling in that view too). `prev/next` page don't make sense for object view, so it's whatever there. So, perhaps, the resetting logic should only exist for `down/up` ops. Maybe maintain it as another stack (this will be neat but require the most work)?

WDYT?

### EDIT

It was decided to implement :view-mode switching on the Orchard side and keep a stack of modes for the history of inspected values. That way, when the user downs to another value, the :view-mode is reset to :normal. When they go back up, the :view-mode is restored from the stack.