### PR TITLE
[trace] Replace clojure.tools.trace with orchard.trace

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/clojure-emacs/cider-nrepl"}
   :dependencies [[nrepl "1.1.1" :exclusions [org.clojure/clojure]]
-                 [cider/orchard "0.26.2" :exclusions [org.clojure/clojure]]
+                 [cider/orchard "0.26.3" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [mx.cider/haystack "0.3.3" :exclusions [cider/orchard]]
                  ^:inline-dep [thunknyc/profile "0.5.2"]
                  ^:inline-dep [mvxcvi/puget "1.3.4" :exclusions [org.clojure/clojure]]
@@ -21,7 +21,6 @@
                     ;; :cognitest uses tools.namespace, so we cannot inline it while running tests.
                     {:inline-dep (not= "true" (System/getenv "SKIP_INLINING_TEST_DEPS"))})
                  ^:inline-dep [io.github.tonsky/clj-reload "0.6.0" :exclusions [org.clojure/clojure]]
-                 ^:inline-dep [org.clojure/tools.trace "0.8.0"]
                  ^:inline-dep [org.clojure/tools.reader "1.4.1"]
                  [mx.cider/logjam "0.3.0" :exclusions [org.clojure/clojure]]]
    ; see Clojure version matrix in profiles below

--- a/src/cider/nrepl/middleware/trace.clj
+++ b/src/cider/nrepl/middleware/trace.clj
@@ -1,7 +1,7 @@
 (ns cider.nrepl.middleware.trace
   (:require
    [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
-   [clojure.tools.trace :as trace]))
+   [orchard.trace :as trace]))
 
 (defn toggle-trace-var
   [{:keys [ns sym]}]
@@ -20,12 +20,10 @@
 (defn toggle-trace-ns
   [{:keys [ns]}]
   (if-let [ns (find-ns (symbol ns))]
-    (if (contains? @traced-ns ns)
-      (do (trace/untrace-ns ns)
-          (swap! traced-ns disj ns)
+    (if (contains? @@#'trace/traced-nses ns)
+      (do (trace/untrace-ns* ns)
           {:ns-status "untraced"})
-      (do (trace/trace-ns ns)
-          (swap! traced-ns conj ns)
+      (do (trace/trace-ns* ns)
           {:ns-status "traced"}))
     {:ns-status "not-found"}))
 

--- a/src/cider/nrepl/middleware/util/meta.clj
+++ b/src/cider/nrepl/middleware/util/meta.clj
@@ -8,7 +8,7 @@
   This is used so that we don't crowd the ns cache with useless or
   redudant information, such as :name and :ns."
   [:indent :deprecated :macro :arglists :test :doc :fn
-   :cider/instrumented :style/indent :clojure.tools.trace/traced])
+   :cider/instrumented :style/indent :orchard.trace/traced])
 
 (defn relevant-meta
   "Filter the entries in map m by `relevant-meta-keys` and non-nil values."

--- a/test/clj/cider/nrepl/middleware/trace_test.clj
+++ b/test/clj/cider/nrepl/middleware/trace_test.clj
@@ -26,9 +26,9 @@
 (deftest toggle-trace-ns-test
   (testing "toggling"
     (is (= {:ns-status "traced"}
-           (toggle-trace-ns {:ns "clojure.core"})))
+           (toggle-trace-ns {:ns "orchard.inspect"})))
     (is (= {:ns-status "untraced"}
-           (toggle-trace-ns {:ns "clojure.core"}))))
+           (toggle-trace-ns {:ns "orchard.inspect"}))))
 
   (testing "toggle-trace-ns-op missing ns should return `not-found`"
     (is (= {:ns-status "not-found"}


### PR DESCRIPTION
Nothing changes on cider-nrepl API side. DId a small blunder of not publicly exposing `traced-nses` in some form from `orchard.trace`, will fix that in the next iteration. 

---
- [ ] You've updated the README