### PR TITLE
Add support for pretty printing values in the inspector.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## 0.55.1 (2025-04-14)
 
 * [#931](https://github.com/clojure-emacs/cider-nrepl/pull/931): Redesign and optimize track-state middleware.
+* [#932](https://github.com/clojure-emacs/cider-nrepl/pull/932) Add support for pretty printing values in the inspector.
 
 ## 0.55.0 (2025-04-10)
 

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -731,6 +731,24 @@ Returns::
 
 
 
+=== `inspect-toggle-pretty-print`
+
+Toggles the pretty printing of values in the inspector.
+
+Required parameters::
+* `:session` The current session
+
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:path` Printed representation of current inspector path.
+* `:status` "done"
+* `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
+
+
+
 === `inspect-toggle-view-mode`
 
 Toggles the viewing mode of the inspector. This influences the way how inspector is rendering the current value. ``:normal`` is the default. When view mode is ``:table``, the value will be rendered as a table (only supported for sequences of maps or tuples). When view mode is ``:object``, any value will be rendered as a Java object (fields shown as is). View mode is automatically reset back to normal when navigating to child values.

--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/clojure-emacs/cider-nrepl"}
   :dependencies [[nrepl/nrepl "1.3.1" :exclusions [org.clojure/clojure]]
-                 [cider/orchard "0.33.0" :exclusions [org.clojure/clojure]]
+                 [cider/orchard "0.34.0" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [fipp ~fipp-version] ; can be removed in unresolved-tree mode
                  ^:inline-dep [compliment "0.7.0"]
                  ^:inline-dep [org.rksm/suitable "0.6.2" :exclusions [org.clojure/clojure

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -341,6 +341,10 @@ if applicable, and re-render the updated value."
                           "max-nested-depth" "New max nested depth of rendered collection"
                           "view-mode" "Mode of viewing the value - either `:normal` or `:object`"}
                :returns inspector-returns}
+              "inspect-toggle-pretty-print"
+              {:doc "Toggles the pretty printing of values in the inspector."
+               :requires {"session" "The current session"}
+               :returns inspector-returns}
               "inspect-toggle-view-mode"
               {:doc "Toggles the viewing mode of the inspector. This influences the way how inspector is rendering the current value. `:normal` is the default. When view mode is `:table`, the value will be rendered as a table (only supported for sequences of maps or tuples). When view mode is `:object`, any value will be rendered as a Java object (fields shown as is). View mode is automatically reset back to normal when navigating to child values."
                :requires {"session" "The current session"}

--- a/src/cider/nrepl/middleware/inspect.clj
+++ b/src/cider/nrepl/middleware/inspect.clj
@@ -31,8 +31,10 @@
      (response-for msg data extra-response-data))))
 
 (defn- msg->inspector-config [msg]
-  (select-keys msg [:page-size :max-atom-length :max-coll-size
-                    :max-value-length :max-nested-depth :display-analytics-hint]))
+  (-> (select-keys msg [:page-size :max-atom-length :max-coll-size
+                        :max-value-length :max-nested-depth :display-analytics-hint
+                        :pretty-print])
+      (update :pretty-print #(= "true" %))))
 
 (defn inspect-reply* [{:keys [view-mode] :as msg} value]
   (let [config (msg->inspector-config msg)
@@ -77,6 +79,9 @@
   (let [overrides (msg->inspector-config msg)]
     (inspector-response msg (swap-inspector! msg #(inspect/refresh % overrides)))))
 
+(defn toggle-pretty-print-reply [msg]
+  (inspector-response msg (swap-inspector! msg #(-> (update % :pretty-print not) (inspect/inspect-render)))))
+
 (defn- toggle-view-mode [{:keys [view-mode] :as inspector}]
   ;; The order in which view modes are cycled depends on the inspected object.
   (let [toggle-order (if (inspect/supports-table-view-mode? inspector)
@@ -120,6 +125,7 @@
       "inspect-next-page" next-page-reply
       "inspect-prev-page" prev-page-reply
       "inspect-refresh" refresh-reply
+      "inspect-toggle-pretty-print" toggle-pretty-print-reply
       "inspect-toggle-view-mode" toggle-view-mode-reply
       "inspect-display-analytics" display-analytics-reply
       "inspect-set-page-size" refresh-reply

--- a/test/clj/cider/nrepl/middleware/inspect_test.clj
+++ b/test/clj/cider/nrepl/middleware/inspect_test.clj
@@ -691,6 +691,49 @@
     (is+ (matchers/prefix table-mode-prefix)
          (value-skip-header (session/message {:op "inspect-toggle-view-mode"})))))
 
+(deftest pretty-print-integration-test
+  (testing "renders an object with the pretty printer"
+    (session/message {:op "inspect-clear"})
+    (session/message {:op      "eval"
+                      :inspect "true"
+                      :code    "(repeat 5 {:a (repeat 5 {:b 2}) :c (repeat 5 {:d 2})})"})
+    (testing "toggle pretty printing and turn it on"
+      (is+ ["--- Contents:" [:newline]
+            "  0. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
+                                 "\n      :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 1]
+            [:newline]
+            "  1. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
+                                 "\n      :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 2]
+            [:newline]
+            "  2. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
+                                 "\n      :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 3]
+            [:newline]
+            "  3. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
+                                 "\n      :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 4]
+            [:newline]
+            "  4. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
+                                 "\n      :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 5]
+            [:newline]]
+           (value-skip-header (session/message {:op "inspect-toggle-pretty-print"}))))
+    (testing "toggle pretty printing and turn it off"
+      (is+ ["--- Contents:" [:newline]
+            "  0. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
+                                 " :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 1]
+            [:newline]
+            "  1. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
+                                 " :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 2]
+            [:newline]
+            "  2. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
+                                 " :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 3]
+            [:newline]
+            "  3. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
+                                 " :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 4]
+            [:newline]
+            "  4. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
+                                 " :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 5]
+            [:newline]]
+           (value-skip-header (session/message {:op "inspect-toggle-pretty-print"}))))))
+
 (deftest print-length-independence-test
   (testing "*print-length* doesn't break rendering of long collections"
     (is (re-find #"showing page: \d+ of \d+"


### PR DESCRIPTION
Hello,

this PR adds a new pretty view mode that uses the pretty printer from https://github.com/eerohele/pp via this PR in orchard https://github.com/clojure-emacs/orchard/pull/335. I believe there are no changes needed on the Emacs side.

TODO:
- Tests are failing because I need a new orchard version on ci, but how?

Open questions:
- Where should we put the pretty mode in the toggle list? I would put it after normal mode, 2nd position. Right now it is last, hard to reach In my opinion.
- When drilling down the inspector always switches to normal mode. If I'm in pretty mode I would like to stay there, and I would argue for other modes as well, if possible. right now you have to toggle a ton, to get that behaviour. 
Wdyt?

---
Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [ ] You've updated the README
- [x] Middleware documentation is up to date
