### PR TITLE
Fully evaluate lazy seqs when macroexpanding

### DIFF
--- a/src/cider/nrepl/middleware/macroexpand.clj
+++ b/src/cider/nrepl/middleware/macroexpand.clj
@@ -121,7 +121,8 @@
                     @clojure.lang.Compiler/LOADER)}
     (->> (let [expander-fn (resolve-expander-clj expander)]
            (binding [*ns* (find-ns ns)]
-             (expander-fn (read-string code))))
+             ;; Ensure that lazy seqs are evaluated with correct dynamic bindings
+             (doall (expander-fn (read-string code)))))
          (walk/prewalk (post-expansion-walker-clj msg)))))
 
 ;; ClojureScript impl
@@ -211,7 +212,7 @@
     (walk/prewalk (post-expansion-walker-cljs msg)
                   (cljs/with-cljs-env msg
                     (cljs/with-cljs-ns ns
-                      (expander-fn code))))))
+                      (doall (expander-fn code)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/test/clj/cider/nrepl/middleware/macroexpand_test.clj
+++ b/test/clj/cider/nrepl/middleware/macroexpand_test.clj
@@ -76,6 +76,21 @@
       (is (= #{"done" "macroexpand-error"} status))
       (is pp-stacktrace))))
 
+(defmacro ^:private lazy-test-macro []
+  `(list ~@(lazy-seq [(ns-name *ns*)])))
+
+(deftest dynamic-binding-test
+  (testing "macroexpansion uses correct *ns* binding"
+    (let [{:keys [expansion status]}
+          (session/message {:op "macroexpand"
+                            :expander "macroexpand"
+                            :ns "cider.nrepl.middleware.macroexpand-test"
+                            :code "(lazy-test-macro)"
+                            :display-namespaces "none"})]
+      (is (= "(list cider.nrepl.middleware.macroexpand-test)"
+             expansion))
+      (is (= #{"done"} status)))))
+
 ;; Tests for the three possible values of the display-namespaces option:
 ;; "qualified", "none" and "tidy"
 


### PR DESCRIPTION
Fixes #886

Note: I also added a `doall` in what seemed like the right spot for the cljs expander, but wasn't able to easily test whether it had any effect. There's no existing test coverage for that code path so I'm fine with removing it in case it breaks anything.


---
Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [ ] You've updated the README
- [ ] Middleware documentation is up to date
  * Please check out and modify the `cider.nrepl` ns which has all middleware documentation.
  * Run `lein docs` afterwards, and commit the results.

Thanks!
