### PR TITLE
Sort printed maps in test output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [#913](https://github.com/clojure-emacs/cider-nrepl/pull/913): Disable background warmup of `orchard.java` cache.
 * [#913](https://github.com/clojure-emacs/cider-nrepl/pull/913): Enable background warmup of Compliment cache.
-* TBD-PR: Sort printed maps in test output
+* [#917](https://github.com/clojure-emacs/cider-nrepl/pull/917): Sort printed maps in test output
 
 ## 0.52.1 (2025-02-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#913](https://github.com/clojure-emacs/cider-nrepl/pull/913): Disable background warmup of `orchard.java` cache.
 * [#913](https://github.com/clojure-emacs/cider-nrepl/pull/913): Enable background warmup of Compliment cache.
+* TBD-PR: Sort printed maps in test output
 
 ## 0.52.1 (2025-02-24)
 

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -91,6 +91,11 @@
          x))
      m)
     (catch Exception _
+      ;; Maps with non-comparable keys aren't sortable, so they should be returned as-is.
+      ;; Examples:
+      ;;   {{} 1}
+      ;;   {1 1 :a 1}
+      ;;   {"a" 1 :a 1}
       m)))
 
 (defn- print-object

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -83,15 +83,12 @@
 (defn deep-sorted-maps
   "Recursively converts all nested maps to sorted maps."
   [m]
-  (try
-    (walk/postwalk
-     (fn [x]
-       (if (map? x)
-         (with-meta (into (sorted-map) x) (meta x))
-         x))
-     m)
-    (catch Exception _
-      m)))
+  (walk/postwalk
+   (fn [x]
+     (if (map? x)
+       (with-meta (into (sorted-map) x) (meta x))
+       x))
+   m))
 
 (defn- print-object
   "Print `object` using println for matcher-combinators results and pprint

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -80,7 +80,6 @@
                 (str/starts-with? frame-cname class-name))))
           first))))
 
-
 (defn deep-sorted-maps
   "Recursively converts all nested maps to sorted maps."
   [m]
@@ -93,7 +92,6 @@
      m)
     (catch Exception _
       m)))
-
 
 (defn- print-object
   "Print `object` using println for matcher-combinators results and pprint

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -91,7 +91,7 @@
          x))
      m)
     (catch Exception _
-      ;; Maps with non-comparable keys aren't sortable, so they should be returned as-is.
+      ;; Maps with non-comparable keys aren't sortable so they should be returned as-is.
       ;; Examples:
       ;;   {{} 1}
       ;;   {1 1 :a 1}

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -80,6 +80,21 @@
                 (str/starts-with? frame-cname class-name))))
           first))))
 
+
+(defn deep-sorted-maps
+  "Recursively converts all nested maps to sorted maps."
+  [m]
+  (try
+    (walk/postwalk
+     (fn [x]
+       (if (map? x)
+         (with-meta (into (sorted-map) x) (meta x))
+         x))
+     m)
+    (catch Exception _
+      m)))
+
+
 (defn- print-object
   "Print `object` using println for matcher-combinators results and pprint
    otherwise. The matcher-combinators library uses a custom print-method
@@ -91,7 +106,7 @@
         print-fn (if matcher-combinators-result?
                    println
                    pp/pprint)
-        result (with-out-str (print-fn object))]
+        result (with-out-str (print-fn (deep-sorted-maps object)))]
     ;; Replace extra newlines at the end, as sometimes returned by matchers-combinators:
     (str/replace result #"\n\n+$" "\n")))
 

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -101,6 +101,7 @@
         print-fn (if matcher-combinators-result?
                    println
                    pp/pprint)
+        ;; The output will contain sorted maps for better readability and diff comparisons.
         result (with-out-str (print-fn (deep-sorted-maps object)))]
     ;; Replace extra newlines at the end, as sometimes returned by matchers-combinators:
     (str/replace result #"\n\n+$" "\n")))

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -83,12 +83,15 @@
 (defn deep-sorted-maps
   "Recursively converts all nested maps to sorted maps."
   [m]
-  (walk/postwalk
-   (fn [x]
-     (if (map? x)
-       (with-meta (into (sorted-map) x) (meta x))
-       x))
-   m))
+  (try
+    (walk/postwalk
+     (fn [x]
+       (if (map? x)
+         (with-meta (into (sorted-map) x) (meta x))
+         x))
+     m)
+    (catch Exception _
+      m)))
 
 (defn- print-object
   "Print `object` using println for matcher-combinators results and pprint

--- a/test/clj/cider/nrepl/middleware/test_test.clj
+++ b/test/clj/cider/nrepl/middleware/test_test.clj
@@ -285,7 +285,6 @@ The `988` value reflects that it times things correctly for a slow test.")
     (is (= "{:a 1, :b 2, :c 3, :d {x 1, y 2, z 3}}\n"
            (#'test/print-object {:b 2 :c 3 :a 1 :d {'z 3 'y 2 'x 1}})))))
 
-
 (deftest test-result-test
   (testing "It passes `:error`s to `test/*test-error-handler*`"
     (let [proof (atom [])

--- a/test/clj/cider/nrepl/middleware/test_test.clj
+++ b/test/clj/cider/nrepl/middleware/test_test.clj
@@ -280,7 +280,11 @@ The `988` value reflects that it times things correctly for a slow test.")
         "pprint is chosen, as indicated by quoted strings and newlines")
     (is (= "{:a \"b\", :c \"42\"}\n"
            (#'test/print-object (with-meta {:a "b" :c "42"} {:type ::mismatch})))
-        "pprint is chosen, because :type does not match matchers-combinators keyword")))
+        "pprint is chosen, because :type does not match matchers-combinators keyword"))
+  (testing "maps are printed with sorted keys"
+    (is (= "{:a 1, :b 2, :c 3, :d {x 1, y 2, z 3}}\n"
+           (#'test/print-object {:b 2 :c 3 :a 1 :d {'z 3 'y 2 'x 1}})))))
+
 
 (deftest test-result-test
   (testing "It passes `:error`s to `test/*test-error-handler*`"


### PR DESCRIPTION
Fixes #916 

This PR performs a clojure.walk to covert all maps to sorted-maps when printing an object in the test results. See #916 for example before and after screenshots of the diffed data.


---

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [ ] You've updated the README
- [x] Middleware documentation is up to date
  * Please check out and modify the `cider.nrepl` ns which has all middleware documentation.
  * Run `lein docs` afterwards, and commit the results.

**Note:** If you're just starting out to hack on `cider-nrepl` you might find
[nREPL's documentation](https://nrepl.org) and the
"Design" section of the README extremely useful.*

Thanks!
