### PR TITLE
Add inspect-print-current-value op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* [#933](https://github.com/clojure-emacs/cider-nrepl/pull/933): Add the `cider-inspector-print-current-value` command to print the current value of the inspector.
 * Bump `orchard` to [0.34.1](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0341-2025-04-23).
 * [#935](https://github.com/clojure-emacs/cider-nrepl/pull/935): Unify injected print-method implementations with orchard.print.
 

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -576,6 +576,30 @@ Returns::
 
 
 
+=== `inspect-print-current-value`
+
+Print the current value of the inspector.
+
+Required parameters::
+* `:session` The current session
+
+
+Optional parameters::
+* `:nrepl.middleware.print/buffer-size` The size of the buffer to use when streaming results. Defaults to 1024.
+* `:nrepl.middleware.print/keys` A seq of the keys in the response whose values should be printed.
+* `:nrepl.middleware.print/options` A map of options to pass to the printing function. Defaults to ``nil``.
+* `:nrepl.middleware.print/print` A fully-qualified symbol naming a var whose function to use for printing. Must point to a function with signature [value writer options].
+* `:nrepl.middleware.print/quota` A hard limit on the number of bytes printed for each value.
+* `:nrepl.middleware.print/stream?` If logical true, the result of printing each value will be streamed to the client over one or more messages.
+
+
+Returns::
+* `:path` Printed representation of current inspector path.
+* `:status` "done"
+* `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
+
+
+
 === `inspect-push`
 
 Inspects the inside value specified by index.

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -313,7 +313,12 @@ Note: Documentation may be incomplete; not all return keys are described."
            inspector's state in the `:value` slot."
     :requires #{"clone" #'wrap-caught #'wrap-print}
     :expects #{"eval"}
-    :handles {"inspect-pop"
+    :handles {"inspect-print-current-value"
+              {:doc "Print the current value of the inspector."
+               :requires {"session" "The current session"}
+               :optional wrap-print-optional-arguments
+               :returns inspector-returns}
+              "inspect-pop"
               {:doc "Moves one level up in the inspector stack."
                :requires {"session" "The current session"}
                :returns inspector-returns}

--- a/test/clj/cider/nrepl/middleware/inspect_test.clj
+++ b/test/clj/cider/nrepl/middleware/inspect_test.clj
@@ -745,6 +745,57 @@
                                                     :inspect "true"
                                                     :code    "(range 100)"}))))))))
 
+(deftest inspect-print-current-value-test
+  (testing "inspect-print-current-value returns the currently inspected value as a printed string"
+    (is (= [(str/join "\n" ["{:a -1,"
+                            " :bb \"111\","
+                            " :ccc (1),"
+                            " :d"
+                            " ({:a 0, :bb \"000\", :ccc ()}"
+                            "  {:a -1, :bb \"111\", :ccc (1)}"
+                            "  {:a -2, :bb \"222\", :ccc (2 1)}"
+                            "  {:a -3, :bb \"333\", :ccc (3 2 1)}"
+                            "  {:a -4, :bb \"444\", :ccc (4 3 2 1)})}"])]
+           (:value (do
+                     (session/message {:op "eval"
+                                       :code "(def test-val
+                                                (for [i (range 2)]
+                                                 {:a (- i)
+                                                  :bb (str i i i)
+                                                  :ccc (range i 0 -1)
+                                                  :d (for [i (range 5)]
+                                                       {:a (- i)
+                                                        :bb (str i i i)
+                                                        :ccc (range i 0 -1)})}))"})
+                     (session/message {:op "eval"
+                                       :inspect "true"
+                                       :code "test-val"})
+                     (session/message {:op "inspect-push"
+                                       :idx 2})
+                     (session/message {:op "inspect-print-current-value"
+                                       :nrepl.middleware.print/print "cider.nrepl.pprint/pprint"})))))))
+
+(deftest inspect-print-current-value-no-value-test
+  (testing "inspect-print-current-value returns nil if nothing has been inspected yet"
+    (is (= ["nil"] (:value (session/message
+                            {:op "inspect-print-current-value"
+                             :nrepl.middleware.print/print "cider.nrepl.pprint/pprint"}))))))
+
+(deftest inspect-print-current-value-default-print-fn-test
+  (testing "inspect-print-current-value uses a default print fn when none is provided"
+    (is (= ["nil"] (:value (session/message {:op "inspect-print-current-value"}))))))
+
+(deftest inspect-print-current-value-infinite-seq-test
+  (testing "inspect-print-current-value works with infinite-seqs"
+    (is (str/starts-with? (first (:value (do (session/message {:op "eval"
+                                                               :code "(def test-val (repeat :x))"})
+                                             (session/message {:op "eval"
+                                                               :inspect "true"
+                                                               :code "test-val"})
+                                             (session/message {:op "inspect-print-current-value"
+                                                               :nrepl.middleware.print/print "cider.nrepl.pprint/pprint"}))))
+                          "(:x"))))
+
 (deftest inspect-def-current-value-test
   (testing "inspect-def-current-value defines a var with the current inspector value"
     (is (= "{3 4}"


### PR DESCRIPTION
This PR adds the `inspect-print-current-value` op. It prints the current value of the inspector with the user provided `::print/print-fn` or a default one.

It is used by CIDER in the `cider-inspector-print-current-value` command, bound to "P" in the inspector, to print it's current value. https://github.com/clojure-emacs/cider/pull/3810

Before submitting a PR make sure the following things have been done:

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are mostly passing (there seem to be some unrelated flaky tests)
- [x] You've updated the CHANGELOG
- [x] Middleware documentation is up to date
