### PR TITLE
[info] Add support for automatically downloading sources JARs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/clojure-emacs/cider-nrepl"}
   :dependencies [[nrepl/nrepl "1.3.1" :exclusions [org.clojure/clojure]]
-                 [cider/orchard "0.29.1" :exclusions [org.clojure/clojure]]
+                 [cider/orchard "0.30.0" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [mx.cider/haystack "0.3.3" :exclusions [cider/orchard]]
                  ^:inline-dep [thunknyc/profile "0.5.2"]
                  ^:inline-dep [mvxcvi/puget "1.3.4" :exclusions [org.clojure/clojure]]

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -57,11 +57,9 @@
   then had to be disabled for test suite reasons in Orchard 0.15.0 to 0.17.0 / cider-nrepl 0.38.0 to 0.41.0, and now it's restored again)
   Note that this can only be done cider-nrepl side, unlike before when it was done in Orchard itself."
   []
-  ;; 1.- Warmup the overall cache for core Java and Clojure stuff
-  @orchard.java/cache-initializer
-  ;; 2.- Also cache classes that are `:import`ed throughout the project.
-  ;;     The class list is obtained through `ns` form analysis,
-  ;;      so that we don't depend on whether the namespaces have been loaded yet:
+  ;; Cache classes that are `:import`ed throughout the project. The class list
+  ;; is obtained through `ns` form analysis, so that we don't depend on whether
+  ;; the namespaces have been loaded yet:
   (doseq [ns-form (vals (orchard.namespace/project-ns-forms))
           class-sym (orchard.namespace/ns-form-imports ns-form)
           :when (try

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -27,7 +27,7 @@
   Having an enforced minimum version can help users and maintainers alike diagnose issues more quickly,
   avoiding problematic code paths in our middleware, and in clients like cider.el."
   {:major 1
-   :minor 9})
+   :minor 10})
 
 ;; Make sure we're running a supported Clojure version
 (when (or (< (-> *clojure-version* :major long)
@@ -37,12 +37,11 @@
                   (-> min-clojure-verion :major long))
                (< (-> *clojure-version* :minor long)
                   (-> min-clojure-verion :minor long))))
-  (try
-    (.println System/err (format "cider-nrepl requires a newer Clojure version (found: %s, minimum required: %s). Exiting."
-                                 *clojure-version*
-                                 min-clojure-verion))
-    (finally
-      (System/exit 1))))
+  (let [msg (format "cider-nrepl requires a newer Clojure version (found: %s, minimum required: %s)."
+                    *clojure-version* min-clojure-verion)]
+    (try
+      (.println System/err msg)
+      (finally (throw (ex-info msg {}))))))
 
 ;; Perform the underlying dynamic `require`s asap, and also not within a
 ;; separate thread (note the `future` used in `#'initializer`), since `require`

--- a/src/cider/nrepl/middleware/track_state.clj
+++ b/src/cider/nrepl/middleware/track_state.clj
@@ -162,9 +162,11 @@
 (def clojure-core-map
   (when clojure-core
     {:aliases {}
-     :interns (->> (ns-map clojure-core)
-                   (filter #(var? (second %)))
-                   (misc/update-vals #(um/relevant-meta (enriched-meta %))))}))
+     :interns (into {}
+                    (keep (fn [[k v]]
+                            (when (var? v)
+                              [k (um/relevant-meta (enriched-meta v))])))
+                    (ns-map clojure-core))}))
 
 (defn calculate-changed-ns-map
   "Return a map of namespaces that changed between new-map and old-map.

--- a/src/cider/nrepl/middleware/util/meta.clj
+++ b/src/cider/nrepl/middleware/util/meta.clj
@@ -13,6 +13,6 @@
 (defn relevant-meta
   "Filter the entries in map m by `relevant-meta-keys` and non-nil values."
   [m]
-  (->> (select-keys m relevant-meta-keys)
-       (filter second)
-       (misc/update-vals pr-str)))
+  (into {}
+        (keep #(when-let [v (get m %)] [% (pr-str v)]))
+        relevant-meta-keys))

--- a/src/cider/nrepl/middleware/xref.clj
+++ b/src/cider/nrepl/middleware/xref.clj
@@ -19,7 +19,8 @@
     {:name (meta/var-name v)
      :doc (meta/var-doc 1 v)
      :file (:file var-meta)
-     :file-url (some-> var-meta :file filename-as-url)
+     :file-url (or (:file-url var-meta)
+                   (some-> var-meta :file filename-as-url))
      :line (:line var-meta)
      :column (:column var-meta)}))
 


### PR DESCRIPTION
Sister PRs: https://github.com/clojure-emacs/orchard/pull/310, https://github.com/clojure-emacs/cider/pull/3769.

Not a lot of changes were needed here. Given how things are implemented on the Orchard side, cider-nrepl only needs to set up a correct `*download-sources-jar-fn*` before calling out to Orchard functions that do Java sources discovery.

We maintain a ConcurrentHashMap (logically, a set, but there is no ConcurrentHashSet, and CHM API for this usecase is cleaner than `(atom #{})`) of Maven coordinates (`groupId/artifactId "version"`) of the dependencies we already tried downloading sources once. If it succeeded, we won't call this function again anyway, if it failed, the CHM will prevent trying for the second time. This debouncer only exists in memory which I suppose makes it easier to retry (by restarting) if the sources failed to download because bad Internet or something, not because the sources JAR does not exist in the repository. If this cache was persistent, retrying will be a bit more involved. Anyway, this may change after user feedback; maybe, there would be frequent annoying cases where certain Java classes wouldn't have sources JAR, and it will be annoying that the first `C-c C-d C-d` on such class is slow after each REPL restart.

We bind `*download-sources-jar-fn*` only in `info` op, not the `eldoc` op. Eldoc is less intentional and much more common, so I don't want to make slow and download things. Counter to that, `info` is invoked by `M-.` or `C-c C-d C-d` where the user explicitly requested something, so it makes sense to attempt downloading then. Until the JAR is downloaded, `eldoc` will simply return results obtained via reflection, after that it will pick up the parsed Javadocs.

---

- [ ] You've added tests to cover your change(s)
- [ ] You've updated the README