### PR TITLE
[complete] Make sort-order customizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#923](https://github.com/clojure-emacs/cider-nrepl/pull/923): Complete: make sorting order customizable.
+
 ## 0.53.1 (2025-03-26)
 
 * Bump `compliment` to [0.7.0](https://github.com/alexander-yakushev/compliment/blob/master/CHANGELOG.md#070-2025-03-25).

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -139,6 +139,7 @@ Required parameters::
 Optional parameters::
 * `:context` Completion context for compliment.
 * `:extra-metadata` List of extra-metadata fields. Possible values: arglists, doc.
+* `:sort-order` Sorting order of candidates. Possible values: by-name, by-length.
 
 
 Returns::

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -196,6 +196,7 @@ Depending on the type of the return value of the evaluation this middleware may 
                           "prefix" "The prefix for completion candidates"
                           "session" "The current session"}
                :optional {"context" "Completion context for compliment."
+                          "sort-order" "Sorting order of candidates. Possible values: by-name, by-length."
                           "extra-metadata" "List of extra-metadata fields. Possible values: arglists, doc."}
                :returns {"completions" "A list of possible completions"}}
               "complete-doc"

--- a/src/cider/nrepl/middleware/complete.clj
+++ b/src/cider/nrepl/middleware/complete.clj
@@ -45,11 +45,13 @@
    :compliment.sources.local-bindings/local-bindings])
 
 (defn complete
-  [{:keys [ns prefix symbol context extra-metadata enhanced-cljs-completion?] :as msg}]
+  [{:keys [ns prefix symbol context extra-metadata enhanced-cljs-completion? sort-order]
+    :as msg}]
   ;; TODO: Drop legacy symbol param in version 1.0
   (let [prefix (str (or prefix symbol))
         completion-opts {:ns             (misc/as-sym ns)
                          :context        context
+                         :sort-order     (or (some-> sort-order keyword) :by-length)
                          :extra-metadata (set (map keyword extra-metadata))}]
     (if-let [cljs-env (cljs/grab-cljs-env msg)]
       ;; ClojureScript completion

--- a/test/clj/cider/nrepl/middleware/complete_test.clj
+++ b/test/clj/cider/nrepl/middleware/complete_test.clj
@@ -40,6 +40,25 @@
                                                 :prefix "assoc"
                                                 :extra-metadata ["arglists" "doc"]})))))
 
+  (testing "default sorting"
+    (is+ (matchers/prefix [{:candidate "map"}
+                           {:candidate "map?"}
+                           {:candidate "mapv"}
+                           {:candidate "mapcat"}])
+         (:completions (session/message {:op "complete"
+                                         :ns "user"
+                                         :prefix "map"}))))
+
+  (testing "by-name sorting"
+    (is+ (matchers/prefix [{:candidate "map"}
+                           {:candidate "map-entry?"}
+                           {:candidate "map-indexed"}
+                           {:candidate "map?"}])
+         (:completions (session/message {:op "complete"
+                                         :ns "user"
+                                         :prefix "map"
+                                         :sort-order "by-name"}))))
+
   (testing "macro metadata"
     (is+ {:arglists ["[name & opts+sigs]"]
           :doc string?}


### PR DESCRIPTION
So, I've merged the new Compliment that brought this: https://github.com/alexander-yakushev/compliment/pull/122. The idea is to improve the order of candidates with information from the backend.

However, I couldn't make it work right away. Turns out, company-mode (and Emacs' own complete-at-point) perform their own client-side post-sorting of candidates – which they do by-name). To get rid of it, there is a metadata parameter that can be assigned to completion backend to avoid client-side sorting. I did that, so now the backend results come as is. And they come in like this, for example:

<img width="483" alt="image" src="https://github.com/user-attachments/assets/1962a9bc-6b87-4aa8-94d2-43f0f6d2c262" />

Notice the weird order – a `java.` class first, then two `javax.` classes, then a `java.` class again. It is because Compliment's own default sorting method is `:by-length` – shorter candidates first. This looks messy. This is also not what users are used to by default – because by default company-mode and friends performed their own sorting and that sorting is strictly alphabetical.

The proposal here is to change the order that cider-nrepl returns to `:by-name`. This is inline with previous user experience and will allow us to cleanly transition to backend-driven sorting. 

---

- [x] You've updated the README
