### PR TITLE
[macroexpand] Make macroexpand mw delegate the expansion to eval

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,9 +62,9 @@ commands:
         default: "1"
     steps:
       - run:
-          name: Install wget, git, and node
+          name: Install node
           command: |
-            apt-get update && apt-get install -y git nodejs wget
+            apt-get update && apt-get install -y nodejs
       - run:
           name: Generate Cache Checksum
           command: |
@@ -78,8 +78,6 @@ commands:
       - save_cache:
           paths:
             - ~/.m2
-            - linux-install-1.10.3.1040.sh
-            - clojure-tools-1.10.3.1040.tar.gz
             - .cpcache
           key: clojure-<< parameters.cache_version >>-{{ checksum "/tmp/clojure_cache_seed" }}
 
@@ -145,18 +143,6 @@ jobs:
             - run:
                 name: Running tests with inlined deps
                 command: PARSER_TARGET=<< parameters.parser_target >> make --debug << parameters.test_command >>
-            - run:
-                name: Install the Clojure CLI
-                command: |
-                  # the `nc` option skips downloading a file as already present
-                  # (as allowed by the Circle caching).
-                  wget -nc https://download.clojure.org/install/linux-install-1.10.3.1040.sh
-                  sed -i 's/curl -O/wget -nc/g' linux-install-1.10.3.1040.sh
-                  chmod +x linux-install-1.10.3.1040.sh
-                  ./linux-install-1.10.3.1040.sh
-            - run:
-                name: Running tests specific to tools.deps
-                command: make tools-deps-test
 
 # The ci-test-matrix does the following:
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 * [#893](https://github.com/clojure-emacs/cider-nrepl/pull/893): Replace `clojure.tools.trace` with `orchard.trace`.
+* [#894](https://github.com/clojure-emacs/cider-nrepl/pull/894): Delegate actual macroexpansion to "eval" command in middleware.macroexpand.
 * Bump `orchard` to [0.26.3](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0263-2024-08-14).
 
 ## 0.49.3 (2024-08-13)

--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,6 @@ quick-test: clean test_impl
 
 fast-test: quick-test
 
-tools-deps-test: clean install
-	cd tools-deps-testing; clojure -M:test
-
 eastwood:
 	lein with-profile -user,-dev,+$(CLOJURE_VERSION),+deploy,+eastwood eastwood
 

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -529,11 +529,12 @@ if applicable, and re-render the updated value."
   (cljs/requires-piggieback
    {:doc "Macroexpansion middleware."
     :requires #{#'session}
+    :expects #{"eval"}
     :handles {"macroexpand"
               {:doc "Produces macroexpansion of some form using the given expander."
                :requires {"code" "The form to macroexpand."}
                :optional {"ns" "The namespace in which to perform the macroexpansion. Defaults to 'user for Clojure and 'cljs.user for ClojureScript."
-                          "expander" "The macroexpansion function to use. Possible values are \"macroexpand-1\", \"macroexpand\", or \"macroexpand-all\". Defaults to \"macroexpand\"."
+                          "expander" "The macroexpansion function to use. Possible values are \"macroexpand-1\", \"macroexpand\", \"macroexpand-step\", or \"macroexpand-all\". Defaults to \"macroexpand\"."
                           "display-namespaces" "How to print namespace-qualified symbols in the result. Possible values are \"qualified\" to leave all namespaces qualified, \"none\" to elide all namespaces, or \"tidy\" to replace namespaces with their aliases in the given namespace. Defaults to \"qualified\"."
                           "print-meta" "If truthy, also print metadata of forms."}
                :returns {"expansion" "The macroexpanded form."}}}}))

--- a/test/clj/cider/nrepl/middleware/macroexpand_test.clj
+++ b/test/clj/cider/nrepl/middleware/macroexpand_test.clj
@@ -76,6 +76,21 @@
       (is (= #{"done" "macroexpand-error"} status))
       (is pp-stacktrace))))
 
+(defmacro ^:private lazy-test-macro []
+  `(list {:a ~@(lazy-seq [(ns-name *ns*)])}))
+
+(deftest lazy-expand-test
+  (testing "lazy macroexpansion expands in the correct namespace"
+    (let [{:keys [expansion status]}
+          (session/message {:op "macroexpand"
+                            :expander "macroexpand"
+                            :ns "cider.nrepl.middleware.macroexpand-test"
+                            :code "(lazy-test-macro)"
+                            :display-namespaces "none"})]
+      (is (= "(list {:a cider.nrepl.middleware.macroexpand-test})"
+             expansion))
+      (is (= #{"done"} status)))))
+
 ;; Tests for the three possible values of the display-namespaces option:
 ;; "qualified", "none" and "tidy"
 

--- a/tools-deps-testing/deps.edn
+++ b/tools-deps-testing/deps.edn
@@ -1,5 +1,0 @@
-{:paths ["."]
- :aliases {:test {:main-opts ["-m" "macroexpand-tools-deps-test"]
-                 :jvm-opts    ["-XX:-OmitStackTraceInFastThrow"
-                               "-Dclojure.main.report=stderr"]}}
- :deps {cider/cider-nrepl {:mvn/version "RELEASE"}}}

--- a/tools-deps-testing/example.clj
+++ b/tools-deps-testing/example.clj
@@ -1,6 +1,0 @@
-(ns example)
-
-(defmacro foo []
-  (println (class @clojure.lang.Compiler/LOADER))
-  (assert (not (instance? clojure.lang.Var$Unbound @clojure.lang.Compiler/LOADER)))
-  42)

--- a/tools-deps-testing/macroexpand_tools_deps_test.clj
+++ b/tools-deps-testing/macroexpand_tools_deps_test.clj
@@ -1,9 +1,0 @@
-(ns macroexpand-tools-deps-test
-  (:require
-   [example]
-   [cider.nrepl.middleware.macroexpand]))
-
-(defn -main [& _]
-  (println (cider.nrepl.middleware.macroexpand/macroexpansion {:ns 'example
-                                                               :code "(foo)"}))
-  (System/exit 0))


### PR DESCRIPTION
This PR is a quite significant do-over of macroexpansion middleware.

The current implementation of CLJ macroexpander performs the expansion in the "middleware context". Because of that, the middleware has to carefully recreate an eval-like context (bind `*ns*`, ensure `LOADER` is bound), and problems like #886 still fall through. But we already have the eval-like context set up in the interruptible-eval middleware. This approach is already used by the `inspect` middleware for the initial inspector start command – it is a flavor of `eval` message that is intercepted by inspect mw on its way out.

I propose to do the same for macroexpansion – let the `eval` mw perform the expansion with all the correct dynamic bindings and context, just like if the user typed `(macroexpand 'form)` at the REPL. Then, intercept the resulting form and perform the "middleware work" (pretty printing, tidying up symbols) in the "middleware context".

---

- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] Middleware documentation is up to date