### PR TITLE
Limited doc update for info op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+[#885 (partial)](https://github.com/clojure-emacs/cider-nrepl/issues/885): Limited update to `info` op doc (`arglists-str`, `file`, `line`, `column`, `name` and `ns` return keys).
+
 ## 0.50.2 (2024-09-03)
 
 * [#900](https://github.com/clojure-emacs/cider-nrepl/pull/900): Fix print middleware interfering with macroexpansion.

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -442,6 +442,8 @@ Returns::
 
 Return a map of information about the specified symbol.
 
+Note: Documentation may be incomplete; not all return keys are described.
+
 Required parameters::
 {blank}
 
@@ -460,9 +462,15 @@ If specified, the value will be concatenated to that of ``orchard.meta/var-meta-
 
 
 Returns::
+* `:arglists-str` The arguments list(s) accepted by the symbol, as a string, if applicable.
+* `:column` The column number where the symbol is defined.
 * `:doc-block-tags-fragments` May be absent. Represent the 'param', 'returns' and 'throws' sections a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-first-sentence-fragments` May be absent. Represents the first sentence of a Java doc comment. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
+* `:file` Either a URI or a relative path where the symbol is defined.
+* `:line` The line number the symbol is defined.
+* `:name` The unqualitfied name of the symbol.
+* `:ns` The namespace the symbol belongs to.
 * `:status` done
 
 
@@ -879,7 +887,7 @@ Required parameters::
 
 Optional parameters::
 * `:display-namespaces` How to print namespace-qualified symbols in the result. Possible values are "qualified" to leave all namespaces qualified, "none" to elide all namespaces, or "tidy" to replace namespaces with their aliases in the given namespace. Defaults to "qualified".
-* `:expander` The macroexpansion function to use. Possible values are "macroexpand-1", "macroexpand", or "macroexpand-all". Defaults to "macroexpand".
+* `:expander` The macroexpansion function to use. Possible values are "macroexpand-1", "macroexpand", "macroexpand-step", or "macroexpand-all". Defaults to "macroexpand".
 * `:ns` The namespace in which to perform the macroexpansion. Defaults to 'user for Clojure and 'cljs.user for ClojureScript.
 * `:print-meta` If truthy, also print metadata of forms.
 

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -469,7 +469,7 @@ Returns::
 * `:doc-fragments` May be absent. Represents the body of a Java doc comment, including the first sentence and excluding any block tags. It's a vector of fragments, where fragment is a map with ``:type`` ('text' or 'html') and ``:content`` plain text or html markup, respectively
 * `:file` Either a URI or a relative path where the symbol is defined.
 * `:line` The line number the symbol is defined.
-* `:name` The unqualitfied name of the symbol.
+* `:name` The unqualified name of the symbol.
 * `:ns` The namespace the symbol belongs to.
 * `:status` done
 

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -296,7 +296,7 @@ Note: Documentation may be incomplete; not all return keys are described."
                                 "column"       "The column number where the symbol is defined."
                                 "file"         "Either a URI or a relative path where the symbol is defined."
                                 "line"         "The line number the symbol is defined."
-                                "name"         "The unqualitfied name of the symbol."
+                                "name"         "The unqualified name of the symbol."
                                 "ns"           "The namespace the symbol belongs to."
                                 "status"       "done"}
                                fragments-doc)}

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -288,9 +288,18 @@ If specified, the value will be concatenated to that of `orchard.meta/var-meta-a
   (cljs/requires-piggieback
    {:requires #{#'session}
     :handles {"info"
-              {:doc "Return a map of information about the specified symbol."
+              {:doc "Return a map of information about the specified symbol.
+
+Note: Documentation may be incomplete; not all return keys are described."
                :optional info-params
-               :returns (merge {"status" "done"} fragments-doc)}
+               :returns (merge {"arglists-str" "The arguments list(s) accepted by the symbol, as a string, if applicable."
+                                "column"       "The column number where the symbol is defined."
+                                "file"         "Either a URI or a relative path where the symbol is defined."
+                                "line"         "The line number the symbol is defined."
+                                "name"         "The unqualitfied name of the symbol."
+                                "ns"           "The namespace the symbol belongs to."
+                                "status"       "done"}
+                               fragments-doc)}
               "eldoc"
               {:doc "Return a map of information about the specified symbol."
                :optional info-params


### PR DESCRIPTION
Hi,

could you please review patch to do limited upated to the `info` op documentation. It partially addresses #885, specifically https://github.com/clojure-emacs/cider-nrepl/issues/885#issuecomment-2356676689.

There are no functional changes. This update provides a reference for the basic usage of `info`, particularly clarifying that the `file` return key value should be either a URI or a relative path.

The new descriptions were determined empirically by examining log messages in CIDER. I'm open to corrections.

(Note: An unexpected `expander` entry appeared in the generated ops doc, which seems to have been missed in #894.)

Thanks

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [ ] You've added tests to cover your change(s)
- [x] All tests are passing
- [ ] You've updated the README
- [x] Middleware documentation is up to date
  * Please check out and modify the `cider.nrepl` ns which has all middleware documentation.
  * Run `lein docs` afterwards, and commit the results.

**Note:** If you're just starting out to hack on `cider-nrepl` you might find
[nREPL's documentation](https://nrepl.org) and the
"Design" section of the README extremely useful.*

Thanks!
