### PR TITLE
[profile] Migrate profiling middleware to orchard.profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## master (unreleased)
 
+* Bump `orchard` to [0.33.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0330-2025-04-08).
+* [#929](https://github.com/clojure-emacs/cider-nrepl/pull/929): Migrate profiling middleware to orchard.profile.
+
 ## 0.54.0 (2025-04-05)
 
 * Bump `orchard` to [0.32.1](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0320-2025-04-05).
-* [#925](https://github.com/clojure-emacs/cider-nrepl/pull/9250): Stop vendoring Puget dependency.
+* [#925](https://github.com/clojure-emacs/cider-nrepl/pull/925): Stop vendoring Puget dependency.
 * [#917](https://github.com/clojure-emacs/cider-nrepl/pull/917): Sort printed maps in test output.
 * [#927](https://github.com/clojure-emacs/cider-nrepl/pull/927): Add `inspect-display-analytics` op.
 * [#928](https://github.com/clojure-emacs/cider-nrepl/pull/922): Add support for `:table` view-mode in inspector.

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -77,21 +77,6 @@ Returns::
 
 
 
-=== `clear-profile`
-
-Clears profile of samples.
-
-Required parameters::
-{blank}
-
-Optional parameters::
-{blank}
-
-Returns::
-* `:status` Done
-
-
-
 === `clojuredocs-lookup`
 
 Return a map of information in ClojureDocs.
@@ -369,22 +354,6 @@ Optional parameters::
 
 Returns::
 * `:formatted-edn` The formatted data.
-
-
-
-=== `get-max-samples`
-
-Returns maximum number of samples to be collected for any var.
-
-Required parameters::
-{blank}
-
-Optional parameters::
-{blank}
-
-Returns::
-* `:status` Done
-* `:value` String representing number of max-sample-count
 
 
 
@@ -779,24 +748,6 @@ Returns::
 
 
 
-=== `is-var-profiled`
-
-Reports whether symbol is currently profiled.
-
-Required parameters::
-* `:ns` The current namespace
-* `:sym` The symbol to check
-
-
-Optional parameters::
-{blank}
-
-Returns::
-* `:status` Done
-* `:value` 'profiled' if profiling enabled, 'unprofiled' if disabled
-
-
-
 === `macroexpand`
 
 Produces macroexpansion of some form using the given expander.
@@ -966,40 +917,6 @@ Returns::
 {blank}
 
 
-=== `profile-summary`
-
-Return profiling data summary.
-
-Required parameters::
-{blank}
-
-Optional parameters::
-{blank}
-
-Returns::
-* `:err` Content of profile summary report
-* `:status` Done
-
-
-
-=== `profile-var-summary`
-
-Return profiling data summary for a single var.
-
-Required parameters::
-* `:ns` The current namespace
-* `:sym` The symbol to profile
-
-
-Optional parameters::
-{blank}
-
-Returns::
-* `:err` Content of profile summary report
-* `:status` Done
-
-
-
 === `refresh`
 
 Reloads all changed files in dependency order.
@@ -1122,23 +1039,6 @@ Returns::
 * `:results` Misc information about the test result. The structure is ``:results {<ns as keyword> {<test var as keyword> [{,,, :elapsed-time {:ms <integer> :humanized <string>}}]}}``
 * `:status` Either done or indication of an error
 * `:var-elapsed-time` a report of the elapsed time spent running each var. The structure is ``:var-elapsed-time {<ns as keyword> {<var as keyword> {:ms <integer> :humanized <string>}}}``.
-
-
-
-=== `set-max-samples`
-
-Sets maximum sample count. Returns new max-sample-count.
-
-Required parameters::
-* `:max-samples` Maximum samples to collect for any single var.
-
-
-Optional parameters::
-{blank}
-
-Returns::
-* `:status` Done
-* `:value` String representing number of max-sample-count
 
 
 
@@ -1329,41 +1229,6 @@ Returns::
 * `:results` Misc information about the test result. The structure is ``:results {<ns as keyword> {<test var as keyword> [{,,, :elapsed-time {:ms <integer> :humanized <string>}}]}}``
 * `:status` Either done or indication of an error
 * `:var-elapsed-time` a report of the elapsed time spent running each var. The structure is ``:var-elapsed-time {<ns as keyword> {<var as keyword> {:ms <integer> :humanized <string>}}}``.
-
-
-
-=== `toggle-profile`
-
-Toggle profiling of a given var.
-
-Required parameters::
-* `:ns` The current namespace
-* `:sym` The symbol to profile
-
-
-Optional parameters::
-{blank}
-
-Returns::
-* `:status` Done
-* `:value` 'profiled' if profiling enabled, 'unprofiled' if disabled, 'unbound' if ns/sym not bound
-
-
-
-=== `toggle-profile-ns`
-
-Toggle profiling of given namespace.
-
-Required parameters::
-* `:ns` The current namespace
-
-
-Optional parameters::
-{blank}
-
-Returns::
-* `:status` Done
-* `:value` 'profiled' if profiling enabled, 'unprofiled' if disabled
 
 
 
@@ -1734,6 +1599,72 @@ Optional parameters::
 Returns::
 * `:status` done
 * `:cider/log-update-consumer` The consumer that was updated.
+
+
+
+=== `cider/profile-clear`
+
+Clear profiling data.
+
+Required parameters::
+{blank}
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:status` Done
+
+
+
+=== `cider/profile-summary`
+
+Return profiling summary optimized for viewing through CIDER inspector.
+
+Required parameters::
+{blank}
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:status` Done
+* `:value` Profile summary as inspectable data structure.
+
+
+
+=== `cider/profile-toggle-ns`
+
+Toggle profiling of given namespace.
+
+Required parameters::
+* `:ns` The current namespace
+
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:status` Done
+* `:value` 'profiled' if profiling enabled, 'unprofiled' if disabled
+
+
+
+=== `cider/profile-toggle-var`
+
+Toggle profiling of a given var.
+
+Required parameters::
+* `:ns` The current namespace
+* `:sym` The symbol to profile
+
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:status` Done
+* `:value` 'profiled' if profiling enabled, 'unprofiled' if disabled
 
 
 

--- a/doc/modules/ROOT/pages/nrepl-api/supplied_middleware.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/supplied_middleware.adoc
@@ -84,8 +84,8 @@
 | `wrap-profile`
 | -
 | No
-| `toggle-profile/toggle-profile-ns/is-var-profiled/profile-summary/profile-var-summary/clear-profile/get-max-samples/set-max-samples`
-| Provides profiling support based on the https://github.com/thunknyc/profile[profile] library.
+| `cider/profile-toggle-var`, `cider/profile-toggle-ns`, `cider/profile-summary`, `cider/profile-clear`
+| Middleware for manual profiling.
 
 | `wrap-refresh`
 | -

--- a/project.clj
+++ b/project.clj
@@ -22,8 +22,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/clojure-emacs/cider-nrepl"}
   :dependencies [[nrepl/nrepl "1.3.1" :exclusions [org.clojure/clojure]]
-                 [cider/orchard "0.32.1" :exclusions [org.clojure/clojure]]
-                 ^:inline-dep [thunknyc/profile "0.5.2"]
+                 [cider/orchard "0.33.0" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [fipp ~fipp-version] ; can be removed in unresolved-tree mode
                  ^:inline-dep [compliment "0.7.0"]
                  ^:inline-dep [org.rksm/suitable "0.6.2" :exclusions [org.clojure/clojure
@@ -151,8 +150,6 @@
              :eastwood [:test
                         {:plugins [[jonase/eastwood "1.4.0"]]
                          :eastwood {:config-files ["eastwood.clj"]
-                                    :exclude-namespaces [cider.nrepl.middleware.test-filter-tests cider.tasks]
-                                    :ignored-faults {:unused-ret-vals-in-try {cider.nrepl.middleware.profile-test [{:line 25}]}
-                                                     :suspicious-test {cider.nrepl.middleware.profile-test [{:line 25}]}}}}]
+                                    :exclude-namespaces [cider.nrepl.middleware.test-filter-tests cider.tasks]}}]
 
              :deploy {:source-paths [".circleci/deploy"]}})

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -739,20 +739,13 @@ stack frame of the most recent exception. This op is deprecated, please use the
               :requires {"ns" "The namespace to trace"}
               :returns  {"ns-status" "The result of tracing operation"}}}})
 
-(def ops-that-can-eval
-  "Set of nREPL ops that can lead to code being evaluated."
-  #{"eval" "load-file"
-    "refresh" "refresh-all" "refresh-clear"
-    "cider.clj-reload/reload" "cider.clj-reload/reload-all" "cider.clj-reload/reload-clear"
-    "toggle-trace-var" "toggle-trace-ns" "undef" "undef-all"})
-
 (def-wrapper wrap-tracker cider.nrepl.middleware.track-state/handle-tracker
-  ops-that-can-eval
+  mw/ops-that-can-eval
   (cljs/expects-piggieback
    {:doc "Under its normal operation mode, enhances the `eval` op by notifying the client of the current REPL state.
 You can also request to compute the info directly by requesting the \"cider/get-state\" op."
     :requires #{#'session}
-    :expects ops-that-can-eval
+    :expects mw/ops-that-can-eval
     :handles {"cider/get-state" {}}
     :returns {"repl-type" "`:clj` or `:cljs`."
               "changed-namespaces" "A map of namespaces to `{:aliases ,,, :interns ,,,}`"}}))

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -580,41 +580,23 @@ if applicable, and re-render the updated value."
               {:doc "Change #'*out* so that it no longer prints to active sessions outside an eval scope."}}}))
 
 (def-wrapper wrap-profile cider.nrepl.middleware.profile/handle-profile
-  {:doc     "Middleware that provides supports Profiling based on https://github.com/thunknyc/profile"
-   :handles {"toggle-profile-ns"   {:doc      "Toggle profiling of given namespace."
-                                    :requires {"ns" "The current namespace"}
-                                    :returns  {"status" "Done"
-                                               "value"  "'profiled' if profiling enabled, 'unprofiled' if disabled"}}
-             "is-var-profiled"     {:doc      "Reports whether symbol is currently profiled."
-                                    :requires {"sym" "The symbol to check"
-                                               "ns"  "The current namespace"}
-                                    :returns  {"status" "Done"
-                                               "value"  "'profiled' if profiling enabled, 'unprofiled' if disabled"}}
-             "get-max-samples"     {:doc      "Returns maximum number of samples to be collected for any var."
-                                    :requires {}
-                                    :returns  {"status" "Done"
-                                               "value"  "String representing number of max-sample-count"}}
-             "set-max-samples"     {:doc      "Sets maximum sample count. Returns new max-sample-count."
-                                    :requires {"max-samples" "Maximum samples to collect for any single var."}
-                                    :returns  {"status" "Done"
-                                               "value"  "String representing number of max-sample-count"}}
-             "toggle-profile"      {:doc      "Toggle profiling of a given var."
-                                    :requires {"sym" "The symbol to profile"
-                                               "ns"  "The current namespace"}
-                                    :returns  {"status" "Done"
-                                               "value"  "'profiled' if profiling enabled, 'unprofiled' if disabled, 'unbound' if ns/sym not bound"}}
-             "profile-var-summary" {:doc      "Return profiling data summary for a single var."
-                                    :requires {"sym" "The symbol to profile"
-                                               "ns"  "The current namespace"}
-                                    :returns  {"status" "Done"
-                                               "err"    "Content of profile summary report"}}
-             "profile-summary"     {:doc      "Return profiling data summary."
-                                    :requires {}
-                                    :returns  {"status" "Done"
-                                               "err"    "Content of profile summary report"}}
-             "clear-profile"       {:doc      "Clears profile of samples."
-                                    :requires {}
-                                    :returns  {"status" "Done"}}}})
+  {:doc     "Middleware for manual profiling"
+   :handles {"cider/profile-toggle-var" {:doc      "Toggle profiling of a given var."
+                                         :requires {"sym" "The symbol to profile"
+                                                    "ns"  "The current namespace"}
+                                         :returns  {"status" "Done"
+                                                    "value"  "'profiled' if profiling enabled, 'unprofiled' if disabled"}}
+             "cider/profile-toggle-ns"  {:doc      "Toggle profiling of given namespace."
+                                         :requires {"ns" "The current namespace"}
+                                         :returns  {"status" "Done"
+                                                    "value"  "'profiled' if profiling enabled, 'unprofiled' if disabled"}}
+             "cider/profile-summary"    {:doc      "Return profiling summary optimized for viewing through CIDER inspector."
+                                         :requires {}
+                                         :returns  {"status" "Done"
+                                                    "value"  "Profile summary as inspectable data structure."}}
+             "cider/profile-clear"      {:doc      "Clear profiling data."
+                                         :requires {}
+                                         :returns  {"status" "Done"}}}})
 
 (def code-reloading-before-after-opts
   {"before" "The namespace-qualified name of a zero-arity function to call before reloading."

--- a/src/cider/nrepl/middleware.clj
+++ b/src/cider/nrepl/middleware.clj
@@ -33,3 +33,12 @@
     cider.nrepl/wrap-undef
     cider.nrepl/wrap-version
     cider.nrepl/wrap-xref])
+
+(def ops-that-can-eval
+  "Set of nREPL ops that can lead to code being evaluated."
+  #{"eval" "load-file"
+    "refresh" "refresh-all" "refresh-clear"
+    "cider.clj-reload/reload" "cider.clj-reload/reload-all" "cider.clj-reload/reload-clear"
+    "toggle-trace-var" "toggle-trace-ns"
+    "undef" "undef-all"
+    "cider/profile-toggle-var" "cider/profile-toggle-ns"})

--- a/src/cider/nrepl/middleware/inspect.clj
+++ b/src/cider/nrepl/middleware/inspect.clj
@@ -34,10 +34,11 @@
   (select-keys msg [:page-size :max-atom-length :max-coll-size
                     :max-value-length :max-nested-depth :display-analytics-hint]))
 
-(defn inspect-reply*
-  [msg value]
+(defn inspect-reply* [{:keys [view-mode] :as msg} value]
   (let [config (msg->inspector-config msg)
-        inspector (swap-inspector! msg #(inspect/start (merge % config) value))]
+        ;; Setting view mode from the start is only needed by cider-profile.
+        inspector (swap-inspector! msg #(cond-> (inspect/start (merge % config) value)
+                                          view-mode (inspect/set-view-mode view-mode)))]
     ;; By using 3-arity `inspector-response` we ensure that the default
     ;; `{:status :done}` is not sent with this message, as the underlying
     ;; eval will send it on its own.

--- a/src/cider/nrepl/middleware/profile.clj
+++ b/src/cider/nrepl/middleware/profile.clj
@@ -1,123 +1,45 @@
 (ns cider.nrepl.middleware.profile
-  "This profiler is intended for interactive profiling applications where you do
-  not expect a profiling tool to automatically compensate for JVM
-  warm-up and garbage collection issues. If you are doing numeric
-  computing or writing other purely functional code that can be
-  executed repeatedly without unpleasant side effects, I recommend you
-  at the very least check out Criterium.
-
-  If you are primarily concerned about the influence of JVM-exogenous
-  factors on your code—HTTP requests, SQL queries, other network-
-  or (possibly) filesystem-accessing operations—then this package may
-  be just what the doctor ordered.
-
-  Based on older middleware (nrepl-profile) that's not actively
-  maintained anymore."
-  {:author "Edwin Watkeys"}
+  "Simplistic manual tracing profiler for coarse usecases where the accuracy
+  doesn't matter much and you already know which functions to measure."
   (:require
-   [cider.nrepl.middleware.util :refer [respond-to]]
-   [profile.core :as p]))
+   [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
+   [cider.nrepl.middleware.inspect :as inspect-mw]
+   [nrepl.misc :refer [response-for]]
+   [orchard.profile :as profile]))
 
-(defn- send-exception
-  [_e msg]
-  (respond-to msg :status :done :value "exception"))
+(defn toggle-var-reply [{:keys [ns sym] :as msg}]
+  (if-let [v (ns-resolve (symbol ns) (symbol sym))]
+    (if (profile/profiled? v)
+      (do (profile/unprofile-var v)
+          (response-for msg :status :done :value "unprofiled"))
+      (if (profile/profilable? v)
+        (do (profile/profile-var v)
+            (response-for msg :status :done :value "profiled"))
+        (response-for msg :status [:done :profile-invalid-var])))
+    (response-for msg :status #{:profile-no-such-var :done})))
 
-(defn toggle-profile
-  [{:keys [ns sym transport] :as msg}]
-  (try
-    (if-let [v (ns-resolve (symbol ns) (symbol sym))]
-      (let [profiled? (p/toggle-profile-var* v)]
-        (respond-to msg
-                    :status :done
-                    :value (if profiled? "profiled" "unprofiled")))
-      (respond-to msg
-                  :status #{:toggle-profile-not-such-var :done}
-                  :value "unbound"))
-    (catch Exception e (send-exception e msg))))
-
-(defn profile-var-summary
-  [{:keys [ns sym transport] :as msg}]
-  (try
-    (if-let [v (ns-resolve (symbol ns) (symbol sym))]
-      (if-let [table (with-out-str (binding [*err* *out*]
-                                     (p/print-entry-summary v)))]
-        (respond-to msg
-                    :status :done
-                    :err table)
-        (respond-to msg
-                    :status :done
-                    :err (format "No profile data for %s." v)))
-      (respond-to msg
+(defn toggle-ns-reply [{:keys [ns transport] :as msg}]
+  (let [profiled? (profile/toggle-profile-ns (symbol ns))]
+    (response-for msg
                   :status :done
-                  :value (format "Var %s/%s is not bound." ns sym)))
-    (catch Exception e (prn :e e) (send-exception e msg))))
+                  :value (if profiled? "profiled" "unprofiled"))))
 
-(defn profile-summary
+(defn summary-reply
+  "Return profiling summary optimized for viewing through CIDER inspector."
   [{:keys [transport] :as msg}]
-  (try
-    (respond-to msg
-                :status :done
-                :err (with-out-str
-                       (binding [*err* *out*] (p/print-summary))))
-    (catch Exception e (send-exception e msg))))
+  (inspect-mw/inspect-reply*
+   (assoc msg
+          :max-coll-size 1 ;; To narrow :samples column.
+          :view-mode :table)
+   (profile/summary-for-inspector)))
 
-(defn clear-profile
-  [{:keys [transport] :as msg}]
-  (try
-    (p/clear-profile-data)
-    (respond-to msg
-                :status :done
-                :value "cleared")
-    (catch Exception e (send-exception e msg))))
+(defn clear-reply [msg]
+  (profile/clear)
+  (response-for msg :status [:done :profile-cleared]))
 
-(defn toggle-profile-ns
-  [{:keys [ns transport] :as msg}]
-  (try (let [profiled? (p/toggle-profile-ns (symbol ns))]
-         (respond-to msg
-                     :status :done
-                     :value (if profiled? "profiled" "unprofiled")))
-       (catch Exception e (send-exception e msg))))
-
-(defn is-var-profiled
-  [{:keys [ns sym transport] :as msg}]
-  (try (let [var (ns-resolve (symbol ns) (symbol sym))
-             profiled? (p/profiled? @var)]
-         (respond-to msg
-                     :status :done
-                     :value (if profiled? "profiled" "unprofiled")))
-       (catch Exception e (send-exception e msg))))
-
-(defn get-max-samples
-  [{:keys [transport] :as msg}]
-  (try (respond-to msg
-                   :status :done
-                   :value (str (p/max-sample-count)))
-       (catch Exception e (send-exception e msg))))
-
-(defn normalize-max-samples [n]
-  (cond (and (sequential? n) (empty? n)) nil
-        (string? n) (Long/parseLong n)
-        :else n))
-
-(defn set-max-samples
-  [{:keys [max-samples transport] :as msg}]
-  (try (let [max-samples (normalize-max-samples max-samples)]
-         (p/set-max-sample-count max-samples)
-         (respond-to msg
-                     :status :done
-                     :value (str (p/max-sample-count))))
-       (catch Exception e  (send-exception e msg))))
-
-(defn handle-profile
-  [handler msg]
-  (let [{:keys [op]} msg]
-    (case op
-      "toggle-profile"      (toggle-profile msg)
-      "toggle-profile-ns"   (toggle-profile-ns msg)
-      "is-var-profiled"     (is-var-profiled msg)
-      "profile-summary"     (profile-summary msg)
-      "profile-var-summary" (profile-var-summary msg)
-      "clear-profile"       (clear-profile msg)
-      "get-max-samples"     (get-max-samples msg)
-      "set-max-samples"     (set-max-samples msg)
-      (handler msg))))
+(defn handle-profile [handler msg]
+  (with-safe-transport handler msg
+    "cider/profile-toggle-var" toggle-var-reply
+    "cider/profile-toggle-ns"  toggle-ns-reply
+    "cider/profile-summary"    summary-reply
+    "cider/profile-clear"      clear-reply))

--- a/src/cider/nrepl/middleware/track_state.clj
+++ b/src/cider/nrepl/middleware/track_state.clj
@@ -2,6 +2,7 @@
   "State tracker for client sessions."
   {:author "Artur Malabarba"}
   (:require
+   [cider.nrepl.middleware :as mw]
    [cider.nrepl.middleware.util :as util]
    [cider.nrepl.middleware.util.cljs :as cljs]
    [cider.nrepl.middleware.util.meta :as um]
@@ -334,17 +335,12 @@
         (send ns-cache update-in [session]
               update-and-send-cache msg)))))
 
-(def ops-that-can-eval
-  "Set of nREPL ops that can lead to code being evaluated."
-  #{"eval" "load-file" "refresh" "refresh-all" "refresh-clear"
-    "toggle-trace-var" "toggle-trace-ns" "undef"})
-
 (defn handle-tracker [handler {:keys [op session] :as msg}]
   (cond
     (= "cider/get-state" op)
     (send ns-cache update-in [session] update-and-send-cache msg)
 
-    (ops-that-can-eval op)
+    (mw/ops-that-can-eval op)
     (handler (assoc msg :transport (make-transport msg)))
 
     :else

--- a/src/cider/nrepl/middleware/util/meta.clj
+++ b/src/cider/nrepl/middleware/util/meta.clj
@@ -8,7 +8,8 @@
   This is used so that we don't crowd the ns cache with useless or
   redudant information, such as :name and :ns."
   [:indent :deprecated :macro :arglists :test :doc :fn
-   :cider/instrumented :style/indent :orchard.trace/traced])
+   :cider/instrumented :style/indent :orchard.trace/traced
+   :orchard.profile/profiled])
 
 (defn relevant-meta
   "Filter the entries in map m by `relevant-meta-keys` and non-nil values."

--- a/test/clj/cider/nrepl/middleware/profile_test.clj
+++ b/test/clj/cider/nrepl/middleware/profile_test.clj
@@ -1,61 +1,47 @@
 (ns cider.nrepl.middleware.profile-test
   (:require
-   [cider.nrepl.middleware.profile :refer :all]
-   [cider.nrepl.test-transport :refer [test-transport]]
-   [clojure.string :as str]
-   [clojure.test :refer :all]))
+   [cider.nrepl.test-session :as session]
+   [cider.test-helpers :refer :all]
+   [clojure.test :refer :all]
+   [matcher-combinators.matchers :as mc]
+   [orchard.profile]))
 
-(defn with-clear-profile
-  [f]
-  (f)
-  (clear-profile {:transport (test-transport)}))
+(defn- with-clear-and-unprofile [f]
+  (orchard.profile/clear)
+  (orchard.profile/unprofile-all)
+  (f))
 
-(use-fixtures :each with-clear-profile)
+(use-fixtures :each session/session-fixture with-clear-and-unprofile)
 
 (deftest toggle-profile-test
   (testing "profile toggling"
-    (is (= [{:value "profiled" :status #{:done}}]
-           (toggle-profile {:ns "clojure.core" :sym "zipmap" :transport (test-transport)})))
-    (is (= [{:value "unprofiled" :status #{:done}}]
-           (toggle-profile {:ns "clojure.core" :sym "zipmap" :transport (test-transport)})))))
+    (is+ {:value ["profiled"] :status #{"done"}}
+         (session/message {:op  "cider/profile-toggle-var"
+                           :ns  "clojure.core"
+                           :sym "zipmap"}))
+    (is+ {:value ["unprofiled"] :status #{"done"}}
+         (session/message {:op  "cider/profile-toggle-var"
+                           :ns  "clojure.core"
+                           :sym "zipmap"}))))
 
-(deftest profile-var-summary-test
+(deftest profile-summary-test
   (testing "Var profile sumary"
-    (toggle-profile {:ns "clojure.core" :sym "zipmap" :transport (test-transport)})
-    (zipmap [:a :b :c] [1 2 3])
-    (let [[{:keys [^String err status]}] (profile-var-summary {:ns        "clojure.core"
-                                                               :sym       "zipmap"
-                                                               :transport (test-transport)})]
-      (is (.startsWith err "#'clojure.core/zipmap"))
-      (is (= #{:done} status)))
-    (toggle-profile {:ns "clojure.core" :sym "zipmap" :transport (test-transport)})
-    (clear-profile {:transport (test-transport)}))
-
-  (testing "No Var bound"
-    (is (= [{:value "Var clojure.core/not-existent is not bound." :status #{:done}}]
-           (profile-var-summary {:ns "clojure.core" :sym "not-existent" :transport (test-transport)})))))
+    (session/message {:op  "cider/profile-toggle-var"
+                      :ns  "clojure.core"
+                      :sym "zipmap"})
+    (is (zipmap [:a :b :c] [1 2 3]))
+    (is+ {:status #{"done"}
+          :value [(mc/via read-string
+                          (mc/prefix ["Class: " [:value "clojure.lang.ArraySeq" 0] [:newline]
+                                      "Count: 1" [:newline] [:newline]
+                                      "--- Contents:" [:newline] [:newline]]))]}
+         (session/message {:op "cider/profile-summary"}))))
 
 (deftest toggle-profile-ns-test
   (testing "toggling profile ns"
-    (is (= [{:value "profiled" :status #{:done}}]
-           (toggle-profile-ns {:ns "clojure.string" :transport (test-transport)})))
-    (is (= [{:value "unprofiled" :status #{:done}}]
-           (toggle-profile-ns {:ns "clojure.string" :transport (test-transport)}))))
-
-  (testing "unbounding profile"
-    (is (= [{:value "exception" :status #{:done}}]
-           (toggle-profile-ns {:ns "my.ns" :transport (test-transport)})))))
-
-(deftest is-var-profiled-test
-  (testing "is var profiled"
-    (toggle-profile {:ns "clojure.core" :sym "zipmap" :transport (test-transport)})
-    (is (= [{:value "profiled" :status #{:done}}]
-           (is-var-profiled {:ns "clojure.core" :sym "zipmap" :transport (test-transport)})))
-    (toggle-profile {:ns "clojure.core" :sym "zipmap" :transport (test-transport)})
-    (is (= [{:value "unprofiled" :status #{:done}}]
-           (is-var-profiled {:ns "clojure.core" :sym "zipmap" :transport (test-transport)})))))
-
-(deftest set-max-examples-test
-  (testing "max examples"
-    (is (= [{:value "5000" :status #{:done}}]
-           (set-max-samples {:max-samples 5000 :transport (test-transport)})))))
+    (is+ {:value ["profiled"] :status #{"done"}}
+         (session/message {:op  "cider/profile-toggle-ns"
+                           :ns  "clojure.string"}))
+    (is+ {:value ["unprofiled"] :status #{"done"}}
+         (session/message {:op  "cider/profile-toggle-ns"
+                           :ns  "clojure.string"}))))


### PR DESCRIPTION
Sister PR: https://github.com/clojure-emacs/orchard/pull/333

- Bumped Orchard
- Removed thunknyc/profile from dependencies
- Dropped several ops from the middleware – things like individual function summaries, tuning max sample count, stuff like that. Only four ops remain: toggle profile for a var, for a whole ns, clear results, and render results via the inspector.
- Renamed the remaining ops to have `cider/` prefix. I briefly tried keeping the semblance of backward compatibility and keep old names too, but since the most important op (summary) is not compatible with its old implementation, it provides no value. GIven that the feature is an obscure one, I don't care much about breakages here.
- Added `:orchard.profile/profiled` as a relevant meta key – we can then outline vars with it in the same way we do with traced vars.

---

- [x] You've added tests to cover your change(s)
- [x] You've updated the README
- [x] Middleware documentation is up to date