### PR TITLE
Exclude tools.cli from dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,8 @@ dump-version:
 .inline-deps: project.clj clean
 	rm -f .no-mranderson
 	lein with-profile -user,-dev inline-deps
+# Remove cljfmt.main because it depends on tools.cli which we explicitly removed.
+	rm -f target/srcdeps/cider/nrepl/inlined/deps/cljfmt/*/cljfmt/main.clj
 	touch $@
 
 test_impl: $(TEST_RUNNER_SOURCE_DIR) test/resources/cider/nrepl/clojuredocs/export.edn

--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,8 @@
                  ^:inline-dep [compliment "0.6.0"]
                  ^:inline-dep [org.rksm/suitable "0.6.2" :exclusions [org.clojure/clojure
                                                                       org.clojure/clojurescript]]
-                 ^:inline-dep [cljfmt "0.9.2" :exclusions [org.clojure/clojurescript]]
+                 ^:inline-dep [cljfmt "0.9.2" :exclusions [org.clojure/clojurescript
+                                                           org.clojure/tools.cli]]
                  ~(with-meta '[org.clojure/tools.namespace "1.3.0"]
                     ;; :cognitest uses tools.namespace, so we cannot inline it while running tests.
                     {:inline-dep (not= "true" (System/getenv "SKIP_INLINING_TEST_DEPS"))})


### PR DESCRIPTION
Tools.cli is brought by cljfmt. In cljfmt, it's only used in `cljfmt.main` namespace to parse args in the main entrypoint. We don't touch that namespace in cider-nrepl, so it should be safe to drop this dependency.

https://github.com/search?q=repo%3Aweavejester%2Fcljfmt%20tools.cli&type=code