### PR TITLE
Haystack to Orchard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## master (unreleased)
 
+* Bump `orchard` to [0.31.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0310-2025-03-14).
+  - Info: recognize printed Java classes/methods and munged Clojure functions in stacktrace outputs.
+  - Add dedicated renderers for exceptions in inspector and debugger.
+* [#919](https://github.com/clojure-emacs/cider-nrepl/pull/919): Move exception analysis to Orchard.
+  - **BREAKING**: Remove `analyze-stacktrace` and `cider/log-analyze-stacktrace` ops.
+  - Stop vendoring Haystack dependency.
 * [#913](https://github.com/clojure-emacs/cider-nrepl/pull/913): Disable background warmup of `orchard.java` cache.
 * [#913](https://github.com/clojure-emacs/cider-nrepl/pull/913): Enable background warmup of Compliment cache.
 * [#914](https://github.com/clojure-emacs/cider-nrepl/pull/914): Remove javadoc section from the inspector output.

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -29,57 +29,6 @@ Returns::
 
 
 
-=== `analyze-stacktrace`
-
-Parse and analyze the ``:stacktrace``
-parameter and return messages describing each cause and stack frame. The
-stacktrace must be a string formatted in one of the following formats:
-
-* ``:aviso`` Stacktraces printed with the
-  https://ioavisopretty.readthedocs.io/en/latest/exceptions.html[write-exception]
-  function of the https://github.com/AvisoNovate/pretty[Aviso] library.
-
-* ``:clojure.tagged-literal`` Stacktraces printed as a tagged literal, like a
-  https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html[java.lang.Throwable]
-  printed with the
-  https://clojure.github.io/clojure/branch-master/clojure.core-api.html#clojure.core/pr[pr]
-  function.
-
-* ``:clojure.stacktrace`` Stacktraces printed with the
-  https://clojure.github.io/clojure/branch-master/clojure.stacktrace-api.html#clojure.stacktrace/print-cause-trace[print-cause-trace]
-  function of the
-  https://clojure.github.io/clojure/branch-master/clojure.stacktrace-api.html[clojure.stacktrace]
-  namespace.
-
-* ``:clojure.repl`` Stacktraces printed with the
-  https://clojure.github.io/clojure/branch-master/clojure.repl-api.html#clojure.repl/pst[pst]
-  function of the
-  https://clojure.github.io/clojure/branch-master/clojure.repl-api.html[clojure.repl]
-  namespace.
-
-* ``:java`` Stacktraces printed with the
-  link:++https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html#printStackTrace--++[printStackTrace]
-  method of
-  https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html[java.lang.Throwable].
-
-Required parameters::
-* `:stacktrace` The stacktrace to be parsed and analyzed as a string.
-
-
-Optional parameters::
-* `:nrepl.middleware.print/buffer-size` The size of the buffer to use when streaming results. Defaults to 1024.
-* `:nrepl.middleware.print/keys` A seq of the keys in the response whose values should be printed.
-* `:nrepl.middleware.print/options` A map of options to pass to the printing function. Defaults to ``nil``.
-* `:nrepl.middleware.print/print` A fully-qualified symbol naming a var whose function to use for printing. Must point to a function with signature [value writer options].
-* `:nrepl.middleware.print/quota` A hard limit on the number of bytes printed for each value.
-* `:nrepl.middleware.print/stream?` If logical true, the result of printing each value will be streamed to the client over one or more messages.
-
-
-Returns::
-* `:status` "done", or "no-error" if ``stracktrace`` is not recognized
-
-
-
 === `apropos`
 
 Return a sequence of vars whose name matches the query pattern, or if specified, having the pattern in their docstring.
@@ -1518,24 +1467,6 @@ Optional parameters::
 Returns::
 * `:status` done
 * `:cider/log-add-consumer` The consumer that was added.
-
-
-
-=== `cider/log-analyze-stacktrace`
-
-Analyze the stacktrace of a log event.
-
-Required parameters::
-* `:appender` The name of the appender.
-* `:event` The id of the event to inspect.
-* `:framework` The id of the log framework.
-
-
-Optional parameters::
-{blank}
-
-Returns::
-* `:status` done
 
 
 

--- a/project.clj
+++ b/project.clj
@@ -21,8 +21,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/clojure-emacs/cider-nrepl"}
   :dependencies [[nrepl/nrepl "1.3.1" :exclusions [org.clojure/clojure]]
-                 [cider/orchard "0.30.1" :exclusions [org.clojure/clojure]]
-                 ^:inline-dep [mx.cider/haystack "0.3.3" :exclusions [cider/orchard]]
+                 [cider/orchard "0.31.0" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [thunknyc/profile "0.5.2"]
                  ^:inline-dep [mvxcvi/puget "1.3.4" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [fipp ~fipp-version] ; can be removed in unresolved-tree mode

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -12,7 +12,6 @@
    [cider.nrepl.middleware.util.cljs :as cljs]
    [cider.nrepl.print-method] ;; we load this namespace, so it's directly available to clients
    [compliment.core :as compliment]
-   [haystack.analyzer :as analyzer]
    [nrepl.middleware :refer [set-descriptor!]]
    [nrepl.middleware.caught :refer [wrap-caught]]
    [nrepl.middleware.print :refer [wrap-print wrap-print-optional-arguments]]
@@ -50,7 +49,6 @@
 ;; shipped with Orchard.
 (try (orchard.java/source-info 'mx.cider.orchard.LruMap)
      (catch Exception _))
-@analyzer/spec-abbrev
 
 (defn warmup-caches!
   "Warm up some of the dependency caches to improve UX performance for first hits.

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -415,13 +415,6 @@ if applicable, and re-render the updated value."
      :returns {"status" "done"
                "cider/log-add-consumer" "The consumer that was added."}}
 
-    "cider/log-analyze-stacktrace"
-    {:doc "Analyze the stacktrace of a log event."
-     :requires {"framework" "The id of the log framework."
-                "appender" "The name of the appender."
-                "event" "The id of the event to inspect."}
-     :returns {"status" "done"}}
-
     "cider/log-clear-appender"
     {:doc "Clear all events of a log appender."
      :requires {"framework" "The id of the log framework."
@@ -708,39 +701,6 @@ Assumes that `analyze-last-stacktrace` has been called first, returning \"no-err
                                         :requires {"index" "0 for inspecting the top-level exception, 1 for its ex-cause, 2 for its ex-cause's ex-cause, and so on."}
                                         :returns {"status" "\"done\", or \"no-error\" if `analyze-last-stacktrace` wasn't called beforehand (or the `index` was out of bounds)."
                                                   "value" "A value, as produced by the Inspector middleware."}}
-              "analyze-stacktrace" {:doc "Parse and analyze the `:stacktrace`
-parameter and return messages describing each cause and stack frame. The
-stacktrace must be a string formatted in one of the following formats:
-
-* `:aviso` Stacktraces printed with the
-  https://ioavisopretty.readthedocs.io/en/latest/exceptions.html[write-exception]
-  function of the https://github.com/AvisoNovate/pretty[Aviso] library.
-
-* `:clojure.tagged-literal` Stacktraces printed as a tagged literal, like a
-  https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html[java.lang.Throwable]
-  printed with the
-  https://clojure.github.io/clojure/branch-master/clojure.core-api.html#clojure.core/pr[pr]
-  function.
-
-* `:clojure.stacktrace` Stacktraces printed with the
-  https://clojure.github.io/clojure/branch-master/clojure.stacktrace-api.html#clojure.stacktrace/print-cause-trace[print-cause-trace]
-  function of the
-  https://clojure.github.io/clojure/branch-master/clojure.stacktrace-api.html[clojure.stacktrace]
-  namespace.
-
-* `:clojure.repl` Stacktraces printed with the
-  https://clojure.github.io/clojure/branch-master/clojure.repl-api.html#clojure.repl/pst[pst]
-  function of the
-  https://clojure.github.io/clojure/branch-master/clojure.repl-api.html[clojure.repl]
-  namespace.
-
-* `:java` Stacktraces printed with the
-  link:++https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html#printStackTrace--++[printStackTrace]
-  method of
-  https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html[java.lang.Throwable]."
-                                    :requires {"stacktrace" "The stacktrace to be parsed and analyzed as a string."}
-                                    :optional wrap-print-optional-arguments
-                                    :returns {"status" "\"done\", or \"no-error\" if `stracktrace` is not recognized"}}
               "stacktrace" {:doc "Return messages describing each cause and
 stack frame of the most recent exception. This op is deprecated, please use the
 `analyze-last-stacktrace` op instead."

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -7,7 +7,6 @@
    [cider.nrepl.middleware.util.cljs :as cljs]
    [cider.nrepl.middleware.util.instrument :as ins]
    [cider.nrepl.middleware.util.nrepl :refer [notify-client]]
-   [haystack.analyzer :as stacktrace.analyzer]
    [nrepl.middleware.interruptible-eval :refer [*msg*]]
    [nrepl.middleware.print :as print]
    [nrepl.misc :refer [response-for]]
@@ -15,7 +14,8 @@
    [orchard.info :as info]
    [orchard.inspect :as inspect]
    [orchard.meta :as m]
-   [orchard.print])
+   [orchard.print]
+   [orchard.stacktrace :as stacktrace])
   (:import
    [clojure.lang Compiler$LocalBinding]
    [java.util UUID]))
@@ -219,7 +219,7 @@ this map (identified by a key), and will `dissoc` it afterwards."}
                     (when-not (instance? ThreadDeath root-ex#)
                       (debugger-send
                        {:status :eval-error
-                        :causes [(let [causes# (stacktrace.analyzer/analyze e# (::print/print-fn *msg*))]
+                        :causes [(let [causes# (stacktrace/analyze e# (::print/print-fn *msg*))]
                                    (when (coll? causes#) (last causes#)))]})))
                   error#))]
      (if (= error# ~sym)
@@ -291,11 +291,11 @@ this map (identified by a key), and will `dissoc` it afterwards."}
   (debugger-send
    {:status :stack
     :causes (if (instance? Throwable value)
-              (stacktrace.analyzer/analyze value (::print/print-fn *msg*))
+              (stacktrace/analyze value (::print/print-fn *msg*))
               [{:class      "StackTrace"
                 :message    "Harmless user-requested stacktrace"
                 :stacktrace (-> (Exception. "Dummy")
-                                (stacktrace.analyzer/analyze (::print/print-fn *msg*))
+                                (stacktrace/analyze (::print/print-fn *msg*))
                                 last :stacktrace)}])}))
 
 (def debug-commands

--- a/src/cider/nrepl/middleware/reload.clj
+++ b/src/cider/nrepl/middleware/reload.clj
@@ -7,11 +7,11 @@
    [clj-reload.core :as reload]
    [clojure.main :refer [repl-caught]]
    [clojure.string :as str]
-   [haystack.analyzer :as analyzer]
    [nrepl.middleware.interruptible-eval :refer [*msg*]]
    [nrepl.middleware.print :as print]
    [nrepl.misc :refer [response-for]]
-   [nrepl.transport :as transport]))
+   [nrepl.transport :as transport]
+   [orchard.stacktrace :as stacktrace]))
 
 (defn- user-reload
   "Resolve clj-reload.core/<sym> from the user project or return fallback."
@@ -56,7 +56,7 @@
                 (respond msg {:status :ok}))
               (catch Throwable error
                 (respond msg {:status :error
-                              :error  (analyzer/analyze error print-fn)})
+                              :error  (stacktrace/analyze error print-fn)})
                 (binding [*msg* msg
                           *err* (print/replying-PrintWriter :err msg {})]
                   (repl-caught error)))))

--- a/src/cider/nrepl/middleware/stacktrace.clj
+++ b/src/cider/nrepl/middleware/stacktrace.clj
@@ -5,7 +5,6 @@
    [cider.nrepl.middleware.util.nrepl :refer [notify-client]]
    [clojure.string :as str]
    [haystack.analyzer :as analyzer]
-   [haystack.parser :as parser]
    [nrepl.middleware.print :as print]
    [cider.nrepl.middleware.inspect :as middleware.inspect]
    [nrepl.misc :refer [response-for]]
@@ -46,23 +45,6 @@
     (no-error msg))
   (done msg))
 
-;; Analyze stacktrace
-
-(defn- analyze-stacktrace
-  "Parse and analyze the `stacktrace`."
-  [{:keys [stacktrace] :as msg}]
-  (if-let [analysis (some-> stacktrace parser/parse analyzer/analyze)]
-    (send-analysis msg analysis)
-    (no-error msg)))
-
-(defn- handle-analyze-stacktrace-op
-  "Handle the analyze stacktrace op."
-  [{:keys [stacktrace] :as msg}]
-  (if (not (str/blank? stacktrace))
-    (analyze-stacktrace msg)
-    (no-error msg))
-  (done msg))
-
 ;; Stacktrace
 
 (defn- handle-stacktrace-op
@@ -93,5 +75,4 @@
   (case op
     "analyze-last-stacktrace" (handle-analyze-last-stacktrace-op msg)
     "inspect-last-exception"  (handle-inspect-last-exception-op msg)
-    "analyze-stacktrace"      (handle-analyze-stacktrace-op msg)
     "stacktrace"              (handle-stacktrace-op msg)))

--- a/src/cider/nrepl/middleware/util/error_handling.clj
+++ b/src/cider/nrepl/middleware/util/error_handling.clj
@@ -20,7 +20,7 @@
 
 (def ^:private analyze-causes
   (delay
-    (requiring-resolve 'haystack.analyzer/analyze)))
+    (requiring-resolve 'orchard.stacktrace/analyze)))
 
 ;;; UTILITY FUNCTIONS
 

--- a/src/cider/nrepl/middleware/util/reload.clj
+++ b/src/cider/nrepl/middleware/util/reload.clj
@@ -3,12 +3,12 @@
   {:added "0.47.0"}
   (:require
    [clojure.main :refer [repl-caught]]
-   [haystack.analyzer :as stacktrace.analyzer]
    [nrepl.middleware.interruptible-eval :refer [*msg*]]
    [nrepl.middleware.print :as print]
    [nrepl.misc :refer [response-for]]
    [nrepl.transport :as transport]
-   [orchard.misc :as misc]))
+   [orchard.misc :as misc]
+   [orchard.stacktrace :as stacktrace]))
 
 (defn error-reply
   [{:keys [error error-ns]}
@@ -17,7 +17,7 @@
   (transport/send
    transport
    (response-for msg (cond-> {:status :error}
-                       error (assoc :error (stacktrace.analyzer/analyze error print-fn))
+                       error (assoc :error (stacktrace/analyze error print-fn))
                        error-ns (assoc :error-ns error-ns))))
 
   (binding [*msg* msg

--- a/test/clj/cider/nrepl/middleware/log_test.clj
+++ b/test/clj/cider/nrepl/middleware/log_test.clj
@@ -111,26 +111,6 @@
       ;; TODO: How to receive the async log event?
       )))
 
-(deftest test-analyze-stacktrace
-  (with-each-framework [framework (frameworks)]
-    (with-appender [framework appender]
-      (framework/log framework {:message "a-1" :exception (ex-info "BOOM" {:some (Object.)})})
-      (let [events (search-events framework appender {})]
-        (is (= 1 (count events)))
-        (let [event (first events)]
-          (is (uuid-str? (:id event)))
-          (is (string? (:level event)))
-          (is (string? (:logger event)))
-          (is (= "a-1" (:message event)))
-          (is (int? (:timestamp event)))
-          (let [response (session/message {:op "cider/log-analyze-stacktrace"
-                                           :framework (:id framework)
-                                           :appender (:id appender)
-                                           :event (:id event)})]
-            (is (= #{"done"} (:status response)))
-            (is (every? #(set/subset? #{:type :flags} (set (keys %)))
-                        (:stacktrace response)))))))))
-
 (deftest test-clear
   (with-each-framework [framework (frameworks)]
     (with-appender [framework appender]

--- a/test/clj/cider/nrepl/middleware/stacktrace_test.clj
+++ b/test/clj/cider/nrepl/middleware/stacktrace_test.clj
@@ -63,21 +63,3 @@
     (let [response (session/message {:op "analyze-last-stacktrace"})]
       (testing "returns done and no-error status"
         (is (= #{"done" "no-error"} (:status response)))))))
-
-;; Analyze stacktrace op
-
-(deftest analyze-stacktrace-test
-  (testing "stacktrace op with stacktrace parameter"
-    (let [response (session/message {:op "analyze-stacktrace" "stacktrace" (pr-str (ex-info "BOOM" {:boom :data}))})]
-      (testing "returns the exception class"
-        (is (= "clojure.lang.ExceptionInfo" (:class response))))
-      (testing "returns the exception message"
-        (is (= "BOOM" (:message response))))
-      (testing "returns done status"
-        (is (= #{"done"} (:status response)))))))
-
-(deftest analyze-stacktrace-invalid-test
-  (testing "stacktrace op with invalid stacktrace parameter"
-    (let [response (session/message {:op "analyze-stacktrace" "stacktrace" "invalid"})]
-      (testing "returns done and no-error status"
-        (is (= #{"done" "no-error"} (:status response)))))))

--- a/test/clj/cider/nrepl/middleware/test_test.clj
+++ b/test/clj/cider/nrepl/middleware/test_test.clj
@@ -4,7 +4,9 @@
    [cider.nrepl.test-session :as session]
    [clojure.string :as string]
    [clojure.test :refer :all]
-   [matcher-combinators.clj-test])
+   [matcher-combinators.clj-test]
+   [matcher-combinators.matchers :as matchers]
+   [matcher-combinators.test :refer [match?]])
   (:import
    (clojure.lang ExceptionInfo)))
 
@@ -18,6 +20,11 @@
   ;; expands without errors. (See #264)
   (is (seq (meta #'test/handle-test))))
 
+;; NB! Most tests in this namespace CANNOT be properly run with cider-test
+;; itself because the internal testing results overwrite the outer results! I've
+;; spent a lot of time figuring this out, don't repeat my mistake. Just use
+;; out-of-process testing (lein test) to validate this namespace.
+
 (deftest only-selected-tests
   (testing "only single test is run with test"
     (are [tests] (let [{:keys [results] :as test-result}
@@ -25,8 +32,7 @@
                         {:op "test"
                          :ns "cider.nrepl.middleware.test-filter-tests"
                          :tests (map name tests)})]
-                   (is (= tests (keys (:cider.nrepl.middleware.test-filter-tests results))))
-                   true)
+                   (= tests (keys (:cider.nrepl.middleware.test-filter-tests results))))
       [:a-puff-of-smoke-test]
       [:a-smokey-test]
       [:a-puff-of-smoke-test :a-smokey-test]
@@ -34,106 +40,61 @@
 
 (deftest only-smoke-test-run-test-deprecated
   (testing "only test marked as smoke is run when test-all is used"
-    (let [{:keys [results] :as test-result}
-          (session/message {:op      "test-all"
-                            :include ["smoke"]
-                            :exclude ["integration"]})
-          tests (keys (:cider.nrepl.middleware.test-filter-tests results))]
-      (is ((set (keys results)) :cider.nrepl.middleware.test-filter-tests)
-          "ns that contains smoke is present")
-      (is (= 1 (count tests))
-          "only one test was run")
-      (is (= :a-puff-of-smoke-test (first tests))
-          "only the test marked 'smoke' was run")))
+    (is (match? {:cider.nrepl.middleware.test-filter-tests {:a-puff-of-smoke-test some?}}
+                (:results (session/message {:op      "test-all"
+                                            :include ["smoke"]
+                                            :exclude ["integration"]})))))
 
   (testing "only test marked as smoke is run when test-ns is used"
-    (let [{:keys [results] :as test-result}
-          (session/message {:op      "test"
-                            :ns      "cider.nrepl.middleware.test-filter-tests"
-                            :include ["smoke"]
-                            :exclude ["integration"]})
-          tests (keys (:cider.nrepl.middleware.test-filter-tests results))]
-      (is ((set (keys results)) :cider.nrepl.middleware.test-filter-tests)
-          "ns that contains smoke is present")
-      (is (= 1 (count tests))
-          "only one test was run")
-      (is (= :a-puff-of-smoke-test (first tests))
-          "only the test marked 'smoke' was run")))
+    (is (match? {:cider.nrepl.middleware.test-filter-tests {:a-puff-of-smoke-test some?}}
+                (:results (session/message {:op      "test"
+                                            :ns      "cider.nrepl.middleware.test-filter-tests"
+                                            :include ["smoke"]
+                                            :exclude ["integration"]})))))
 
   (testing "only test not marked as integration is run when test-ns is used"
-    (let [{:keys [results] :as test-result}
-          (session/message {:op      "test"
-                            :ns      "cider.nrepl.middleware.test-filter-tests"
-                            :exclude ["integration"]})
-          tests (keys (:cider.nrepl.middleware.test-filter-tests results))]
-      (is ((set (keys results)) :cider.nrepl.middleware.test-filter-tests)
-          "ns that contains smoke is present")
-      (is (= 3 (count tests))
-          "only one test was run")
-      (is (= #{:a-puff-of-smoke-test :yet-an-other-test :test-with-map-as-message} (set tests))
-          "only the test marked 'smoke' was run")))
+    (is (match? {:cider.nrepl.middleware.test-filter-tests {:a-puff-of-smoke-test some?
+                                                            :yet-an-other-test some?
+                                                            :test-with-map-as-message some?}}
+                (:results (session/message {:op      "test"
+                                            :ns      "cider.nrepl.middleware.test-filter-tests"
+                                            :exclude ["integration"]})))))
 
   (testing "marked test is still run if filter is not used"
-    (let [{:keys [results] :as test-result}
-          (session/message {:op "test"
-                            :ns "cider.nrepl.middleware.test-filter-tests"})
-          tests (keys (:cider.nrepl.middleware.test-filter-tests results))]
-      (is ((set (keys results)) :cider.nrepl.middleware.test-filter-tests) "ns that contains smoke is present")
-      (is (< 1 (count tests)) "more tests were run")
-      (is ((set tests) :a-puff-of-smoke-test) "smoke test is still present without a filter"))))
+    (is (match? {:cider.nrepl.middleware.test-filter-tests
+                 (matchers/all-of {:a-puff-of-smoke-test some?}
+                                  #(> (count %) 1))}
+                (:results (session/message {:op "test"
+                                            :ns "cider.nrepl.middleware.test-filter-tests"}))))))
 
 (deftest only-smoke-test-run-test
   (testing "only test marked as smoke is run when test-var-query is used"
-    (let [{:keys [results] :as test-result}
-          (session/message {:op "test-var-query"
-                            :var-query {:include-meta-key ["smoke"]
-                                        :exclude-meta-key ["integration"]}})
-          tests (keys (:cider.nrepl.middleware.test-filter-tests results))]
-      (is ((set (keys results)) :cider.nrepl.middleware.test-filter-tests)
-          "ns that contains smoke is present")
-      (is (= 1 (count tests))
-          "only one test was run")
-      (is (= :a-puff-of-smoke-test (first tests))
-          "only the test marked 'smoke' was run")))
+    (is (match? {:cider.nrepl.middleware.test-filter-tests {:a-puff-of-smoke-test some?}}
+                (:results (session/message {:op "test-var-query"
+                                            :var-query {:include-meta-key ["smoke"]
+                                                        :exclude-meta-key ["integration"]}})))))
 
   (testing "only test marked as smoke is run when test-ns is used"
-    (let [{:keys [results] :as test-result}
-          (session/message {:op "test-var-query"
-                            :var-query {:ns-query {:exactly ["cider.nrepl.middleware.test-filter-tests"]}
-                                        :include-meta-key ["smoke"]
-                                        :exclude-meta-key ["integration"]}})
-          tests (keys (:cider.nrepl.middleware.test-filter-tests results))]
-      (is ((set (keys results)) :cider.nrepl.middleware.test-filter-tests)
-          "ns that contains smoke is present")
-      (is (= 1 (count tests))
-          "only one test was run")
-      (is (= :a-puff-of-smoke-test (first tests))
-          "only the test marked 'smoke' was run")))
+    (is (match? {:cider.nrepl.middleware.test-filter-tests {:a-puff-of-smoke-test some?}}
+                (:results (session/message {:op "test-var-query"
+                                            :var-query {:ns-query {:exactly ["cider.nrepl.middleware.test-filter-tests"]}
+                                                        :include-meta-key ["smoke"]
+                                                        :exclude-meta-key ["integration"]}})))))
 
   (testing "only test not marked as integration is run when test-ns is used"
-    (let [{:keys [results] :as test-result}
-          (session/message {:op "test-var-query"
-                            :var-query {:ns-query {:exactly ["cider.nrepl.middleware.test-filter-tests"]}
-                                        :exclude-meta-key ["integration"]}})
-          tests (keys (:cider.nrepl.middleware.test-filter-tests results))]
-      (is ((set (keys results)) :cider.nrepl.middleware.test-filter-tests)
-          "ns that contains smoke is present")
-      (is (= 3 (count tests))
-          "only one test was run")
-      (is (= #{:a-puff-of-smoke-test :yet-an-other-test :test-with-map-as-message} (set tests))
-          "only the test marked 'smoke' was run")))
+    (is (match? {:cider.nrepl.middleware.test-filter-tests {:a-puff-of-smoke-test some?
+                                                            :yet-an-other-test some?
+                                                            :test-with-map-as-message some?}}
+                (:results (session/message {:op "test-var-query"
+                                            :var-query {:ns-query {:exactly ["cider.nrepl.middleware.test-filter-tests"]}
+                                                        :exclude-meta-key ["integration"]}})))))
 
   (testing "marked test is still run if filter is not used"
-    (let [{:keys [results] :as test-result}
-          (session/message {:op "test-var-query"
-                            :var-query {:ns-query {:exactly ["cider.nrepl.middleware.test-filter-tests"]}}})
-          tests (keys (:cider.nrepl.middleware.test-filter-tests results))]
-      (is ((set (keys results)) :cider.nrepl.middleware.test-filter-tests)
-          "ns that contains smoke is present")
-      (is (< 1 (count tests))
-          "more tests were run")
-      (is ((set tests) :a-puff-of-smoke-test)
-          "smoke test is still present without a filter"))))
+    (is (match? {:cider.nrepl.middleware.test-filter-tests
+                 (matchers/all-of {:a-puff-of-smoke-test some?}
+                                  #(> (count %) 1))}
+                (:results (session/message {:op "test-var-query"
+                                            :var-query {:ns-query {:exactly ["cider.nrepl.middleware.test-filter-tests"]}}}))))))
 
 (deftest handling-of-tests-with-throwing-fixtures
   (require 'cider.nrepl.middleware.test-with-throwing-fixtures)
@@ -146,103 +107,71 @@
                         ;; assist in debugging this.
                         (.printStackTrace e))
                       (orig-fn ns e))]
-        (let [{{{[{:keys [error]}] :cider.nrepl.middleware.test/unknown} :cider.nrepl.middleware.test-with-throwing-fixtures} :results
-               :keys [summary status]
-               :as test-result}
-              (session/message {:op "test"
-                                :ns "cider.nrepl.middleware.test-with-throwing-fixtures"})]
-          (testing (pr-str test-result)
-            (is (= "clojure.lang.ExceptionInfo: I'm an exception inside a fixture! {:data 42}"
-                   error))
-            (is (= {:error 1, :fail 0, :ns 1, :pass 0, :test 0, :var 0}
-                   summary))
-            (is (= #{"done"} status))))))))
+        (is (match? {:status #{"done"}
+                     :summary {:error 1, :fail 0, :ns 1, :pass 0, :test 0, :var 0}
+                     :results {:cider.nrepl.middleware.test-with-throwing-fixtures
+                               {:cider.nrepl.middleware.test/unknown
+                                [{:error "clojure.lang.ExceptionInfo: I'm an exception inside a fixture! {:data 42}"}]}}}
+                    (session/message {:op "test"
+                                      :ns "cider.nrepl.middleware.test-with-throwing-fixtures"})))))))
 
 (deftest run-test-with-map-as-documentation-message
   (testing "documentation message map is returned as string"
-    (let [{:keys [results] :as test-result}
-          (session/message {:op "test"
-                            :ns "cider.nrepl.middleware.test-filter-tests"
-                            :tests ["test-with-map-as-message"]})]
-      (is (= (str {:key "val"}) (-> results
-                                    :cider.nrepl.middleware.test-filter-tests
-                                    :test-with-map-as-message
-                                    first
-                                    :message))))))
+    (is (match? {:results
+                 {:cider.nrepl.middleware.test-filter-tests
+                  {:test-with-map-as-message [{:message "{:key \"val\"}"}]}}}
+                (session/message {:op "test"
+                                  :ns "cider.nrepl.middleware.test-filter-tests"
+                                  :tests ["test-with-map-as-message"]})))))
 
 (deftest elapsed-time-test
   (require 'failing-test-ns)
   (require 'failing-test-ns-2)
-  (let [test-result (session/message {:op "test-var-query"
-                                      :var-query {:ns-query {:exactly ["failing-test-ns"]}}})
-        [[var1 elapsed-time1]
-         [var2 elapsed-time2]]
-        (->> test-result
-             :results
-             :failing-test-ns
-             ((juxt :fast-failing-test :slow-failing-test))
-             (map (fn [[{:keys [var]
-                         {:keys [ms]} :elapsed-time}]]
-                    [var ms])))]
-    (is (= "fast-failing-test" var1))
-    (is (< elapsed-time1 (if (System/getenv "CI")
-                           200
-                           50))
-        "Reports the elapsed time under [:elapsed-time :ms], as integer.
-The low numberic value reflects that it times things correctly for a fast test.")
+  (is (match? {:results {:failing-test-ns
+                         {:fast-failing-test [{:var "fast-failing-test"
+                                               ;; Should finish quickly
+                                               :elapsed-time {:ms #(< % 200)}}]
+                          :slow-failing-test [{:var "slow-failing-test"
+                                               ;; Should finish slowly
+                                               :elapsed-time {:ms #(> % 950)}}]}}
+               :ns-elapsed-time {:failing-test-ns
+                                 {:humanized #"Completed in \d+ ms"
+                                  ;; Reports the elapsed time for the entire ns
+                                  :ms #(> % 950)}}
+               :elapsed-time {:humanized #"Completed in \d+ ms"
+                              ;; Reports the elapsed time for the entire run,
+                              ;; across namespaces
+                              :ms #(> % 950)}}
+              (session/message {:op "test-var-query"
+                                :var-query {:ns-query {:exactly ["failing-test-ns"]}}})))
 
-    (is (= "slow-failing-test" var2))
-    (is (> elapsed-time2 998)
-        "Reports the elapsed time under [:elapsed-time :ms], as integer.
-The `988` value reflects that it times things correctly for a slow test.")
-
-    (let [{:keys [humanized ms]} (-> test-result :ns-elapsed-time :failing-test-ns)]
-      (is (> ms 998)
-          "Reports the elapsed time for the entire ns")
-      (is (= (str "Completed in " ms " ms")
-             humanized)))
-
-    (let [{:keys [humanized ms]} (-> test-result :elapsed-time)]
-      (is (> ms 998)
-          "Reports the elapsed time for the entire run, across namespaces")
-      (is (= (str "Completed in " ms " ms")
-             humanized))))
-
-  (let [test-result (session/message {:op "retest"})]
-    (is (string? (:humanized (:elapsed-time test-result)))
-        "Timing also works for the `retest` op (global level)")
-    (is (-> test-result :ns-elapsed-time :failing-test-ns :humanized string?)
-        "Timing also works for the `retest` op (ns level)")
-    (is (-> test-result :results :failing-test-ns :fast-failing-test (get 0) :elapsed-time :humanized string?)
-        "Timing also works for the `retest` op (var level)"))
+  (testing "Timing also works for `retest` on all levels"
+    (is (match? {:elapsed-time {:humanized string?}
+                 :ns-elapsed-time {:failing-test-ns {:humanized string?}}
+                 :results {:failing-test-ns
+                           {:fast-failing-test [{:elapsed-time {:humanized string?}}]}}}
+                (session/message {:op "retest"}))))
 
   (testing "Tests with multiple testing contexts"
-    (let [test-result (session/message {:op "test-var-query"
-                                        :var-query {:ns-query {:exactly ["failing-test-ns2"]}}})
-          vars1 (-> test-result :results :failing-test-ns2 :two-clauses)
-          vars2 (-> test-result :results :failing-test-ns2 :uses-are)]
-      (assert (-> vars1 count #{2})
-              "There's a test with two testing contexts")
-      (assert (-> vars2 count #{2})
-              "There's a test with two testing contexts")
-      (assert (every? (fn [m]
-                        (contains? m :expected))
-                      vars1))
-      (assert (every? (fn [m]
-                        (contains? m :expected))
-                      vars2))
-      (is (not-any? (fn [m]
-                      (contains? m :elapsed-time))
-                    vars1)
-          "If a deftest contains two testing contexts, :elapsed-time will be absent")
-      (is (not-any? (fn [m]
-                      (contains? m :elapsed-time))
-                    vars2)
-          "If a deftest contains two testing contexts, :elapsed-time will be absent")
-      (is (-> test-result :var-elapsed-time :failing-test-ns2 :two-clauses :elapsed-time)
-          "Timing info is, however, available at the var level")
-      (is (-> test-result :var-elapsed-time :failing-test-ns2 :uses-are :elapsed-time)
-          "Timing info is, however, available at the var level"))))
+    (is (match? {:results {:failing-test-ns2
+                           {:two-clauses
+                            [{:expected some?
+                              ;; If a deftest contains two testing
+                              ;; contexts, :elapsed-time will be absent
+                              :elapsed-time matchers/absent}
+                             {:expected some?
+                              :elapsed-time matchers/absent}]
+                            :uses-are
+                            [{:expected some?
+                              :elapsed-time matchers/absent}
+                             {:expected some?
+                              :elapsed-time matchers/absent}]}}
+                 ;; Timing info is, however, available at the var level.
+                 :var-elapsed-time {:failing-test-ns2
+                                    {:two-clauses {:elapsed-time some?}
+                                     :uses-are {:elapsed-time some?}}}}
+                (session/message {:op "test-var-query"
+                                  :var-query {:ns-query {:exactly ["failing-test-ns2"]}}})))))
 
 (deftest fail-fast-test
   (require 'failing-test-ns)
@@ -299,26 +228,21 @@ The `988` value reflects that it times things correctly for a slow test.")
 (defn throws []
   (throw (ex-info "." {})))
 
-(defn comparable-stack-frame
-  "A stack-frame map without varying parts that make testing more cumbersome."
-  [stack-frame]
-  (dissoc stack-frame :file-url :line))
-
 (deftest stack-frame-test
   (let [e (try
             (throws)
             (catch ExceptionInfo e
               e))]
-    (is (= {:fn "throws"
-            :method "invokeStatic"
-            :ns "cider.nrepl.middleware.test-test"
-            :name "cider.nrepl.middleware.test_test$throws/invokeStatic"
-            :file "test_test.clj"
-            :type :clj
-            :var "cider.nrepl.middleware.test-test/throws"
-            :class "cider.nrepl.middleware.test_test$throws"
-            :flags #{:project :clj}}
-           (comparable-stack-frame (test/stack-frame e throws)))
+    (is (match? {:fn "throws"
+                 :method "invokeStatic"
+                 :ns "cider.nrepl.middleware.test-test"
+                 :name "cider.nrepl.middleware.test_test$throws/invokeStatic"
+                 :file "test_test.clj"
+                 :type :clj
+                 :var "cider.nrepl.middleware.test-test/throws"
+                 :class "cider.nrepl.middleware.test_test$throws"
+                 :flags #{:project :clj :tooling}}
+                (test/stack-frame e throws))
         "Returns a map representing the stack frame of the precise function
 that threw the exception")))
 


### PR DESCRIPTION
Multiple things going on in this PR:

1. Remove analyze-stacktrace ops (the ones that took an exception printed as string, parsed it, and returned as an exception object that can be presented via `*cider-error*`). The idea is that https://github.com/clojure-emacs/orchard/pull/320 will cover the usecases where user wants to jump to source location from a printed stacktrace, and that is more discoverable than a separate quite obscure command.
2. Replace the usage of `haystack.analyzer` with `orchard.stacktrace`. The latter is almost the same as the former, but with improvements and optimizations. See https://github.com/clojure-emacs/orchard/pull/322.
3. I rewrote a few test namespaces along the way to use matcher-combinators to reduce noise and improve error reporting.

I plan to let it hang here for some time while I dogfood the changes.

---

- [x] You've updated the CHANGELOG
- [x] Middleware documentation is up to date
  * Please check out and modify the `cider.nrepl` ns which has all middleware documentation.
  * Run `lein docs` afterwards, and commit the results.