### PR TITLE
[util] Add util/respond-to

### DIFF
--- a/src/cider/nrepl/middleware/info.clj
+++ b/src/cider/nrepl/middleware/info.clj
@@ -2,12 +2,10 @@
   (:require
    [compliment.context]
    [compliment.sources.class-members]
-   [cider.nrepl.middleware.util :as util]
+   [cider.nrepl.middleware.util :as util :refer [respond-to]]
    [cider.nrepl.middleware.util.cljs :as cljs]
    [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
    [clojure.string :as str]
-   [nrepl.transport :as transport]
-   [nrepl.misc :refer [response-for]]
    [orchard.eldoc :as eldoc]
    [orchard.info :as info]
    [orchard.java.source-files :as src-files]
@@ -89,14 +87,13 @@
   download an artifact that doesn't exist or can't be found."
   (ConcurrentHashMap.))
 
-(defn- download-sources-jar-for-class
-  [klass {:keys [transport] :as msg}]
+(defn- download-sources-jar-for-class [klass msg]
   (when-let [coords (src-files/infer-maven-coordinates-for-class klass)]
     (when (nil? (.putIfAbsent attempted-to-download-coords coords true))
       ;; Tell the client we are going to download an artifict so it can notify
       ;; the user. It may take a few seconds.
-      (transport/send transport (response-for msg {:status :download-sources-jar
-                                                   :coords coords}))
+      (respond-to msg {:status :download-sources-jar
+                       :coords coords})
       (src-files/download-sources-jar-for-coordinates coords))))
 
 (defn info

--- a/src/cider/nrepl/middleware/macroexpand.clj
+++ b/src/cider/nrepl/middleware/macroexpand.clj
@@ -2,11 +2,11 @@
   "Macroexpansion middleware."
   {:author "Bozhidar Batsov"}
   (:require
+   [cider.nrepl.middleware.util :refer [respond-to]]
    [cider.nrepl.middleware.util.cljs :as cljs]
    [cider.nrepl.middleware.util.error-handling
     :refer [base-error-response eval-interceptor-transport with-safe-transport]]
    [orchard.cljs.analysis :as cljs-ana]
-   [nrepl.misc :refer [response-for]]
    [nrepl.transport :as transport]
    [clojure.pprint :as pp]
    [clojure.tools.reader :as reader]
@@ -124,12 +124,11 @@
   (transport/send (:transport msg)
                   (base-error-response msg ex :done :macroexpand-error)))
 
-(defn macroexpansion-reply-clj [{:keys [transport] :as msg}
-                                {:keys [value] :as resp}]
+(defn macroexpansion-reply-clj [msg {:keys [value] :as resp}]
   (try (let [msg (update msg :ns #(or (misc/as-sym %) 'user))
              expansion (walk/prewalk (post-expansion-walker-clj msg) value)
              response-map (macroexpansion-response-map msg expansion)]
-         (transport/send transport (response-for msg response-map)))
+         (respond-to msg response-map))
        (catch Exception ex
          (send-middleware-error msg ex))))
 

--- a/src/cider/nrepl/middleware/slurp.clj
+++ b/src/cider/nrepl/middleware/slurp.clj
@@ -5,11 +5,10 @@
   convert URLs to values which can be handled nicely."
   {:authors ["Reid 'arrdem' McKenzie <me@arrdem.com>"]}
   (:require
+   [cider.nrepl.middleware.util :refer [respond-to]]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
-   [clojure.string :as str]
-   [nrepl.misc :refer [response-for]]
-   [nrepl.transport :as transport])
+   [clojure.string :as str])
   (:import
    (java.io ByteArrayOutputStream FileNotFoundException InputStream)
    (java.net MalformedURLException URI URL URLConnection)
@@ -120,8 +119,6 @@
   [handler msg]
   (let [{:keys [op url transport]} msg]
     (if (and (= "slurp" op) url)
-      (do (transport/send transport
-                          (response-for msg (slurp-url-to-content+body url)))
-          (transport/send transport
-                          (response-for msg {:status ["done"]})))
+      (do (respond-to msg (slurp-url-to-content+body url))
+          (respond-to msg :status :done))
       (handler msg))))

--- a/src/cider/nrepl/middleware/util.clj
+++ b/src/cider/nrepl/middleware/util.clj
@@ -1,5 +1,7 @@
 (ns cider.nrepl.middleware.util
-  "Utility functions that might be useful in middleware.")
+  "Utility functions that might be useful in middleware."
+  (:require [nrepl.transport :as transport]
+            [nrepl.misc :refer [response-for]]))
 
 (defmulti transform-value "Transform a value for output" type)
 
@@ -42,3 +44,8 @@
 
 ;; handles vectors
 (prefer-method transform-value clojure.lang.Sequential clojure.lang.Associative)
+
+(defn respond-to
+  "Send a response for `msg` with `response-data` using message's transport."
+  [msg & response-data]
+  (transport/send (:transport msg) (apply response-for msg response-data)))

--- a/src/cider/nrepl/middleware/util/reload.clj
+++ b/src/cider/nrepl/middleware/util/reload.clj
@@ -2,23 +2,20 @@
   "Common parts for the code-reloading middleware namespaces."
   {:added "0.47.0"}
   (:require
+   [cider.nrepl.middleware.util :refer [respond-to]]
    [clojure.main :refer [repl-caught]]
    [nrepl.middleware.interruptible-eval :refer [*msg*]]
    [nrepl.middleware.print :as print]
-   [nrepl.misc :refer [response-for]]
-   [nrepl.transport :as transport]
    [orchard.misc :as misc]
    [orchard.stacktrace :as stacktrace]))
 
 (defn error-reply
   [{:keys [error error-ns]}
-   {:keys [::print/print-fn transport] :as msg}]
+   {:keys [::print/print-fn] :as msg}]
 
-  (transport/send
-   transport
-   (response-for msg (cond-> {:status :error}
-                       error (assoc :error (stacktrace/analyze error print-fn))
-                       error-ns (assoc :error-ns error-ns))))
+  (respond-to msg (cond-> {:status :error}
+                    error (assoc :error (stacktrace/analyze error print-fn))
+                    error-ns (assoc :error-ns error-ns)))
 
   (binding [*msg* msg
             *err* (print/replying-PrintWriter :err msg {})]
@@ -49,38 +46,29 @@
         (@the-var))
       (var? the-var))))
 
-(defn before-reply [{:keys [before transport] :as msg}]
+(defn before-reply [{:keys [before] :as msg}]
   (when before
-    (transport/send
-     transport
-     (response-for msg {:status :invoking-before
-                        :before before}))
+    (respond-to msg {:status :invoking-before
+                     :before before})
 
     (let [resolved? (resolve-and-invoke before msg)]
-      (transport/send
-       transport
-       (response-for msg
-                     {:status (if resolved?
-                                :invoked-before
-                                :invoked-not-resolved)
-                      :before before})))))
+      (respond-to msg {:status (if resolved?
+                                 :invoked-before
+                                 :invoked-not-resolved)
+                       :before before}))))
 
 (defn after-reply [error
-                   {:keys [after transport] :as msg}]
+                   {:keys [after] :as msg}]
   (when (and (not error) after)
     (try
-      (transport/send
-       transport
-       (response-for msg {:status :invoking-after
-                          :after after}))
+      (respond-to msg {:status :invoking-after
+                       :after after})
 
       (let [resolved? (resolve-and-invoke after msg)]
-        (transport/send
-         transport
-         (response-for msg {:status (if resolved?
-                                      :invoked-after
-                                      :invoked-not-resolved)
-                            :after after})))
+        (respond-to msg {:status (if resolved?
+                                   :invoked-after
+                                   :invoked-not-resolved)
+                         :after after}))
 
       (catch Exception e
         (error-reply {:error e} msg)))))

--- a/src/cider/nrepl/middleware/version.clj
+++ b/src/cider/nrepl/middleware/version.clj
@@ -2,13 +2,9 @@
   "Return version info of the CIDER-nREPL middleware itself."
   (:require
    [cider.nrepl.version :as version]
-   [nrepl.misc :refer [response-for]]
-   [nrepl.transport :as transport]))
+   [cider.nrepl.middleware.util :refer [respond-to]]))
 
 (defn handle-version [handler msg]
   (if (= (:op msg) "cider-version")
-    (->> {:cider-version version/version}
-         (merge {:status #{"done"}})
-         (response-for msg)
-         (transport/send (:transport msg)))
+    (respond-to msg {:status :done, :cider-version version/version})
     (handler msg)))


### PR DESCRIPTION
There is a very common pattern used everywhere in cider-nrepl:

```clj
(transport/send (:transport msg) (response-for msg ...))
```

This PR commemorates this pattern as a function `respond-to` and replaces all matching usages with it. Perhaps, this is something that could live in nREPL itself, but we'll still have to support older versions of nREPL here, so might as well add it here.