### PR TITLE
[debug] Reduce instrumentation footprint 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#941](https://github.com/clojure-emacs/cider-nrepl/pull/941): Stop vendoring Fipp dependency.
 * [#941](https://github.com/clojure-emacs/cider-nrepl/pull/941): Default to orchard.pp printer when Fipp/Puget/Zprint is selected but not found on classpath.
+* [#943](https://github.com/clojure-emacs/cider-nrepl/pull/943): Debug: reduce insrumentation bytecode footprint.
 
 ## 0.55.7 (2025-04-29)
 

--- a/project.clj
+++ b/project.clj
@@ -138,4 +138,5 @@
              :eastwood [:test
                         {:plugins [[jonase/eastwood "1.4.3"]]
                          :eastwood {:config-files ["eastwood.clj"]
-                                    :exclude-namespaces [cider.nrepl.middleware.test-filter-tests]}}]})
+                                    :exclude-namespaces [cider.nrepl.middleware.debug-test
+                                                         cider.nrepl.middleware.test-filter-tests]}}]})

--- a/project.clj
+++ b/project.clj
@@ -52,6 +52,7 @@
   :filespecs [{:type :bytes :path "cider/cider-nrepl/project.clj" :bytes ~(slurp "project.clj")}]
 
   :source-paths ["src"]
+  :java-source-paths ["src"]
   :resource-paths ["resources"]
   :test-paths ["test/clj" "test/cljs" "test/common"]
 

--- a/src/cider/nrepl/middleware/DebugSupport.java
+++ b/src/cider/nrepl/middleware/DebugSupport.java
@@ -1,0 +1,33 @@
+package cider.nrepl.middleware;
+
+import clojure.lang.*;
+
+/**
+ * Contains instrumentation helpers for cider.nrepl.middleware.debug. The main
+ * purpose of having these helpers in Java is reducing the instrumentation
+ * footprint (measured in bytecode size). Invoking Java methods usually takes
+ * fewer bytecode instructions than a corresponding Clojure function. Java also
+ * allows us to have primitive overrides which further reduces overhead when
+ * instrumenting code that contains primitives, but also preserves type hints
+ * (so instrumented code behaves closer to original code).
+ *
+ * The reason we care about bytecode size is 65KB method limit that JVM imposes.
+ */
+public class DebugSupport {
+
+    private static volatile IFn breakFn = null;
+
+    public static Object doBreak(Object coor, Object val, Object locals, Object STATE__) {
+        if (breakFn == null)
+            breakFn = (IFn)RT.var("cider.nrepl.middleware.debug", "break");
+        return breakFn.invoke(coor, val, locals, STATE__);
+    }
+
+    public static long doBreak(Object coor, long val, Object locals, Object STATE__) {
+        return (long)doBreak(coor, Numbers.num(val), locals, STATE__);
+    }
+
+    public static double doBreak(Object coor, double val, Object locals, Object STATE__) {
+        return (double)doBreak(coor, Numbers.num(val), locals, STATE__);
+    }
+}

--- a/src/cider/nrepl/middleware/DebugSupport.java
+++ b/src/cider/nrepl/middleware/DebugSupport.java
@@ -30,4 +30,26 @@ public class DebugSupport {
     public static double doBreak(Object coor, double val, Object locals, Object STATE__) {
         return (double)doBreak(coor, Numbers.num(val), locals, STATE__);
     }
+
+    // The purpose of the following assoc methods is to build a locals map.
+    // Chaining such assoc calls is more bytecode-compact than a single
+    // RT.mapUniqueKeys(...) because the latter constructs an array (load each
+    // key and value onto the stack, save them into the array) and boxes
+    // primitives (invocations of Numbers.num). Additionally, in this custom
+    // method we turn string keys into symbols, which means we don't have to
+    // generate symbols at the callsite (in the instrumented method). This saves
+    // bytecode because LDC of a constant string is more compact than
+    // ALOAD+GETFIELD of an interned symbol.
+
+    public static IPersistentMap assoc(Object map, Object key, Object value) {
+        return ((IPersistentMap)map).assoc(Symbol.intern(null, (String)key), value);
+    }
+
+    public static IPersistentMap assoc(Object map, Object key, long value) {
+        return assoc(map, key, Numbers.num(value));
+    }
+
+    public static IPersistentMap assoc(Object map, Object key, double value) {
+        return assoc(map, key, Numbers.num(value));
+    }
 }

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -15,6 +15,7 @@
    [orchard.print]
    [orchard.stacktrace :as stacktrace])
   (:import
+   (cider.nrepl.middleware DebugSupport)
    (clojure.lang Compiler$LocalBinding)
    (java.util UUID)))
 
@@ -557,7 +558,7 @@ this map (identified by a key), and will `dissoc` it afterwards."}
     ;; Keep original forms in a separate atom to save some code
     ;; size. Unfortunately same trick wouldn't work for locals.
     (swap! *tmp-forms* assoc coor original-form)
-    `(break ~coor ~val-form ~locals ~'STATE__)))
+    `(DebugSupport/doBreak ~coor ~val-form ~locals ~'STATE__)))
 
 (def irrelevant-return-value-forms
   "Set of special-forms whose return value we don't care about.

--- a/src/cider/nrepl/middleware/enlighten.clj
+++ b/src/cider/nrepl/middleware/enlighten.clj
@@ -66,7 +66,7 @@
     (symbol? original-form) `(do
                                (send-if-local '~original-form
                                               (assoc (:msg ~'STATE__) :coor ~coor)
-                                              ~(d/sanitize-env &env))
+                                              ~(d/locals-capturer &env))
                                ~form)
     (seq? form) (wrap-function-form form extras)
     :else form))


### PR DESCRIPTION
We care about instrumentation size because when instrumenting large functions, we run into the JVM method size limit (65KB). This PR adds two improvements:

- Inject `DebugSupport/doBreak` instead of `c.n.m.debug/break`. Invoking a method requires less bytecode than calling a function. A method also has overrides for common primitives.
- Generate a more compact code for constructing a locals map.

---

- [x] You've added tests to cover your change(s)
- [x] You've updated the README