### PR TITLE
Redo testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,9 +62,9 @@ commands:
         default: "1"
     steps:
       - run:
-          name: Install node
+          name: Install packages
           command: |
-            apt-get update && apt-get install -y nodejs
+            apt-get update && apt-get install -y wget nodejs unzip zip
       - run:
           name: Generate Cache Checksum
           command: |
@@ -79,6 +79,7 @@ commands:
           paths:
             - ~/.m2
             - .cpcache
+            - base-src.zip
           key: clojure-<< parameters.cache_version >>-{{ checksum "/tmp/clojure_cache_seed" }}
 
 # The jobs are relatively simple. One runs utility commands against
@@ -98,7 +99,7 @@ jobs:
     steps:
       - checkout
       - with_cache:
-          cache_version: "util_v1_1.11.4"
+          cache_version: "util_v3_1.11.4"
           steps: << parameters.steps >>
 
   deploy:
@@ -115,7 +116,7 @@ jobs:
          command: |
            lein with-profile -user,+deploy run -m deploy-release make deploy
 
-  test_code:
+  test:
     description: |
       Run tests against given version of JDK and Clojure
     parameters:
@@ -128,21 +129,23 @@ jobs:
       parser_target:
         description: The Orchard Java parser to be exercised
         type: string
-      test_command:
-        description: The command to run
-        type: string
+        default: parser
     executor: << parameters.jdk_version >>
     environment:
       CLOJURE_VERSION: << parameters.clojure_version >>
+      PARSER_TARGET: << parameters.parser_target >>
       PROJECT_VERSION: 999.99.9
     steps:
       - checkout
       - with_cache:
-          cache_version: "test_code_v1_<< parameters.clojure_version >>"
+          cache_version: "test_code_v3_<< parameters.clojure_version >>"
           steps:
             - run:
                 name: Running tests with inlined deps
-                command: PARSER_TARGET=<< parameters.parser_target >> make --debug << parameters.test_command >>
+                command: make --debug test
+            - run:
+                name: Running smoketest
+                command: make --debug smoketest
 
 # The ci-test-matrix does the following:
 #
@@ -157,29 +160,28 @@ workflows:
   version: 2.1
   ci-test-matrix:
     jobs:
-      - test_code:
+      - test:
+          # Regular tests for all Clojure and JDK versions (except JDK21, see
+          # below). This matrix doesn't perform parser tests because we don't
+          # have JDK sources here.
           matrix:
-            alias: "test_code_jdk8"
+            alias: "test"
             parameters:
               clojure_version: ["1.10", "1.11", "1.12"]
-              jdk_version: [jdk8]
-              # It doesn't make sense to exercise the newer Orchard Java parsers against JDK8
-              # (given that JDK8 is explicitly excluded by those parsers)
-              parser_target: ["legacy-parser"]
-              test_command: ["test", "smoketest"]
+              jdk_version: [jdk8, jdk11, jdk17, jdk22]
           filters:
             branches:
               only: /.*/
             <<: *tags_filter
-      - test_code:
+      - test:
+          # We have source for JDK21, so with this JDK version we also perform
+          # Java parser tests (for both regular parser and parser-next).
           matrix:
-            alias: "test_code"
+            alias: "test_with_sources"
             parameters:
               clojure_version: ["1.10", "1.11", "1.12"]
-              jdk_version: [jdk11, jdk17, jdk21, jdk22]
-              # Don't test legacy parser on JDK11+ since it is never invoked there.
-              parser_target: ["parser-next", "parser"]
-              test_command: ["test", "smoketest"]
+              jdk_version: [jdk21]
+              parser_target: ["parser", "parser-next"]
           filters:
             branches:
               only: /.*/
@@ -206,8 +208,8 @@ workflows:
                   make eastwood
       - deploy:
           requires:
-            - "test_code"
-            - "test_code_jdk8"
+            - "test"
+            - "test_with_sources"
             - "Code Linting"
           filters:
             branches:

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -24,4 +24,4 @@
            :type-mismatch         {:level :off}
            :unresolved-namespace  {:exclude [clojure.main nrepl.transport js]}}
  :output  {:progress      true
-           :exclude-files ["data_readers" "tasks"]}}
+           :exclude-files ["data_readers" "tasks" "base-src.zip"]}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [#893](https://github.com/clojure-emacs/cider-nrepl/pull/893): Replace `clojure.tools.trace` with `orchard.trace`.
 * [#894](https://github.com/clojure-emacs/cider-nrepl/pull/894): Delegate actual macroexpansion to "eval" command in middleware.macroexpand.
-* Bump `orchard` to [0.27.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0270-2024-08-21).
+* Bump `orchard` to [0.27.1](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0271-2024-08-27).
   - BREAKING: Remove special handling of Boot classpath.
 
 ## 0.49.3 (2024-08-13)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ make repl
 PARSER_TARGET=parser-next make test
 
 # Run tests, without using mranderson (considerably faster)
-PARSER_TARGET=parser-next make fast-test
+PARSER_TARGET=parser-next make quick-test
 
 # Install the project in your local ~/.m2 directory, using mranderson (recommended)
 # The JVM flag is a temporary workaround.

--- a/project.clj
+++ b/project.clj
@@ -51,7 +51,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/clojure-emacs/cider-nrepl"}
   :dependencies [[nrepl "1.1.1" :exclusions [org.clojure/clojure]]
-                 [cider/orchard "0.27.0" :exclusions [org.clojure/clojure]]
+                 [cider/orchard "0.27.1" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [mx.cider/haystack "0.3.3" :exclusions [cider/orchard]]
                  ^:inline-dep [thunknyc/profile "0.5.2"]
                  ^:inline-dep [mvxcvi/puget "1.3.4" :exclusions [org.clojure/clojure]]

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -341,10 +341,6 @@
                   nil
                   vars)))
        (catch Throwable e
-         (when (System/getProperty "cider.internal.testing")
-           ;; print stacktrace, in case it didn't have anything to do with fixtures
-           ;; (in which case, things would become very confusing)
-           (.printStackTrace e))
          (report-fixture-error ns e))))))
 
 (defn test-ns

--- a/test/clj/cider/nrepl/middleware/inspect_test.clj
+++ b/test/clj/cider/nrepl/middleware/inspect_test.clj
@@ -3,9 +3,11 @@
    [matcher-combinators.matchers :as matchers]
    [cider.nrepl.middleware.inspect :as i]
    [cider.nrepl.test-session :as session]
+   [cider.nrepl.middleware.info-test :as info-test]
    [clojure.edn :as edn]
    [clojure.string :as string]
    [clojure.test :refer :all]
+   [orchard.java]
    [orchard.inspect]
    [orchard.info :as info]))
 
@@ -760,8 +762,8 @@
     (is (= 7 @inspect-tap-current-value-test-atom))))
 
 (deftest doc-fragments-test
-  (when (contains? (info/info 'user `Thread/sleep)
-                   :doc-fragments) ;; this test is only runnable with enrich-classpath active
+  ;; This test is only runnable when JDK sources are present and with parser-next.
+  (when (and info-test/jdk-sources-present? @@orchard.java/parser-next-available?)
     (testing "Responses for classes, methods and fields contain `:doc-fragments` attributes"
       (doseq [code ["java.lang.Thread"
                     "(-> java.lang.Thread .getMethods first)"

--- a/test/clj/cider/nrepl/plugin_test.clj
+++ b/test/clj/cider/nrepl/plugin_test.clj
@@ -10,7 +10,7 @@
                   ['cider/cider-nrepl version-string]]
    :repl-options {:nrepl-middleware mw/cider-middleware}})
 
-(deftest ^:cognitest-exclude version-checks
+(deftest version-checks
   (testing "undefined versions work"
     (is (= expected-output
            (middleware {:dependencies [['org.clojure/clojure]]}))))

--- a/test/smoketest/src/smoketest/core.clj
+++ b/test/smoketest/src/smoketest/core.clj
@@ -87,4 +87,5 @@
     (when-not (every? identity results)
       (println "smoketest: FAIL")
       (System/exit 1)))
-  (println "smoketest: OK"))
+  (println "smoketest: OK")
+  (System/exit 0))


### PR DESCRIPTION
This PR gives the same treatment to CI/testing as https://github.com/clojure-emacs/orchard/pull/288.

1. Pull in JDK sources which were missing so that Java parsing capabilities can be tested.
2. Test parsers on JDK21 where we have the sources.
3. Simplify testing setup, remove dependency on enrich-classpath for testing, remove the necessity for Cognitest.
4. Move `smoketest` runs back into every `test` job since it already has sources MrAndersoned. Just don't clean them beforehand, so the smoketest is fast then.

---

- [x] All tests are passing