### PR TITLE
Cleanup the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+## 0.49.0 (2024-06-02)
+
 ### Changes
 
 * [#877](https://github.com/clojure-emacs/cider-nrepl/pull/877): `inspect-refresh` middleware is now capable of setting all config options that `orchard.inspect` supports.

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ light-kondo: clean
 
 lint: kondo cljfmt eastwood
 
-# PROJECT_VERSION=0.48.0 make install
+# PROJECT_VERSION=0.49.0 make install
 install: dump-version check-install-env .inline-deps
 	rm -f .no-mranderson
 	touch .no-pedantic
@@ -118,7 +118,7 @@ install: dump-version check-install-env .inline-deps
 	make clean
 	git checkout resources/cider/nrepl/version.edn
 
-# PROJECT_VERSION=0.48.0 make fast-install
+# PROJECT_VERSION=0.49.0 make fast-install
 fast-install: dump-version check-install-env
 	lein with-profile -user,-dev,+$(CLOJURE_VERSION) install
 	make clean

--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ PARSER_TARGET=parser-next make fast-test
 # Install the project in your local ~/.m2 directory, using mranderson (recommended)
 # The JVM flag is a temporary workaround.
 export LEIN_JVM_OPTS="-Dmranderson.internal.no-parallelism=true"
-PROJECT_VERSION=0.48.0 make install
+PROJECT_VERSION=0.49.0 make install
 
 # Install the project in your local ~/.m2 directory, without using mranderson
 # (it's faster, but please only use when you repeatedly need to install cider-nrepl)
 # The JVM flag is a temporary workaround.
 export LEIN_JVM_OPTS="-Dmranderson.internal.no-parallelism=true"
-PROJECT_VERSION=0.48.0 make fast-install
+PROJECT_VERSION=0.49.0 make fast-install
 
 # Runs clj-kondo, cljfmt and Eastwood (in that order, with fail-fast).
 # Please try to run this before pushing commits.
@@ -107,7 +107,7 @@ before cutting a new release.
 Release to [clojars](https://clojars.org/) by tagging a new release:
 
 ```
-git tag -a v0.48.0 -m "Release 0.48.0"
+git tag -a v0.49.0 -m "Release 0.49.0"
 git push --tags
 ```
 

--- a/doc/antora.yml
+++ b/doc/antora.yml
@@ -2,6 +2,6 @@ name: cider-nrepl
 title: CIDER nREPL
 # The version should be in the format major.minor (e.g. 0.28).
 # Don't include patch in the version (e.g. 0.28.7).
-version: ~
+version: 0.49
 nav:
 - modules/ROOT/nav.adoc

--- a/doc/modules/ROOT/pages/about/history.adoc
+++ b/doc/modules/ROOT/pages/about/history.adoc
@@ -7,16 +7,15 @@ with the assumption that this would make it easier to develop CIDER and would op
 to build complex features like an interactive debugger. Fortunately, the assumption turned out to be correct.
 Today `cider-nrepl` provides pretty much everything that a Clojure development environment might need (and more).
 
- We quickly
-realized that there was nothing CIDER specific in those middleware and we've
-started to encourage more tool authors to leverage them. Today `cider-nrepl` is
-developed and released independently from CIDER and is used by most of the
-nREPL-based editors and IDEs out there, which is a great example of team work.
-Eventually `cider-nrepl` served as the inspiration for more similar
+We quickly realized that there was nothing CIDER specific in those middleware
+and we've started to encourage more tool authors to leverage them. Today
+`cider-nrepl` is developed and released independently from CIDER and is used by
+most of the nREPL-based editors and IDEs out there, which is a great example of
+team work. Eventually `cider-nrepl` served as the inspiration for more similar
 middleware libraries - e.g. `refactor-nrepl`, `iced-nrepl` and `sayid`.
 
-More recently we've been working to extract the core functionality out of `cider-nrepl`
-into a https://github.com/clojure-emacs/orchard[REPL-agnostic library].footnote:[This process started in 2019.]
+In 2019, the core functionality has been extracted out of `cider-nrepl` into
+https://github.com/clojure-emacs/orchard[Orchard], a REPL-agnostic library.
 
 You can check out https://www.youtube.com/watch?v=4X-1fJm25Ww[this talk], which explores the birth of
 `cider-nrepl`.

--- a/doc/modules/ROOT/pages/compatibility.adoc
+++ b/doc/modules/ROOT/pages/compatibility.adoc
@@ -2,10 +2,9 @@
 
 == Java
 
-`cider-nrepl` officially targets Java 8, Java 11 and the most recent rapid
-release version (e.g. Java 13).  More generally speaking - we aim
-to support all Java releases that are currently officially supported
-by Oracle.
+`cider-nrepl` officially targets Java 8, 11, 17, 21, and the most recent rapid
+release version (e.g. Java 22). More generally speaking - we aim to support all
+Java releases that are currently officially supported by Oracle.
 
 == Clojure
 
@@ -85,12 +84,12 @@ requirements were bumped to nREPL 0.6 in recent versions.
 | 1.9
 | 1.0.0
 
-| 0.48.0
+| 0.47.0
 | 8
 | 1.9
 | 1.0.0
 
-| 0.48.0
+| 0.49.0
 | 8
 | 1.10
 | 1.0.0

--- a/doc/modules/ROOT/pages/compatibility.adoc
+++ b/doc/modules/ROOT/pages/compatibility.adoc
@@ -31,14 +31,15 @@ Currently `cider-nrepl` requires Piggieback 0.4+ to work properly.
 
 `cider-nrepl` supports nREPL 0.6+.
 
-NOTE: We pay special attention to supporting whatever nREPL is bundled with the current stable Leiningen
-and Boot releases.
+NOTE: We pay special attention to supporting whatever nREPL is bundled with the
+current stable Leiningen release.
 
 == Compatibility Matrix
 
-Below you can find the official compatibility matrix for `cider-nrepl`. For a
-very long time the project targeted nREPL 0.2.x, but the
-requirements were bumped to nREPL 0.6 in recent versions.
+Below you can find the official compatibility matrix for `cider-nrepl`.
+
+NOTE: The matrix lists only the last versions of `cider-nrepl` that supports the
+given compatibility tuple.
 
 .Compatibility Matrix
 |===
@@ -53,26 +54,6 @@ requirements were bumped to nREPL 0.6 in recent versions.
 | 8
 | 1.8
 | 0.4.x
-
-| 0.21
-| 8
-| 1.8
-| 0.6
-
-| 0.22
-| 8
-| 1.8
-| 0.6
-
-| 0.23
-| 8
-| 1.8
-| 0.6
-
-| 0.24
-| 8
-| 1.8
-| 0.6
 
 | 0.25
 | 8

--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -73,13 +73,19 @@ hackers to make this a reality.
 
 === Isolated Runtime Dependencies
 
-All of cider-nrepl's dependencies are processed with
+Most of cider-nrepl's dependencies are processed with
 https://github.com/benedekfazekas/mranderson[mranderson], so that
 they won't collide with the dependencies of your own projects. This
-basically means that cider-nrepl doesn't have any runtime dependencies in
+basically means that cider-nrepl has almost no  runtime dependencies in
 the production artifact - just copies of the deps inlined with changed
 namespaces/packages. It's a bit ugly and painful, but it gets the job
 done.
+
+The exclusion to this rule are the artifacts that are themselves part of the
+CIDER ecosystem and have to runtime dependencies of their own:
+
+- https://github.com/clojure-emacs/orchard[Orchard]
+- https://github.com/clojure-emacs/logjam[Logjam]
 
 If someone has better ideas how to isolate our runtime dependencies -
 we're all ears!

--- a/doc/modules/ROOT/pages/internals.adoc
+++ b/doc/modules/ROOT/pages/internals.adoc
@@ -2,7 +2,7 @@
 
 == Lazy middleware loading
 
-Eager loading of all of `cider-nrepl`'s middleware resulted in a significant impact to the
+Eager loading of all of cider-nrepl's middleware resulted in a significant impact to the
 startup time of the nREPL server. To mitigate this we've devised a strategy to postpone
 the actual initialization of some middleware until the first time it's actually used
 by a client.
@@ -42,10 +42,10 @@ a string). Hopefully this will change down the road.
 
 == Dependency obfuscation
 
-`cider-nrepl`'s dependency would conflict with the dependencies of the application using it,
+cider-nrepl's dependency would conflict with the dependencies of the application using it,
 so we have to take some care to avoid such situation.
 
-All of cider-nrepl's dependencies are processed with
+Most of cider-nrepl's dependencies are processed with
 https://github.com/benedekfazekas/mranderson[mranderson], so that
 they won't collide with the dependencies of your own projects. This
 basically means that cider-nrepl doesn't have any runtime dependencies in
@@ -53,5 +53,5 @@ the production artifact - just copies of the deps inlined with changed
 namespaces/packages.
 
 This means that `cider-nrepl` has to also take some steps to hide the inlined namespaces,
-so they won't pollute the results users would be interested in. Pretty much all of `cider-nrepl`'s
+so they won't pollute the results users would be interested in. Pretty much all of cider-nrepl's
 ops would filter out the inlined namespaces.

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -58,36 +58,6 @@ under `:repl-options`.
                   cider.nrepl/wrap-xref]}
 ----
 
-=== Via Boot
-
-Boot users can configure the injected middleware by either specifying
-it on the command line through the `cider.tasks/add-middleware` task
-(the lengthy command below will include the `apropos` and `version`
-functionality):
-
-----
-boot -d nrepl:1.0.0 -d cider/cider-nrepl:0.49.0 -i "(require 'cider.tasks)" cider.tasks/add-middleware -m cider.nrepl.middleware.apropos/wrap-apropos -m cider.nrepl.middleware.version/wrap-version repl --server wait
-----
-
-Or for all of their projects by adding a `~/.boot/profile.boot` file like so:
-
-[source,clojure]
-----
-(set-env! :dependencies '[[nrepl "1.0.0"]
-                          [cider/cider-nrepl "0.49.0"]])
-
-(require '[cider.tasks :refer [add-middleware]])
-
-(task-options! add-middleware {:middleware '[cider.nrepl.middleware.apropos/wrap-apropos
-                                             cider.nrepl.middleware.version/wrap-version]})
-----
-
-And then launching `boot add-middleware repl --server wait`.
-
-Note that this is not necessary when using the standard `cider-jack-in`.
-
-For more information visit https://github.com/boot-clj/boot/wiki/Cider-REPL[boot-clj wiki].
-
 == Via clj
 
 You can easily boot an nREPL server with the CIDER middleware loaded
@@ -103,11 +73,11 @@ There are also two convenient aliases you can employ:
 ----
 {...
  :aliases
- {:cider-clj {:extra-deps {org.clojure/clojure {:mvn/version "1.10.1"}
+ {:cider-clj {:extra-deps {org.clojure/clojure {:mvn/version "1.10.3"}
                            cider/cider-nrepl {:mvn/version "0.49.0"}}
               :main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"]}
 
-  :cider-cljs {:extra-deps {org.clojure/clojure {:mvn/version "1.10.1"}
+  :cider-cljs {:extra-deps {org.clojure/clojure {:mvn/version "1.10.3"}
                             org.clojure/clojurescript {:mvn/version "1.10.339"}
                             cider/cider-nrepl {:mvn/version "0.49.0"}
                             cider/piggieback {:mvn/version "0.5.2"}}

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -15,14 +15,14 @@ Use the convenient plugin for defaults, either in your project's
 
 [source,clojure]
 ----
-:plugins [[cider/cider-nrepl "0.48.0"]]
+:plugins [[cider/cider-nrepl "0.49.0"]]
 ----
 
 A minimal `profiles.clj` for CIDER would be:
 
 [source,clojure]
 ----
-{:user {:plugins [[cider/cider-nrepl "0.48.0"]]}}
+{:user {:plugins [[cider/cider-nrepl "0.49.0"]]}}
 ----
 
 Or (if you know what you're doing) add `cider-nrepl` to your `:dev
@@ -31,7 +31,7 @@ under `:repl-options`.
 
 [source,clojure]
 ----
-:dependencies [[cider/cider-nrepl "0.48.0"]]
+:dependencies [[cider/cider-nrepl "0.49.0"]]
 :repl-options {:nrepl-middleware
                  [cider.nrepl/wrap-apropos
                   cider.nrepl/wrap-classpath
@@ -66,7 +66,7 @@ it on the command line through the `cider.tasks/add-middleware` task
 functionality):
 
 ----
-boot -d nrepl:1.0.0 -d cider/cider-nrepl:0.48.0 -i "(require 'cider.tasks)" cider.tasks/add-middleware -m cider.nrepl.middleware.apropos/wrap-apropos -m cider.nrepl.middleware.version/wrap-version repl --server wait
+boot -d nrepl:1.0.0 -d cider/cider-nrepl:0.49.0 -i "(require 'cider.tasks)" cider.tasks/add-middleware -m cider.nrepl.middleware.apropos/wrap-apropos -m cider.nrepl.middleware.version/wrap-version repl --server wait
 ----
 
 Or for all of their projects by adding a `~/.boot/profile.boot` file like so:
@@ -74,7 +74,7 @@ Or for all of their projects by adding a `~/.boot/profile.boot` file like so:
 [source,clojure]
 ----
 (set-env! :dependencies '[[nrepl "1.0.0"]
-                          [cider/cider-nrepl "0.48.0"]])
+                          [cider/cider-nrepl "0.49.0"]])
 
 (require '[cider.tasks :refer [add-middleware]])
 
@@ -94,7 +94,7 @@ You can easily boot an nREPL server with the CIDER middleware loaded
 with the following "magic" incantation:
 
 ----
-clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.48.0"} }}' -M -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
+clj -Sdeps '{:deps {cider/cider-nrepl {:mvn/version "0.49.0"} }}' -M -m nrepl.cmdline --middleware "[cider.nrepl/cider-middleware]"
 ----
 
 There are also two convenient aliases you can employ:
@@ -104,12 +104,12 @@ There are also two convenient aliases you can employ:
 {...
  :aliases
  {:cider-clj {:extra-deps {org.clojure/clojure {:mvn/version "1.10.1"}
-                           cider/cider-nrepl {:mvn/version "0.48.0"}}
+                           cider/cider-nrepl {:mvn/version "0.49.0"}}
               :main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"]}
 
   :cider-cljs {:extra-deps {org.clojure/clojure {:mvn/version "1.10.1"}
                             org.clojure/clojurescript {:mvn/version "1.10.339"}
-                            cider/cider-nrepl {:mvn/version "0.48.0"}
+                            cider/cider-nrepl {:mvn/version "0.49.0"}
                             cider/piggieback {:mvn/version "0.5.2"}}
                :main-opts ["-m" "nrepl.cmdline" "--middleware"
                            "[cider.nrepl/cider-middleware,cider.piggieback/wrap-cljs-repl]"]}}}


### PR DESCRIPTION
Notable changes:
- Removed mentions of Boot as part of the soft-deprecation process (@bbatsov).
- Trimmed the compatibility table to leave only versions where compatibilities have changed.

Ignore the 0.49.0 commit, I will rebase it when that PR is merged.