### PR TITLE
Don't apply indentation inference for `:style/indent nil` metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+## Bugs fixed
+
+* [CIDER#3684](https://github.com/clojure-emacs/cider/issues/3684): Don't apply indentation inference for `:style/indent nil` metadata.
+
 ## 0.49.0 (2024-06-02)
 
 ### Changes

--- a/src/cider/nrepl/middleware/track_state.clj
+++ b/src/cider/nrepl/middleware/track_state.clj
@@ -31,8 +31,8 @@
   [m]
   (and (:macro m)
        (:arglists m)
-       (not (:style/indent m))
-       (not (:indent m))
+       (not (contains? m :style/indent))
+       (not (contains? m :indent))
        (if-let [namespace-name (some-> (cond
                                          (instance? Namespace (:ns m)) ;; JVM clojure
                                          (-> m :ns ns-name)

--- a/test/clj/cider/nrepl/middleware/track_state_test.clj
+++ b/test/clj/cider/nrepl/middleware/track_state_test.clj
@@ -208,6 +208,7 @@
 (defmacro macro-without-style-indent-1 [opts & body])
 (defmacro macro-without-style-indent-2 [opts body])
 (defmacro macro-without-style-indent-3 [opts baddy])
+(defmacro macro-with-explicitly-nil-style-indent {:style/indent nil} [opts & body])
 
 (def mock-msg (reify nrepl.transport/Transport
                 (recv [this])
@@ -226,7 +227,9 @@
       (is (= "1"
              (-> interns (get 'macro-without-style-indent-2) :style/indent)))
       (is (= nil
-             (-> interns (get 'macro-without-style-indent-3) :style/indent))))))
+             (-> interns (get 'macro-without-style-indent-3) :style/indent)))
+      (is (= nil
+             (-> interns (get 'macro-with-explicitly-nil-style-indent) :style/indent))))))
 
 (deftest inferrable-indent?-test
   (testing "clojure.* macros are not inferrable"


### PR DESCRIPTION
> Fixes https://github.com/clojure-emacs/cider/issues/3684
