### PR TITLE
Decrease minimal Clojure version in Leiningen plugin to 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#883](https://github.com/clojure-emacs/cider-nrepl/pull/883): Reduce minimal Clojure requirement to 1.10.0.
+
 ## 0.49.0 (2024-06-02)
 
 ### Changes

--- a/src/cider_nrepl/plugin.clj
+++ b/src/cider_nrepl/plugin.clj
@@ -7,7 +7,7 @@
    [leiningen.core.main :as lein]))
 
 (def minimum-versions {:lein    "2.8.3"
-                       :clojure "1.10.3"})
+                       :clojure "1.10.0"})
 
 (defn valid-version? [kind version] (lein/version-satisfies? version (minimum-versions kind)))
 (def valid-lein-version? (partial valid-version? :lein))
@@ -46,9 +46,9 @@
     (when-not lein-version-ok?
       (lein/warn "Warning: cider-nrepl requires Leiningen 2.8.3 or greater."))
     (when-not clojure-version-ok?
-      (lein/warn "Warning: cider-nrepl requires Clojure 1.10.3 or greater."))
+      (lein/warn "Warning: cider-nrepl requires Clojure 1.10.0 or greater."))
     (when clojure-excluded?
-      (lein/warn "Warning: Clojure is excluded, assuming an appropriate fork (Clojure 1.10.3 or later) is provided."))
+      (lein/warn "Warning: Clojure is excluded, assuming an appropriate fork (Clojure 1.10.0 or later) is provided."))
     (when-not (and lein-version-ok? clojure-version-ok?)
       (lein/warn "Warning: cider-nrepl will not be included in your project."))
 

--- a/test/clj/cider/nrepl/plugin_test.clj
+++ b/test/clj/cider/nrepl/plugin_test.clj
@@ -15,5 +15,5 @@
     (is (= expected-output
            (middleware {:dependencies [['org.clojure/clojure]]}))))
   (testing "defined versions also work"
-    (is (= (update-in expected-output [:dependencies 0] conj "1.10.3")
-           (middleware {:dependencies [['org.clojure/clojure "1.10.3"]]})))))
+    (is (= (update-in expected-output [:dependencies 0] conj "1.10.0")
+           (middleware {:dependencies [['org.clojure/clojure "1.10.0"]]})))))

--- a/test/common/cider_nrepl/plugin_test.clj
+++ b/test/common/cider_nrepl/plugin_test.clj
@@ -17,7 +17,7 @@
   (binding [lein/*info* false]
     (with-redefs [lein/leiningen-version (constantly (plugin/minimum-versions :lein))]
       (testing "Valid Lein version; valid Clojure version"
-        (let [project (plugin/middleware '{:dependencies [[org.clojure/clojure "1.10.3"]]})]
+        (let [project (plugin/middleware '{:dependencies [[org.clojure/clojure "1.10.0"]]})]
           (is (contains-cider-nrepl-dep? project))
           (is (contains-cider-nrepl-middleware? project))))
 
@@ -39,7 +39,7 @@
 
     (with-redefs [lein/leiningen-version (constantly "2.5.1")]
       (testing "Invalid Lein version; valid Clojure version"
-        (let [project (plugin/middleware '{:dependencies [[org.clojure/clojure "1.10.3"]]})]
+        (let [project (plugin/middleware '{:dependencies [[org.clojure/clojure "1.10.0"]]})]
           (is (not (contains-cider-nrepl-dep? project)))
           (is (not (contains-cider-nrepl-middleware? project)))))
 


### PR DESCRIPTION
Turns out, it was a bad idea to set the minimal Clojure version to `1.10.3` - a patch version that was released much later than the original 1.10.0. Since we don't really care as long as it's 1.10, I propose to reduce the requirement.
Context: https://clojurians.slack.com/archives/C0617A8PQ/p1718210427715849