### PR TITLE
[stacktrace] Add support for directly inspecting ex-data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Bump `orchard` to [0.33.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0330-2025-04-08).
 * [#929](https://github.com/clojure-emacs/cider-nrepl/pull/929): Migrate profiling middleware to orchard.profile.
+* [#930](https://github.com/clojure-emacs/cider-nrepl/pull/930): Stacktrace: add support for directly inspecting ex-data
 
 ## 0.54.0 (2025-04-05)
 

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -475,7 +475,8 @@ Required parameters::
 
 
 Optional parameters::
-{blank}
+* `:ex-data` When equal to "true", inspect ex-data of the exception instead of full exception.
+
 
 Returns::
 * `:status` "done", or "no-error" if ``analyze-last-stacktrace`` wasn't called beforehand (or the ``index`` was out of bounds).

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -686,6 +686,7 @@ those configured directories will be honored."
               "inspect-last-exception" {:doc "Returns an Inspector response for the last exception that has been processed through `analyze-last-stacktrace` for the current nrepl session.
 Assumes that `analyze-last-stacktrace` has been called first, returning \"no-error\" otherwise."
                                         :requires {"index" "0 for inspecting the top-level exception, 1 for its ex-cause, 2 for its ex-cause's ex-cause, and so on."}
+                                        :optional {"ex-data" "When equal to \"true\", inspect ex-data of the exception instead of full exception."}
                                         :returns {"status" "\"done\", or \"no-error\" if `analyze-last-stacktrace` wasn't called beforehand (or the `index` was out of bounds)."
                                                   "value" "A value, as produced by the Inspector middleware."}}
               "stacktrace" {:doc "Return messages describing each cause and


### PR DESCRIPTION
Changes made to address https://github.com/clojure-emacs/cider/issues/3804.

1. The op `inspect-last-exception` now accepts `ex-data: true` parameter that tells it the user wants to inspect ex-data of the exception directly, not the entire exception. This is used to have separate buttons in `*cider-error*` buffer for the whole exception and for just ex-data.
2. Replaced a separate dynamic variable manually stored in the session with storing the last analyzed exception inside session's metadata – the same approach as used by inspector middleware.

---

- [x] You've updated the README
- [x] Middleware documentation is up to date