### PR TITLE
[complete] Bump Compliment to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* Bump `compliment` to [0.6.0](https://github.com/alexander-yakushev/compliment/blob/master/CHANGELOG.md#060-2024-08-13).
+
 ## 0.49.2 (2024-07-19)
 
 ### Changes

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
                  ^:inline-dep [thunknyc/profile "0.5.2"]
                  ^:inline-dep [mvxcvi/puget "1.3.4" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [fipp ~fipp-version] ; can be removed in unresolved-tree mode
-                 ^:inline-dep [compliment "0.5.5"]
+                 ^:inline-dep [compliment "0.6.0"]
                  ^:inline-dep [org.rksm/suitable "0.6.2" :exclusions [org.clojure/clojure
                                                                       org.clojure/clojurescript]]
                  ^:inline-dep [cljfmt "0.9.2" :exclusions [org.clojure/clojurescript]]

--- a/test/clj/cider/nrepl/middleware/complete_test.clj
+++ b/test/clj/cider/nrepl/middleware/complete_test.clj
@@ -55,7 +55,16 @@
                                      :extra-metadata ["arglists" "doc"]})
           candidate (first (:completions response))]
       (is (= '("[name & opts+sigs]") (:arglists candidate)))
-      (is (string? (:doc candidate))))))
+      (is (string? (:doc candidate)))))
+
+  (testing "Clojure 1.12 qualified methods"
+    (when (or (> (:major *clojure-version*) 1)
+              (>= (:minor *clojure-version*) 12))
+      (let [response (session/message {:op "complete"
+                                       :ns "user"
+                                       :prefix "Thread/.int"})]
+        (is (= {:candidate "Thread/.interrupt", :type "method"}
+               (first (:completions response))))))))
 
 (deftest complete-doc-test
   (testing "blank"


### PR DESCRIPTION
This version brings new 1.12 completions for class members like `Thread/.interrupt` or `Thread/new`.
