### PR TITLE
Bind *report-counters* during test execution

### DIFF
--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -367,7 +367,8 @@
    (test-ns ns vars false))
 
   ([ns vars fail-fast?]
-   (binding [test/report report]
+   (binding [test/report report
+             test/*report-counters* (ref test/*initial-report-counters*)]
      (test/do-report {:type :begin-test-ns, :ns ns})
      (let [time-info (atom nil)]
        (timing time-info

--- a/test/clj/cider/nrepl/middleware/test_report_counters_tests.clj
+++ b/test/clj/cider/nrepl/middleware/test_report_counters_tests.clj
@@ -1,0 +1,9 @@
+(ns cider.nrepl.middleware.test-report-counters-tests
+  "Tests that verify *report-counters* is bound during test execution.
+  Used by `cider.nrepl.middleware.test-test`."
+  (:require
+   [clojure.test :refer :all]))
+
+(deftest report-counters-bound-test
+  (is (some? clojure.test/*report-counters*)
+      "*report-counters* should be bound during test execution"))

--- a/test/clj/cider/nrepl/middleware/test_test.clj
+++ b/test/clj/cider/nrepl/middleware/test_test.clj
@@ -12,6 +12,7 @@
 
 ;; Ensure tested tests are loaded:
 (require 'cider.nrepl.middleware.test-filter-tests)
+(require 'cider.nrepl.middleware.test-report-counters-tests)
 
 (use-fixtures :each session/session-fixture)
 
@@ -259,6 +260,13 @@ that threw the exception")))
                    e
                    (-> #'stack-frame-line-test meta :test))))
         "Returns the line of the exception")))
+
+(deftest report-counters-bound-test
+  (testing "*report-counters* is bound during test execution (see #686)"
+    (is+ {:summary {:pass 1, :fail 0, :error 0}}
+         (session/message {:op "cider/test"
+                           :ns "cider.nrepl.middleware.test-report-counters-tests"
+                           :tests ["report-counters-bound-test"]}))))
 
 (deftest deprecated-ops-test
   (testing "Deprecated 'test' op still works"


### PR DESCRIPTION
clojure.test expects test runners to bind `*report-counters*` so that `inc-report-counter` actually works. Without this binding the call in our test middleware was a no-op. This also enables user-authored testing macros to inspect `*report-counters*` during execution.

Fixes #686