### PR TITLE
[test] Don't turn records into maps when post-processing test results

### DIFF
--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -78,7 +78,7 @@
   (try
     (walk/postwalk
      (fn [x]
-       (if (map? x)
+       (if (and (map? x) (not (record? x))) ;; Prevent records turning into maps
          (with-meta (into (sorted-map) x) (meta x))
          x))
      m)

--- a/test/clj/cider/nrepl/middleware/test_test.clj
+++ b/test/clj/cider/nrepl/middleware/test_test.clj
@@ -6,7 +6,8 @@
    [clojure.string :as string]
    [clojure.test :refer :all]
    [matcher-combinators.clj-test]
-   [matcher-combinators.matchers :as matchers])
+   [matcher-combinators.matchers :as matchers]
+   [matcher-combinators.model])
   (:import
    (clojure.lang ExceptionInfo)))
 
@@ -199,10 +200,10 @@
 
 (deftest print-object-test
   (testing "uses println for matcher-combinators results, otherwise invokes pprint"
-    (is (= "{no quotes}\n"
+    (is (= "(mismatch (expected [33m1[0m) (actual [31m2[0m))\n"
            (#'test/print-object (matcher-combinators.clj-test/tagged-for-pretty-printing
                                  '(not (match? 1 2))
-                                 {:matcher-combinators.result/value {"no" "quotes"}})))
+                                 {:matcher-combinators.result/value (matcher-combinators.model/->Mismatch "1" "2")})))
         "println is chosen, as indicated by strings printed without quotes")
     (is (= "{:a\n (\"a-sufficiently-long-string\"\n  \"a-sufficiently-long-string\"\n  \"a-sufficiently-long-string\")}\n"
            (#'test/print-object {:a (repeat 3 "a-sufficiently-long-string")}))


### PR DESCRIPTION
#917 introduced a small bug where matcher-combinators results that contain records are converted to maps, and then the way they are printed gets broken.

---

- [x] You've added tests to cover your change(s)