### PR TITLE
[inspect] Add support for :table view-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## master (unreleased)
 
-* Bump `orchard` to [0.32.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0320-2025-04-05).
+* Bump `orchard` to [0.32.1](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0320-2025-04-05).
 * [#925](https://github.com/clojure-emacs/cider-nrepl/pull/9250): Stop vendoring Puget dependency.
 * [#917](https://github.com/clojure-emacs/cider-nrepl/pull/917): Sort printed maps in test output.
 * [#927](https://github.com/clojure-emacs/cider-nrepl/pull/927): Add `inspect-display-analytics` op.
+* [#928](https://github.com/clojure-emacs/cider-nrepl/pull/922): Add support for `:table` view-mode in inspector.
 
 ## 0.53.2 (2025-03-26)
 

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -763,7 +763,7 @@ Returns::
 
 === `inspect-toggle-view-mode`
 
-Toggles the viewing mode of the inspector. This influences the way how inspector is rendering the current value. ``:normal`` is the default. When view mode is ``:object``, any value will be rendered as a Java object (fields shown as is). View mode is automatically reset back to normal when navigating to child values.
+Toggles the viewing mode of the inspector. This influences the way how inspector is rendering the current value. ``:normal`` is the default. When view mode is ``:table``, the value will be rendered as a table (only supported for sequences of maps or tuples). When view mode is ``:object``, any value will be rendered as a Java object (fields shown as is). View mode is automatically reset back to normal when navigating to child values.
 
 Required parameters::
 * `:session` The current session

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -342,7 +342,7 @@ if applicable, and re-render the updated value."
                           "view-mode" "Mode of viewing the value - either `:normal` or `:object`"}
                :returns inspector-returns}
               "inspect-toggle-view-mode"
-              {:doc "Toggles the viewing mode of the inspector. This influences the way how inspector is rendering the current value. `:normal` is the default. When view mode is `:object`, any value will be rendered as a Java object (fields shown as is). View mode is automatically reset back to normal when navigating to child values."
+              {:doc "Toggles the viewing mode of the inspector. This influences the way how inspector is rendering the current value. `:normal` is the default. When view mode is `:table`, the value will be rendered as a table (only supported for sequences of maps or tuples). When view mode is `:object`, any value will be rendered as a Java object (fields shown as is). View mode is automatically reset back to normal when navigating to child values."
                :requires {"session" "The current session"}
                :returns inspector-returns}
               "inspect-display-analytics"

--- a/src/cider/nrepl/middleware/inspect.clj
+++ b/src/cider/nrepl/middleware/inspect.clj
@@ -77,7 +77,10 @@
     (inspector-response msg (swap-inspector! msg #(inspect/refresh % overrides)))))
 
 (defn- toggle-view-mode [{:keys [view-mode] :as inspector}]
-  (let [toggle-order {:normal :object, :object :normal}
+  ;; The order in which view modes are cycled depends on the inspected object.
+  (let [toggle-order (if (inspect/supports-table-view-mode? inspector)
+                       {:normal :table, :table :object, :object :normal}
+                       {:normal :object, :object :normal})
         next-view-mode (toggle-order view-mode :normal)]
     (inspect/set-view-mode inspector next-view-mode)))
 

--- a/test/clj/cider/nrepl/middleware/inspect_test.clj
+++ b/test/clj/cider/nrepl/middleware/inspect_test.clj
@@ -630,6 +630,15 @@
    "  " [:value "_rest" number?] " = " [:value "(2 3)" number?]
    [:newline]])
 
+(def table-mode-prefix
+  ["--- Contents:" [:newline]
+   [:newline]
+   "  |  " [:value "#" pos?] " | " [:value ":a" pos?] " | " [:newline]
+   "  |----+----|" [:newline]
+   "  |  " [:value "0" pos?] " |  " [:value "1" pos?] " | " [:newline]
+   "  |  " [:value "1" pos?] " |  " [:value "1" pos?] " | " [:newline]
+   "  |  " [:value "2" pos?] " |  " [:value "1" pos?] " | " [:newline]])
+
 (deftest object-view-mode-integration-test
   (testing "view-mode can be toggled with inspect-toggle-view-mode op"
     (session/message {:op "inspect-clear"})
@@ -672,6 +681,15 @@
                                               :inspect "true"
                                               :code    "(range 100)"
                                               :display-analytics-hint "true"})))))
+
+(deftest table-view-mode-integration-test
+  (testing "table view-mode is supported for lists of maps"
+    (session/message {:op "inspect-clear"})
+    (session/message {:op      "eval"
+                      :inspect "true"
+                      :code    "(repeat 20 {:a 1})"})
+    (is+ (matchers/prefix table-mode-prefix)
+         (value-skip-header (session/message {:op "inspect-toggle-view-mode"})))))
 
 (deftest print-length-independence-test
   (testing "*print-length* doesn't break rendering of long collections"


### PR DESCRIPTION
Sister PR: https://github.com/clojure-emacs/orchard/pull/331

Not a lot to be done here. We already have `inspector-toggle-view-mode` that does the heavy lifting. The only meaningful thing here is checking if the current object can be rendered as a table.

- If it does, the view mode cycle goes like `normal -> table -> object -> normal`
- Otherwise, it's `normal -> object -> normal`.

---

- [x] You've added tests to cover your change(s)
- [x] You've updated the CHANGELOG
- [x] Middleware documentation is up to date