### PR TITLE
Stop shipping Puget with cider-nrepl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+* [#925](https://github.com/clojure-emacs/cider-nrepl/pull/9250): Stop vendoring Puget dependency.
+* [#917](https://github.com/clojure-emacs/cider-nrepl/pull/917): Sort printed maps in test output.
+
 ## 0.53.2 (2025-03-26)
 
 * [#923](https://github.com/clojure-emacs/cider-nrepl/pull/923): Complete: make sorting order customizable.
@@ -21,7 +24,6 @@
 * [#913](https://github.com/clojure-emacs/cider-nrepl/pull/913): Disable background warmup of `orchard.java` cache.
 * [#913](https://github.com/clojure-emacs/cider-nrepl/pull/913): Enable background warmup of Compliment cache.
 * [#914](https://github.com/clojure-emacs/cider-nrepl/pull/914): Remove javadoc section from the inspector output.
-* [#917](https://github.com/clojure-emacs/cider-nrepl/pull/917): Sort printed maps in test output
 
 ## 0.52.1 (2025-02-24)
 

--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,7 @@
   {:dependencies '[[org.clojure/clojurescript "1.11.60" :scope "provided"]
                    ;; 1.3.7 and 1.4.7 are working, but we need 1.3.7 for JDK8
                    [ch.qos.logback/logback-classic "1.3.7"]
+                   [mvxcvi/puget "1.3.4" :exclusions [org.clojure/clojure]]
                    [org.clojure/test.check "1.1.1"]
                    [cider/piggieback "0.6.0"]
                    [nubank/matcher-combinators "3.9.1"]]
@@ -23,7 +24,6 @@
   :dependencies [[nrepl/nrepl "1.3.1" :exclusions [org.clojure/clojure]]
                  [cider/orchard "0.31.1" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [thunknyc/profile "0.5.2"]
-                 ^:inline-dep [mvxcvi/puget "1.3.4" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [fipp ~fipp-version] ; can be removed in unresolved-tree mode
                  ^:inline-dep [compliment "0.7.0"]
                  ^:inline-dep [org.rksm/suitable "0.6.2" :exclusions [org.clojure/clojure
@@ -50,8 +50,8 @@
               '[[thomasa/mranderson "0.5.4-SNAPSHOT"]])
 
   :mranderson {:project-prefix "cider.nrepl.inlined.deps"
-               :overrides       {[mvxcvi/puget fipp] [fipp ~fipp-version]} ; only takes effect in unresolved-tree mode
-               :expositions     [[mvxcvi/puget fipp]] ; only takes effect unresolved-tree mode
+               :overrides       {[fipp] [fipp ~fipp-version]} ; only takes effect in unresolved-tree mode
+               :expositions     [[fipp]] ; only takes effect unresolved-tree mode
                :unresolved-tree false}
 
   :filespecs [{:type :bytes :path "cider/cider-nrepl/project.clj" :bytes ~(slurp "project.clj")}]

--- a/src/cider/nrepl/pprint.clj
+++ b/src/cider/nrepl/pprint.clj
@@ -78,11 +78,14 @@
      (pprint value writer options))))
 
 (def ^:private zprint-printer
-  (delay (requiring-resolve 'zprint.core/zprint)))
+  (delay (try-resolve 'zprint.core/zprint "zprint")))
 
 (defn zprint-pprint
   ([value writer]
    (zprint-pprint value writer {}))
   ([value writer options]
-   (binding [*out* writer]
-     (@zprint-printer value options))))
+   (if-some [zprint @zprint-printer]
+     (binding [*out* writer]
+       (zprint value options))
+     ;; Default ot clojure.pprint/pprint if Zprint could not be loaded.
+     (pprint value writer options))))

--- a/src/cider/nrepl/pprint.clj
+++ b/src/cider/nrepl/pprint.clj
@@ -5,7 +5,8 @@
   {:added "0.20"}
   (:refer-clojure :exclude [pr])
   (:require
-   [clojure.pprint :as pp]))
+   [clojure.pprint :as pp]
+   [orchard.misc :as misc]))
 
 (def ^:private pr-options
   [:print-dup
@@ -18,6 +19,13 @@
 (defn- option->var
   [option]
   (resolve (symbol "clojure.core" (str "*" (name option) "*"))))
+
+(defn- try-resolve [var-symbol pprinter-name]
+  (or (misc/require-and-resolve var-symbol)
+      (binding [*out* *err*]
+        (println (format "Could not load %s namespace. To use %s pretty-printing with CIDER, add it to dependencies explicitly."
+                         (namespace var-symbol) pprinter-name))
+        nil)))
 
 (defn- pr-bindings
   [options]
@@ -57,14 +65,17 @@
      (@fipp-printer value options))))
 
 (def ^:private puget-printer
-  (delay (requiring-resolve 'puget.printer/pprint)))
+  (delay (try-resolve 'puget.printer/pprint "Puget")))
 
 (defn puget-pprint
   ([value writer]
    (puget-pprint value writer {}))
   ([value writer options]
-   (binding [*out* writer]
-     (@puget-printer value options))))
+   (if-some [puget @puget-printer]
+     (binding [*out* writer]
+       (puget value options))
+     ;; Default ot clojure.pprint/pprint if Puget could not be loaded.
+     (pprint value writer options))))
 
 (def ^:private zprint-printer
   (delay (requiring-resolve 'zprint.core/zprint)))


### PR DESCRIPTION
So, here's another attempt to reduce the surface of cider-nrepl dependency. The proposal is based on this completely unscientific test that checks how many people are using non-standard pretty-printers with CIDER. Out of 15 responses, 2 are using Fipp and 1 is using Puget.

The idea in the PR is to revert to clojure.pprint if Puget could not be loaded. We also print a warning to tell the user what's going on. I'd say this is graceful UX degradation as the results are still being pretty-printed, and there is a path for the user to fix this. One flow I'm worried about is the `cider-jack-in` one where user haven't ever set up a custom profile to put extra dependencies there.

There's no rush with this one, I'll be happy to know what you think.

---

- [x] You've updated the CHANGELOG