### PR TITLE
[track-state] Completely redesign track-state middleware

### DIFF
--- a/test/clj/cider/nrepl/middleware/track_state_test.clj
+++ b/test/clj/cider/nrepl/middleware/track_state_test.clj
@@ -1,93 +1,22 @@
 (ns cider.nrepl.middleware.track-state-test
   (:require
    [cider.nrepl.middleware.track-state :as sut]
-   [cider.nrepl.middleware.util.cljs :as cljs]
-   [cider.nrepl.middleware.util.meta :as um]
-   [clojure.test :refer :all])
-  (:import
-   (nrepl.transport Transport)))
+   [cider.nrepl.test-session :as session]
+   [cider.test-helpers :refer :all]
+   [clojure.test :refer [deftest is testing]]
+   [matcher-combinators.matchers :as matchers]
+   [nrepl.core :as nrepl]
+   [nrepl.misc]))
 
-(def some-ns-map {'cider.nrepl.middleware.track-state-test
-                  (sut/ns-as-map (find-ns 'cider.nrepl.middleware.track-state-test)
-                                 (all-ns))})
-
-;;; This is to prevent the agent from flooding test reports with
-;;; irrelevant exceptions.
-(set-error-handler! sut/ns-cache (constantly nil))
-(set-error-mode! sut/ns-cache :continue)
-
-(def msg {:session :dummy})
-
-(deftest make-transport-test
-  (is (instance? Transport (sut/make-transport msg)))
-  (is (try (send (sut/make-transport msg) 10)
-           nil
-           (catch Exception e true))))
-
-(defn update-and-send-cache-tester
-  "Use the other arity of sut/update-and-send-cache to evaluate
-  strictly in test mode."
-  [old-data msg sent-value]
-  (sut/update-and-send-cache old-data msg
-                             #{}
-                             (fn [t m] (reset! sent-value m))))
-
-(deftest update-and-send-cache-test
-  (let [sent-value (atom nil)]
-    (let [new-data (update-and-send-cache-tester nil msg sent-value)]
-      (is (map? new-data))
-      (is (< 100 (count new-data))))
-    (let [{:keys [repl-type changed-namespaces]} @sent-value]
-      (is (= :clj repl-type))
-      (is (map? changed-namespaces))
-      (is (< 100 (count changed-namespaces))))
-    (let [full-cache (update-and-send-cache-tester nil msg sent-value)
-          get-sent-value (fn [old] (update-and-send-cache-tester old msg sent-value)
-                           @sent-value)]
-      ;; Return value depends only on the current state.
-      (is (= (update-and-send-cache-tester nil msg sent-value)
-             (update-and-send-cache-tester (into {} (take 5 full-cache)) msg sent-value)
-             (update-and-send-cache-tester full-cache msg sent-value)))
-      ;; Sent message depends on the first arg.
-      (is (= (get-sent-value full-cache)
-             (get-sent-value full-cache)))
-      (is (= (get-sent-value (into {} (drop 3 full-cache)))
-             (get-sent-value (into {} (drop 3 full-cache))))))
-    ;; In particular, the sent message only contains the diff.
-
-    (let [changed-again (:changed-namespaces @sent-value)]
-      (is (map? changed-again))
-      (is (= 3 (count changed-again))))
-    ;; Check repl-type :cljs
-
-    (with-redefs [cljs/grab-cljs-env (constantly true)]
-      (update-and-send-cache-tester nil msg sent-value)
-      (let [{:keys [repl-type changed-namespaces]} @sent-value]
-        (is (= :cljs repl-type))
-        (is (map? changed-namespaces))))))
+(def some-ns-map
+  (delay {'cider.nrepl.middleware.track-state-test
+          (with-bindings* {#'sut/*real-metadata-cache* (atom {})} ;; [@ (atom {})]
+            #(#'sut/ns-state (find-ns 'cider.nrepl.middleware.track-state-test)))}))
 
 (def ^:private fn-test-var nil)
 (def ^:private fn-test-def-fn (fn []))
 (defn- fn-test-defn-fn [])
 (defmulti fn-test-multi (fn [x]))
-
-(deftest filter-core-and-get-meta-test
-  (is (= (sut/filter-core-and-get-meta {'and #'and, 'b #'map, 'c #'deftest})
-         '{c {:macro "true"
-              :arglists "([name & body])"
-              :fn "true"
-              :doc "\"Defines a test function with no arguments.  Test functions may call\\n  other tests, so tests may be composed.  If you compose tests, you\\n  should also define a function named test-ns-hook; run-tests will\\n  call test-ns-hook instead of testing all vars.\\n\\n  Note: Actually, the test body goes in the :test metadata on the var,\\n  and the real function (the value of the var) calls test-var on\\n  itself.\\n\\n  When *load-tests* is false, deftest is ignored.\""}}))
-  (is (= [nil "true" "true" "true"]
-         (map (comp :fn
-                    (sut/filter-core-and-get-meta
-                     {'fn-test-var #'fn-test-var
-                      'fn-test-def-fn #'fn-test-def-fn
-                      'fn-test-defn-fn #'fn-test-defn-fn
-                      'fn-test-multi #'fn-test-multi}))
-              '[fn-test-var fn-test-def-fn fn-test-defn-fn fn-test-multi])))
-  (is (-> (find-ns 'clojure.core)
-          ns-map sut/filter-core-and-get-meta
-          seq not)))
 
 (defn- test-fn "docstring"
   ([a b] nil)
@@ -96,34 +25,22 @@
 
 (defmacro test-macro [a & body])
 
-(deftest ns-as-map-test
-  (is (empty? (sut/ns-as-map nil (all-ns))))
-  (let [m (meta #'make-transport-test)]
-    ;; #'make-transport refers to the deftest, and not the defn
-    (->> (interleave um/relevant-meta-keys (range))
-         (apply hash-map)
-         (alter-meta! #'make-transport-test merge))
-    ;; note: this test inspects the current namespace, so the
-    ;; test conditions below may change as the namespace declaration
-    ;; evolves.
-    (let [{:keys [interns aliases] :as ns}
-          (sut/ns-as-map (find-ns 'cider.nrepl.middleware.track-state-test)
-                         (all-ns))]
-      (is (< 5 (count interns)))
-      (is (map? interns))
-      (is (interns 'ns-as-map-test))
-      (is (:test (interns 'ns-as-map-test)))
-      (is (= (into #{} (keys (interns 'make-transport-test)))
-             (into #{} um/relevant-meta-keys)))
-      (is (= 3 (count aliases)))
-      (is (= 'cider.nrepl.middleware.track-state (aliases 'sut))))
-    (alter-meta! #'make-transport-test (fn [x y] y) m))
-  (let [{:keys [interns aliases] :as ns}
-        (sut/ns-as-map (find-ns 'cider.nrepl.middleware.track-state-test)
-                       (all-ns))]
-    (is interns)))
+(deftest ns-state-clj-test
+  (is+ '{:aliases {sut cider.nrepl.middleware.track-state
+                   matchers matcher-combinators.matchers}
+         :interns {test-fn {:fn "true"}
+                   testing {:macro "true"}
+                   macro-without-style-indent-1 {:macro "true", :style/indent "1"}
+                   is {:macro "true"}
+                   is+ {:macro "true"}
+                   fn-test-multi {:fn "true"}
+                   deftest {:macro "true"}
+                   fn-test-def-fn {:fn "true"}
+                   fn-test-var {}
+                   test-macro {:macro "true", :style/indent "1"}}}
+       (sut/ns-state (find-ns 'cider.nrepl.middleware.track-state-test))))
 
-(deftest ns-as-map-cljs-test
+(deftest ns-state-cljs-test
   (let [cljs-ns {:use-macros {'test-fn 'cider.nrepl.middleware.track-state-test
 
                               'test-macro 'cider.nrepl.middleware.track-state-test}
@@ -152,87 +69,83 @@
                  :requires {'sym-3 'some-namespace}}
         other-namespaces [{:name 'some-other-cljs-ns
                            :defs {'sym-1 {:meta {:arglists '([] [a] [a b])}}}}]
-        {:keys [aliases interns]} (sut/ns-as-map cljs-ns other-namespaces)]
-    (is (any? (sut/ns-as-map (dissoc cljs-ns :macros :require-macros :use-macrps)
-                             other-namespaces))
-        "Doesn't throw exceptions in the absence of optional keys")
-    (is (= '{sym-2 some-namespace sym-3 some-namespace} aliases))
-    (is (= '{a-fn {:fn "true"},
-             b-fn {:fn "true"},
-             c-fn {:fn "true"},
-             d-fn {:fn "true"},
-             a-var {},
-             ;; fetched by traversing `other-namespaces`:
-             sym-1 {:arglists "([] [a] [a b])"},
-             ;; fetched by inspecting the JVM clojure environment:
-             test-fn {:arglists "([a b] [a] [])", :doc "\"docstring\""}
-             ;; adds :style/indent despite it not being originally present:
-             test-macro {:macro "true", :arglists "([a & body])", :style/indent "1"}
-             ;; :style/indent is preserved:
-             from-macros-with-style-indent {:macro "true", :arglists "([& args])", :style/indent ":defn"},
-             ;; :style/indent is inferred:
-             from-macros-without-style-indent {:macro "true", :arglists "([& args])", :style/indent "0"}}
-           interns))))
+        {:keys [aliases interns]} (sut/ns-state cljs-ns)]
+    (binding [sut/*all-cljs-namespaces* other-namespaces]
+      (let [{:keys [aliases interns]} (sut/ns-state cljs-ns)]
+        (is (any? (sut/ns-state (dissoc cljs-ns :macros :require-macros :use-macros)))
+            "Doesn't throw exceptions in the absence of optional keys")
+        (is (= '{sym-2 some-namespace sym-3 some-namespace} aliases))
+        (is (= '{a-fn {:fn "true"},
+                 b-fn {:fn "true"},
+                 c-fn {:fn "true"},
+                 d-fn {:fn "true"},
+                 a-var {},
+                 ;; fetched by traversing `other-namespaces`:
+                 sym-1 {:arglists "([] [a] [a b])"},
+                 ;; fetched by inspecting the JVM clojure environment:
+                 test-fn {:arglists "([a b] [a] [])", :doc "\"docstring\""}
+                 ;; adds :style/indent despite it not being originally present:
+                 test-macro {:macro "true", :arglists "([a & body])", :style/indent "1"}
+                 ;; :style/indent is preserved:
+                 from-macros-with-style-indent {:macro "true", :arglists "([& args])", :style/indent ":defn"},
+                 ;; :style/indent is inferred:
+                 from-macros-without-style-indent {:macro "true", :arglists "([& args])", :style/indent "0"}}
+               interns))))))
 
 (deftest calculate-used-aliases-test
-  (is (contains? (sut/merge-used-aliases some-ns-map nil ns-name (all-ns))
-                 'cider.nrepl.middleware.track-state))
-  (is (contains? (sut/merge-used-aliases some-ns-map {'cider.nrepl.middleware.track-state nil} ns-name (all-ns))
-                 'cider.nrepl.middleware.track-state))
-  (is (contains? (sut/merge-used-aliases (assoc some-ns-map 'cider.nrepl.middleware.track-state nil) nil ns-name (all-ns))
+  (is (contains? (#'sut/merge-used-aliases @some-ns-map)
                  'cider.nrepl.middleware.track-state)))
 
 (deftest ensure-clojure-core-present
   (testing "if clojurescript doesn't add clojure"
-    ;; note that the {:msg :stuff} object is much more complex in
-    ;; actual use and in fact the msg is much more complicated
-    (is (-> (sut/ensure-clojure-core-present {}
-                                             {'cljs.core :present}
-                                             {:msg :stuff}
-                                             (all-ns))
-            keys
-            #{sut/clojure-core}
-            not)))
-  (testing "if core already present doesn't overwrite or add"
-    (is (= :present
-           (-> (sut/ensure-clojure-core-present {}
-                                                {sut/clojure-core :present}
-                                                nil
-                                                (all-ns))
-               (get sut/clojure-core)))))
+    (binding [sut/*cljs* true]
+      (is (not (contains? (#'sut/add-core-namespace-vars {}) 'clojure.core)))))
   (testing "if core missing and not cljs, it adds it"
-    (is (= sut/clojure-core-map
-           (-> (sut/ensure-clojure-core-present {} {} nil (all-ns))
-               (get sut/clojure-core))))))
+    (is (contains? (#'sut/add-core-namespace-vars {}) 'clojure.core))))
 
 (defmacro macro-without-style-indent-1 [opts & body])
 (defmacro macro-without-style-indent-2 [opts body])
 (defmacro macro-without-style-indent-3 [opts baddy])
 (defmacro macro-with-explicitly-nil-style-indent {:style/indent nil} [opts & body])
 
-(def mock-msg (reify nrepl.transport/Transport
-                (recv [this])
-                (recv [this timeout])
-                (send [this msg])))
-
 (deftest indentation-inference-test
   (testing "Adds `:style/indent` metadata when it's suitable to do so"
-    (let [cache (sut/update-and-send-cache nil
-                                           {:transport mock-msg})
-          interns (-> cache
-                      (get 'cider.nrepl.middleware.track-state-test)
-                      :interns)]
-      (is (= "1"
-             (-> interns (get 'macro-without-style-indent-1) :style/indent)))
-      (is (= "1"
-             (-> interns (get 'macro-without-style-indent-2) :style/indent)))
-      (is (= nil
-             (-> interns (get 'macro-without-style-indent-3) :style/indent)))
-      (is (= nil
-             (-> interns (get 'macro-with-explicitly-nil-style-indent) :style/indent))))))
+    (is+ {"interns" {"macro-without-style-indent-1" {"style/indent" "1"}
+                     "macro-without-style-indent-2" {"style/indent" "1"}
+                     "macro-without-style-indent-3" {"style/indent" matchers/absent}
+                     "macro-with-explicitly-nil-style-indent" {"style/indent" matchers/absent}}}
+         (-> (sut/calculate-changed-project-state-response {:session (atom {})})
+             (get-in [:changed-namespaces "cider.nrepl.middleware.track-state-test"])))))
 
 (deftest inferrable-indent?-test
   (testing "clojure.* macros are not inferrable"
     (is (#'sut/inferrable-indent? (meta #'macro-without-style-indent-1)))
     (is (not (#'sut/inferrable-indent? (meta #'defn))))
     (is (not (#'sut/inferrable-indent? (meta #'deftest))))))
+
+(defn- message-and-state [msg]
+  (last ((#'nrepl/delimited-transport-seq
+          session/*session* #{"state" :state} {:id (nrepl.misc/uuid)}) msg)))
+
+(deftest integration-test
+  (session/session-fixture
+   (fn []
+     (is+ {:changed-namespaces {:cider.nrepl.middleware.track-state-test
+                                {:interns #(> (count %) 10)}}}
+          (message-and-state {:op   "eval"
+                              :code "(+ 1 2)"}))
+
+     (testing "subsequent evaluation reports empty changed state"
+       (is+ {:changed-namespaces empty?}
+            (message-and-state {:op   "eval"
+                                :code "(+ 1 2)"})))
+
+     (testing "modifying metadata reports just updates to that var"
+       (is+ {:changed-namespaces
+             (matchers/all-of #(= (count %) 1)
+                              {:cider.nrepl.middleware.track-state-test
+                               {:interns {:fn-test-defn-fn {:fn "true" :deprecated "true"}}}})}
+            (message-and-state {:op   "eval"
+                                :code "(alter-meta! #'cider.nrepl.middleware.track-state-test/fn-test-defn-fn assoc :deprecated true)"})))
+     ;; Restore
+     (alter-meta! #'cider.nrepl.middleware.track-state-test/fn-test-defn-fn dissoc :deprecated))))


### PR DESCRIPTION
I can't believe it took me this long to get to this. The current implementation of `track-state` is very far from ideal and I had problems with it for a long time (see #806). In the current large project I'm testing this, every eval op takes ~300-400ms to recalculate the updated state (even if there were no changes to relevant metadata) and this produces ~250-300 MB of garbage. The state recalculation doesn't delay the evaluation result (as the state update happens on a separate thread), but it delays font lock updates which can be annoying. Besides, the allocated garbage produces extra strain if a REPL process is already low on memory. Finally, the cache used by this middleware occupies again ~200 MB of heap, and there is a counterpart cache on the Emacs side which eats memory and causes GC pauses too.

This is a complete redesign. Here are the main points:
- Drop metadata that is not relevant to state tracking. Namely, I removed `:doc` and `:arglists`. This instantly reduced the cache size by a lot.
- The most common relevant metadata for functions is `{:fn "true"}` (not private, not deprecated, not a macro). Reusing this as a literal brings down retained cached size further. This is very significant.
- **New cache design.**
   - For each namespace, we keep a map of `var-symbol -> real-metadata-map`. Because the "relevant metadata map" is always a derivative of a real metadata map, we can skip recomputing the relevant map if the real one hasn't changed, and take the computed map from the cache (from previous run). This map is kept as WeakHashMap to avoid holding onto metadata maps for vars that could have been undefined. The cache WHM is updated if the real metadata of the var has changed since the previous run.
   - For each loaded namespace, we go over its vars and recompute relevant metadata maps. If none of the vars changed its metadata, it means we took all relevant meta maps from cache, and the whole namespace state can remain as is (speeds up the comparison/diff operations later).

The remaining changes are mostly about refactoring and prettyfication. I introduced a couple of dynamic vars to simplify the internal API. Dynvars usually have worse performance, but here it is negligible, and I cache them into local vars where necessary.

Results on that large project:
- ~15ms middleware execution time (it becomes ~20-40ms end to end – time between "done" and "state" messages, but it still feels instant).
- ~3-4 MB allocated.

The public API hasn't changed. There are minor tweaks to be done on CIDER side later, but overall this is backwards-compatible.

---

- [ ] You've updated the README