### PR TITLE
Unify injected print-method implementations with orchard.print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+* Bump `orchard` to [0.34.1](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0341-2025-04-23).
+* [#935](https://github.com/clojure-emacs/cider-nrepl/pull/935): Unify injected print-method implementations with orchard.print.
+
 ## 0.55.2 (2025-04-18)
 
 * Bump `orchard` to [0.34.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0340-2025-04-18).

--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/clojure-emacs/cider-nrepl"}
   :dependencies [[nrepl/nrepl "1.3.1" :exclusions [org.clojure/clojure]]
-                 [cider/orchard "0.34.0" :exclusions [org.clojure/clojure]]
+                 [cider/orchard "0.34.1" :exclusions [org.clojure/clojure]]
                  ^:inline-dep [fipp ~fipp-version] ; can be removed in unresolved-tree mode
                  ^:inline-dep [compliment "0.7.0"]
                  ^:inline-dep [org.rksm/suitable "0.6.2" :exclusions [org.clojure/clojure

--- a/test/clj/cider/nrepl/middleware/inspect_test.clj
+++ b/test/clj/cider/nrepl/middleware/inspect_test.clj
@@ -41,7 +41,7 @@
    "  " [:value ":column" 4] " = " [:value #"\d+" 5] [:newline]
    "  " [:value ":file" 6] " = " [:value #"\".*cider/nrepl/middleware/inspect_test.clj\"" 7] [:newline]
    "  " [:value ":name" 8] " = " [:value "any-var" 9] [:newline]
-   "  " [:value ":ns" 10] " = " [:value "cider.nrepl.middleware.inspect-test" 11] [:newline]
+   "  " [:value ":ns" 10] " = " [:value "#namespace[cider.nrepl.middleware.inspect-test]" 11] [:newline]
    [:newline]
    "--- Datafy:" [:newline]
    "  0. " [:value "true" 12] [:newline]])
@@ -696,41 +696,44 @@
     (session/message {:op "inspect-clear"})
     (session/message {:op      "eval"
                       :inspect "true"
-                      :code    "(repeat 5 {:a (repeat 5 {:b 2}) :c (repeat 5 {:d 2})})"})
+                      :max-coll-size 6
+                      :code    "(repeat 5 {:a (repeat 6 {:b 2}) :c (repeat 6 {:d 2})})"})
     (testing "toggle pretty printing and turn it on"
       (is+ ["--- Contents:" [:newline]
-            "  0. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
-                                 "\n      :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 1]
+            "  0. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
+                                 "\n      :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 1]
             [:newline]
-            "  1. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
-                                 "\n      :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 2]
+            "  1. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
+                                 "\n      :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 2]
             [:newline]
-            "  2. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
-                                 "\n      :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 3]
+            "  2. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
+                                 "\n      :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 3]
             [:newline]
-            "  3. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
-                                 "\n      :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 4]
+            "  3. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
+                                 "\n      :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 4]
             [:newline]
-            "  4. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
-                                 "\n      :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 5]
-            [:newline]]
+            "  4. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
+                                 "\n      :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 5]
+            [:newline] [:newline]
+            "--- View mode:" [:newline]
+            "  :pretty"]
            (value-skip-header (session/message {:op "inspect-toggle-pretty-print"}))))
     (testing "toggle pretty printing and turn it off"
       (is+ ["--- Contents:" [:newline]
-            "  0. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
-                                 " :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 1]
+            "  0. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
+                                 " :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 1]
             [:newline]
-            "  1. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
-                                 " :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 2]
+            "  1. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
+                                 " :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 2]
             [:newline]
-            "  2. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
-                                 " :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 3]
+            "  2. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
+                                 " :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 3]
             [:newline]
-            "  3. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
-                                 " :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 4]
+            "  3. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
+                                 " :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 4]
             [:newline]
-            "  4. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
-                                 " :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 5]
+            "  4. " [:value (str "{:a ({:b 2} {:b 2} {:b 2} {:b 2} {:b 2} {:b 2}),"
+                                 " :c ({:d 2} {:d 2} {:d 2} {:d 2} {:d 2} {:d 2})}") 5]
             [:newline]]
            (value-skip-header (session/message {:op "inspect-toggle-pretty-print"}))))))
 

--- a/test/clj/cider/nrepl/print_method_test.clj
+++ b/test/clj/cider/nrepl/print_method_test.clj
@@ -1,42 +1,39 @@
 (ns cider.nrepl.print-method-test
   (:require
    [cider.nrepl.print-method :refer :all]
-   [clojure.test :refer :all])
-  (:import
-   java.util.regex.Pattern))
+   [clojure.test :refer :all]))
 
 (defn dummy-fn [o])
 
 (deftest print-atoms-test
-  (is (re-find #"#atom\[\"\" 0x[a-z0-9]+\]" (pr-str (atom ""))))
-  (is (re-find #"#atom\[nil 0x[a-z0-9]+\]" (pr-str (atom nil))))
-  (is (re-find #"#atom\[\{:foo :bar\} 0x[a-z0-9]+\]" (pr-str (atom {:foo :bar}))))
-  (is (re-find #"#atom\[#function\[clojure.core/\+\] 0x[a-z0-9]+\]" (pr-str (atom +)))))
+  (is (= "#atom[\"\"]" (pr-str (atom ""))))
+  (is (= "#atom[nil]" (pr-str (atom nil))))
+  (is (= "#atom[{:foo :bar}]" (pr-str (atom {:foo :bar}))))
+  (is (= "#atom[#function[clojure.core/+]]" (pr-str (atom +)))))
 
 (deftest print-idrefs-test
   (let [f (future (Thread/sleep 200) 1)
         p (promise)
         d (delay 1)
         a (agent 1)]
-    (are [o r] (re-find r (pr-str o))
-      a #"#agent\[\{:status :ready, :val 1\} 0x[a-z0-9]+\]"
-      d #"#delay\[\{:status :pending, :val nil\} 0x[a-z0-9]+\]"
-      f #"#future\[\{:status :pending, :val nil\} 0x[a-z0-9]+\]"
-      p #"#promise\[\{:status :pending, :val nil\} 0x[a-z0-9]+\]")
+    (are [o r] (= r (pr-str o))
+      a "#agent[1]"
+      d "#delay[<pending>]"
+      f "#future[<pending>]"
+      p "#promise[<pending>]")
     (Thread/sleep 300)
     @d
     (deliver p 1)
     @f
-    (are [o r] (re-find r (pr-str o))
-      f #"#future\[\{:status :ready, :val 1\} 0x[a-z0-9]+\]"
-      d #"#delay\[\{:status :ready, :val 1\} 0x[a-z0-9]+\]"
-      p #"#promise\[\{:status :ready, :val 1\} 0x[a-z0-9]+\]")))
+    (are [o r] (= r (pr-str o))
+      f "#future[1]"
+      d "#delay[1]"
+      p "#promise[1]")))
 
 (deftest print-functions-test
   (are [f s] (= (pr-str f) s)
     print-functions-test "#function[cider.nrepl.print-method-test/print-functions-test]"
     dummy-fn "#function[cider.nrepl.print-method-test/dummy-fn]"
-    multifn-name "#function[cider.nrepl.print-method/multifn-name]"
     + "#function[clojure.core/+]"
     * "#function[clojure.core/*]"
     / "#function[clojure.core//]"
@@ -45,8 +42,8 @@
 (deftest print-multimethods-test
   (require 'cider.nrepl.middleware.track-state)
   (let [var (resolve 'print-method)]
-    (is (re-find (Pattern/compile (format "#multifn\\[%s 0x[a-z0-9]+\\]"
-                                          (:name (meta var))))
+    (is (re-find (re-pattern (format "#multifn\\[%s 0x[a-z0-9]+\\]"
+                                     (:name (meta var))))
                  (pr-str @var)))))
 
 (deftest print-namespaces-test


### PR DESCRIPTION
Now that orchard.print has more printers for different classes, we can use it instead of custom code in cider-nrepl to modify `print-method` behavior. Brings more consistency and removes some code too.

One controversial change: different derefables like atoms, futures, etc., have changed how they look:

```clj
;; before
#atom[{:status :ready, :val 1} 0x11381415]
#promise[{:status :pending, :val nil} 0x2a40ec4d]
#delay[{:status :failed, :val #error {....}]

;; now
#atom[1]
#promise[<pending>]
#delay[<failed> #error[...]]
```

I hope this doesn't break anything – if people rely on printed representation of these objects, specifically on how cider-nrepl augments them, and then parse that, they are probably in a bigger trouble already.

---

- [ ] All tests are passing
- [x] You've updated the README