### PR TITLE
Stop shipping fipp with cider-nrepl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+* [#941](https://github.com/clojure-emacs/cider-nrepl/pull/941): Stop vendoring Fipp dependency.
+* [#941](https://github.com/clojure-emacs/cider-nrepl/pull/941): Default to orchard.pp printer when Fipp/Puget/Zprint is selected but not found on classpath.
+
 ## 0.55.7 (2025-04-29)
 
 * [#939](https://github.com/clojure-emacs/cider-nrepl/pull/939): Tracker: synchronize access to WeakHashMap cache to prevent infinite loops.

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,9 @@
-(def fipp-version "0.6.26")
-
 (def dev-test-common-profile
   {:dependencies '[[org.clojure/clojurescript "1.11.60" :scope "provided"]
                    ;; 1.3.7 and 1.4.7 are working, but we need 1.3.7 for JDK8
                    [ch.qos.logback/logback-classic "1.3.7"]
                    [mvxcvi/puget "1.3.4" :exclusions [org.clojure/clojure]]
+                   [fipp "0.6.26"]
                    [org.clojure/test.check "1.1.1"]
                    [cider/piggieback "0.6.0"]
                    [nubank/matcher-combinators "3.9.1"]]
@@ -23,7 +22,6 @@
   :scm {:name "git" :url "https://github.com/clojure-emacs/cider-nrepl"}
   :dependencies [[nrepl/nrepl "1.3.1" :exclusions [org.clojure/clojure]]
                  [cider/orchard "0.34.3" :exclusions [org.clojure/clojure]]
-                 ^:inline-dep [fipp ~fipp-version] ; can be removed in unresolved-tree mode
                  ^:inline-dep [compliment "0.7.0"]
                  ^:inline-dep [org.rksm/suitable "0.6.2" :exclusions [org.clojure/clojure
                                                                       org.clojure/clojurescript]]
@@ -49,8 +47,6 @@
               '[[thomasa/mranderson "0.5.4-SNAPSHOT"]])
 
   :mranderson {:project-prefix "cider.nrepl.inlined.deps"
-               :overrides       {[fipp] [fipp ~fipp-version]} ; only takes effect in unresolved-tree mode
-               :expositions     [[fipp]] ; only takes effect unresolved-tree mode
                :unresolved-tree false}
 
   :filespecs [{:type :bytes :path "cider/cider-nrepl/project.clj" :bytes ~(slurp "project.clj")}]

--- a/src/cider/nrepl/pprint.clj
+++ b/src/cider/nrepl/pprint.clj
@@ -62,14 +62,17 @@
    (pp/pprint writer value options)))
 
 (def ^:private fipp-printer
-  (delay (requiring-resolve 'fipp.edn/pprint)))
+  (delay (try-resolve 'fipp.edn/pprint "Fipp")))
 
 (defn fipp-pprint
   ([value writer]
    (fipp-pprint value writer {}))
   ([value writer options]
-   (binding [*out* writer]
-     (@fipp-printer value options))))
+   (if-some [fipp @fipp-printer]
+     (binding [*out* writer]
+       (fipp value options))
+     ;; Default to orchard.pp/pprint if Fipp could not be loaded.
+     (pp/pprint writer value options))))
 
 (def ^:private puget-printer
   (delay (try-resolve 'puget.printer/pprint "Puget")))

--- a/src/cider/nrepl/pprint.clj
+++ b/src/cider/nrepl/pprint.clj
@@ -5,7 +5,8 @@
   {:added "0.20"}
   (:refer-clojure :exclude [pr])
   (:require
-   [clojure.pprint :as pp]
+   [clojure.pprint]
+   [orchard.pp :as pp]
    [orchard.misc :as misc]))
 
 (def ^:private pr-options
@@ -52,7 +53,13 @@
   ([value writer]
    (pprint value writer {}))
   ([value writer options]
-   (apply pp/write value (mapcat identity (assoc options :stream writer)))))
+   (apply clojure.pprint/write value (mapcat identity (assoc options :stream writer)))))
+
+(defn orchard-pprint
+  ([value writer]
+   (pp/pprint writer value {}))
+  ([value writer options]
+   (pp/pprint writer value options)))
 
 (def ^:private fipp-printer
   (delay (requiring-resolve 'fipp.edn/pprint)))
@@ -74,8 +81,8 @@
    (if-some [puget @puget-printer]
      (binding [*out* writer]
        (puget value options))
-     ;; Default ot clojure.pprint/pprint if Puget could not be loaded.
-     (pprint value writer options))))
+     ;; Default to orchard.pp/pprint if Puget could not be loaded.
+     (pp/pprint writer value options))))
 
 (def ^:private zprint-printer
   (delay (try-resolve 'zprint.core/zprint "zprint")))
@@ -87,5 +94,5 @@
    (if-some [zprint @zprint-printer]
      (binding [*out* writer]
        (zprint value options))
-     ;; Default ot clojure.pprint/pprint if Zprint could not be loaded.
-     (pprint value writer options))))
+     ;; Default to orchard.pp/pprint if Puget could not be loaded.
+     (pp/pprint writer value options))))


### PR DESCRIPTION
In the same way as Puget and zprint.

Additionally, default all three to `orchard.pp`, our new pretty-printing implementation that is faster than `clojure.pprint` and is also more consistent with the way we do printing in other parts of CIDER (inspector, debugger).

---

- [x] You've updated the README
