### PR TITLE
Bump Orchard to 0.27.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ commands:
       files:
         description: Files to consider when creating the cache key
         type: string
-        default: "deps.edn project.clj build.boot"
+        default: "deps.edn project.clj"
       cache_version:
         type: string
         description: "Change this value to force a cache update"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 * [#893](https://github.com/clojure-emacs/cider-nrepl/pull/893): Replace `clojure.tools.trace` with `orchard.trace`.
 * [#894](https://github.com/clojure-emacs/cider-nrepl/pull/894): Delegate actual macroexpansion to "eval" command in middleware.macroexpand.
-* Bump `orchard` to [0.26.3](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0263-2024-08-14).
+* Bump `orchard` to [0.27.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0270-2024-08-21).
+  - BREAKING: Remove special handling of Boot classpath.
 
 ## 0.49.3 (2024-08-13)
 

--- a/doc/modules/ROOT/pages/usage.adoc
+++ b/doc/modules/ROOT/pages/usage.adoc
@@ -2,10 +2,9 @@
 
 == Prerequisites
 
-`cider-nrepl` supports only Clojure(Script) 1.9+ and Java 8+.
+`cider-nrepl` supports only Clojure(Script) 1.10+ and Java 8+.
 
 Leiningen users will need to have version 2.8.3 or newer installed.
-Boot users will need to have version 2.8.2 or newer installed.
 
 == Via Leiningen
 

--- a/project.clj
+++ b/project.clj
@@ -105,9 +105,7 @@
                     :jvm-opts ["-Djava.util.logging.config.file=test/resources/logging.properties"
                                "-Dcider.internal.testing=true"]
                     :resource-paths ["test/resources"]
-                    :dependencies [[boot/base "2.8.3"]
-                                   [boot/core "2.8.3" :exclusions [org.tcrawley/dynapath]]
-                                   ;; 1.3.7 and 1.4.7 are working, but we need 1.3.7 for JDK8
+                    :dependencies [;; 1.3.7 and 1.4.7 are working, but we need 1.3.7 for JDK8
                                    [ch.qos.logback/logback-classic "1.3.7"]
                                    [org.clojure/test.check "1.1.1"]
                                    [org.apache.httpcomponents/httpclient "4.5.14" :exclusions [commons-logging]]
@@ -179,7 +177,7 @@
              :eastwood [:test
                         {:plugins [[jonase/eastwood "1.4.0"]]
                          :eastwood {:config-files ["eastwood.clj"]
-                                    :exclude-namespaces [cider.nrepl.middleware.test-filter-tests]
+                                    :exclude-namespaces [cider.nrepl.middleware.test-filter-tests cider.tasks]
                                     :ignored-faults {:unused-ret-vals-in-try {cider.nrepl.middleware.profile-test [{:line 25}]}
                                                      :suspicious-test {cider.nrepl.middleware.profile-test [{:line 25}]}}}}]
 

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/clojure-emacs/cider-nrepl"}
   :dependencies [[nrepl "1.1.1" :exclusions [org.clojure/clojure]]
-                 [cider/orchard "0.26.3" :exclusions [org.clojure/clojure]]
+                 [cider/orchard "0.27.0" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [mx.cider/haystack "0.3.3" :exclusions [cider/orchard]]
                  ^:inline-dep [thunknyc/profile "0.5.2"]
                  ^:inline-dep [mvxcvi/puget "1.3.4" :exclusions [org.clojure/clojure]]

--- a/test/clj/cider/nrepl/middleware/info_test.clj
+++ b/test/clj/cider/nrepl/middleware/info_test.clj
@@ -329,18 +329,14 @@
         (is (= "#{:public}" (:modifiers individual)))))
 
     (testing "Boot support"
-      (try
-        (System/setProperty "fake.class.path" (System/getProperty "java.class.path"))
-        (let [response (session/message {:op "info" :sym "as->" :ns "user"})]
-          (is (= #{"done"} (:status response))
-              (pr-str response))
-          (is (= "clojure.core" (:ns response)))
-          (is (= "as->" (:name response)))
-          (is (= "[expr name & forms]" (:arglists-str response)))
-          (is (= "true" (:macro response)))
-          (is (-> response ^String (:doc) (.startsWith "Binds name to expr, evaluates"))))
-        (finally
-          (System/clearProperty "fake.class.path"))))
+      (let [response (session/message {:op "info" :sym "as->" :ns "user"})]
+        (is (= #{"done"} (:status response))
+            (pr-str response))
+        (is (= "clojure.core" (:ns response)))
+        (is (= "as->" (:name response)))
+        (is (= "[expr name & forms]" (:arglists-str response)))
+        (is (= "true" (:macro response)))
+        (is (-> response ^String (:doc) (.startsWith "Binds name to expr, evaluates")))))
 
     (testing "get protocol info"
       (let [reply       (session/message {:op "info"


### PR DESCRIPTION
Removed "Boot testing" section from tests – this looks like some leftover because it doesn't seem to me like it tests anything Boot-specific (or touches Boot at all).

Removed boot jars from `:test` profile – looks like this was meant for Eastwood to check `cider.tasks`.

`cider.tasks` for adding cider-nrepl to `boot repl` task still remains.