### PR TITLE
Remove MrAnderson dependency inlining

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,12 +115,7 @@ jobs:
                   make eastwood
 
   deploy:
-    # JDK 8 is preferred for deployments (https://github.com/benedekfazekas/mranderson/issues/57)
     executor: jdk8
-    environment:
-      # Parallelism is disabled, at least for now
-      # (https://github.com/benedekfazekas/mranderson/issues/56)
-      LEIN_JVM_OPTS: -Dmranderson.internal.no-parallelism=true
     steps:
       - checkout
       - run:
@@ -129,7 +124,7 @@ jobs:
 
   test:
     description: |
-      Run quick tests against given version of JDK and Clojure without inlining dependencies
+      Run tests against given version of JDK and Clojure
     parameters:
       jdk_version:
         description: Version of JDK to test against
@@ -152,35 +147,8 @@ jobs:
           cache_version: "test_v1_<< parameters.clojure_version >>_<< parameters.jdk_version >>_<< parameters.nrepl_version >>"
           steps:
             - run:
-                name: Running quick tests
-                command: make quick-test
-
-  full-test:
-    description: |
-      Run tests against given version of JDK and Clojure with inlining the dependencies
-    parameters:
-      jdk_version:
-        description: Version of JDK to test against
-        type: string
-      clojure_version:
-        description: Version of Clojure to test against
-        type: string
-    executor: << parameters.jdk_version >>
-    environment:
-      CLOJURE_VERSION: << parameters.clojure_version >>
-      JDK_SRC_VERSION: << parameters.jdk_version >>
-      PROJECT_VERSION: 999.99.9
-    steps:
-      - checkout
-      - with_cache:
-          cache_version: "full_test_v1_<< parameters.clojure_version >>_<< parameters.jdk_version >>"
-          steps:
-            - run:
-                name: Running tests with inlined deps
-                command: make --debug test
-            - run:
-                name: Running smoketest
-                command: make --debug smoketest
+                name: Running tests
+                command: make test
 
 # The ci-test-matrix does the following:
 #
@@ -198,16 +166,16 @@ workflows:
   version: 2.1
   ci-test-matrix:
     jobs:
-      - full-test:
-          # Full tests against latest Clojure and fringe JDKs.
+      - test:
+          # Tests against latest Clojure and fringe JDKs.
           matrix:
-            alias: "full-test"
+            alias: "test-fringe-jdks"
             parameters:
               clojure_version: ["1.12"]
               jdk_version: [jdk8, jdk25]
           <<: *run_always
       - test:
-          # Quick tests for older Clojure versions and fringe JDKs.
+          # Tests for older Clojure versions and fringe JDKs.
           matrix:
             alias: "test-older-clojure"
             parameters:
@@ -215,7 +183,7 @@ workflows:
               jdk_version: [jdk8, jdk25]
           <<: *run_always
       - test:
-          # Quick tests for latest Clojure and interim JDK versions.
+          # Tests for latest Clojure and interim JDK versions.
           matrix:
             alias: "test-latest-clojure"
             parameters:
@@ -235,7 +203,7 @@ workflows:
           <<: *run_always
       - deploy:
           requires:
-            - full-test
+            - test-fringe-jdks
             - test-older-clojure
             - test-latest-clojure
             - nrepl-test

--- a/.gitignore
+++ b/.gitignore
@@ -10,15 +10,12 @@ out
 *.jar
 *.class
 .cljs_nashorn_repl
-.inline-deps
 .no-pedantic
 .lein-deps-sum
 .lein-failures
 .lein-plugins
 .lein-repl-history
 .nrepl-port
-.source-deps
 .clj-kondo/.cache
-/.no-mranderson
 /test-runner
 /.test-classpath

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* Remove MrAnderson dependency inlining. cljfmt, tools.namespace, and tools.reader are now regular dependencies.
 * Bump `nrepl` to [1.5.2](https://github.com/nrepl/nrepl/blob/master/CHANGELOG.md#152-2025-12-29).
 * Bump `orchard` to [0.39.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0390-2026-02-07).
 * [#959](https://github.com/clojure-emacs/cider-nrepl/pull/959): Stop shading Compliment and clj-reload.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-.PHONY: test quick-test eastwood cljfmt cljfmt-fix install fast-install smoketest deploy clean lint docs test_impl
-.DEFAULT_GOAL := quick-test
+.PHONY: test eastwood cljfmt cljfmt-fix install smoketest deploy clean lint docs test_impl
+.DEFAULT_GOAL := test
 
 # Set bash instead of sh for the @if [[ conditions,
 # and use the usual safety flags:
@@ -36,16 +36,8 @@ copy-sources-to-jdk: base-src-$(JDK_SRC_VERSION).zip
 dump-version:
 	echo '"$(PROJECT_VERSION)"' > resources/cider/nrepl/version.edn
 
-target/srcdeps: project.clj
-	lein with-profile -user,-dev inline-deps
-# Remove cljfmt.main because it depends on tools.cli which we explicitly removed.
-	rm -f target/srcdeps/cider/nrepl/inlined/deps/cljfmt/*/cljfmt/main.clj
-
-quick-test: copy-sources-to-jdk
+test: copy-sources-to-jdk
 	lein with-profile $(COMMON_PROFILES),$(TEST_PROFILES) test
-
-test: target/srcdeps
-	lein with-profile $(COMMON_PROFILES),$(TEST_PROFILES),+plugin.mranderson/config test
 
 eastwood:
 	lein with-profile -user,-dev,$(COMMON_PROFILES),+deploy,+eastwood eastwood
@@ -57,20 +49,16 @@ cljfmt-fix:
 	lein with-profile -user,-dev,$(COMMON_PROFILES),+cljfmt cljfmt fix
 
 .make_kondo_prep: project.clj .clj-kondo/config.edn
-	CIDER_NO_MRANDERSON="true" CIDER_NO_PEDANTIC="true" lein with-profile -user,-dev,+test,+clj-kondo,+deploy,$(COMMON_PROFILES) clj-kondo --copy-configs --dependencies --lint '$$classpath' > $@
+	CIDER_NO_PEDANTIC="true" lein with-profile -user,-dev,+test,+clj-kondo,+deploy,$(COMMON_PROFILES) clj-kondo --copy-configs --dependencies --lint '$$classpath' > $@
 
 kondo: .make_kondo_prep clean
-	CIDER_NO_MRANDERSON="true" CIDER_NO_PEDANTIC="true" lein with-profile -user,-dev,+test,+clj-kondo,+deploy,$(COMMON_PROFILES) clj-kondo
+	CIDER_NO_PEDANTIC="true" lein with-profile -user,-dev,+test,+clj-kondo,+deploy,$(COMMON_PROFILES) clj-kondo
 
 lint: kondo cljfmt eastwood
 
 # PROJECT_VERSION=x.y.z make install
-install: dump-version check-install-env target/srcdeps
-	CIDER_RELEASE=true CIDER_NO_PEDANTIC="true" lein with-profile -user,-dev,-provided,$(COMMON_PROFILES),+plugin.mranderson/config install
-
-# PROJECT_VERSION=x.y.z make fast-install
-fast-install: dump-version check-install-env
-	lein with-profile -user,-dev,$(COMMON_PROFILES) install
+install: dump-version check-install-env
+	CIDER_RELEASE=true CIDER_NO_PEDANTIC="true" lein with-profile -user,-dev,-provided,$(COMMON_PROFILES) install
 
 smoketest: install
 	cd test/smoketest && \
@@ -78,16 +66,15 @@ smoketest: install
         java -jar target/smoketest-0.1.0-SNAPSHOT-standalone.jar
 
 # Deployment is performed via CI by creating a git tag prefixed with "v".
-# Please do not deploy locally as it skips various measures (particularly around mranderson).
-deploy: check-env target/srcdeps
+# Please do not deploy locally as it skips various CI measures.
+deploy: check-env
 	@if ! echo "$(CIRCLE_TAG)" | grep -q "^v"; then \
 		echo "[Error] CIRCLE_TAG $(CIRCLE_TAG) must start with 'v'."; \
 		exit 1; \
 	fi
-	rm -f .no-mranderson
 	export PROJECT_VERSION=$$(echo "$(CIRCLE_TAG)" | sed 's/^v//'); \
 	echo "\"$$PROJECT_VERSION\"" > resources/cider/nrepl/version.edn; \
-	CIDER_RELEASE=true lein with-profile -user,-dev,-provided,$(COMMON_PROFILES),+plugin.mranderson/config deploy clojars
+	CIDER_RELEASE=true lein with-profile -user,-dev,-provided,$(COMMON_PROFILES) deploy clojars
 
 check-env:
 ifndef CLOJARS_USERNAME

--- a/README.md
+++ b/README.md
@@ -66,28 +66,14 @@ guidelines](.github/CONTRIBUTING.md).
 ### Local development
 
 Local development tasks, like running the tests or locally installing
-cider-nrepl are offered by our Makefile.  We recommend using it, since some
-aspects (e.g. the use of [mranderson][]) can be intricate to newcomers.
-
-These are its main tasks for local development:
+cider-nrepl are offered by our Makefile:
 
 ```shell
-# Run tests, using mranderson (slower but more realistic)
+# Run tests
 make test
 
-# Run tests, without using mranderson (considerably faster)
-make quick-test
-
-# Install the project in your local ~/.m2 directory, using mranderson (recommended)
-# The JVM flag is a temporary workaround.
-export LEIN_JVM_OPTS="-Dmranderson.internal.no-parallelism=true"
+# Install the project in your local ~/.m2 directory
 PROJECT_VERSION=X.Y.Z make install
-
-# Install the project in your local ~/.m2 directory, without using mranderson
-# (it's faster, but please only use when you repeatedly need to install cider-nrepl)
-# The JVM flag is a temporary workaround.
-export LEIN_JVM_OPTS="-Dmranderson.internal.no-parallelism=true"
-PROJECT_VERSION=X.Y.Z make fast-install
 
 # Runs clj-kondo, cljfmt and Eastwood (in that order, with fail-fast).
 # Please try to run this before pushing commits.
@@ -152,4 +138,3 @@ Distributed under the Eclipse Public License, the same as Clojure.
 [tools.namespace]: https://github.com/clojure/tools.namespace
 [clj-reload]: https://github.com/tonsky/clj-reload
 [cljfmt]: https://github.com/weavejester/cljfmt
-[mranderson]: https://github.com/benedekfazekas/mranderson

--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -71,25 +71,6 @@ now are Clojure-only.
 We'd really appreciate all the help we can get from ClojureScript
 hackers to make this a reality.
 
-=== Isolated Runtime Dependencies
-
-Most of cider-nrepl's dependencies are processed with
-https://github.com/benedekfazekas/mranderson[mranderson], so that
-they won't collide with the dependencies of your own projects. This
-basically means that cider-nrepl has almost no  runtime dependencies in
-the production artifact - just copies of the deps inlined with changed
-namespaces/packages. It's a bit ugly and painful, but it gets the job
-done.
-
-The exclusion to this rule are the artifacts that are themselves part of the
-CIDER ecosystem and have to runtime dependencies of their own:
-
-- https://github.com/clojure-emacs/orchard[Orchard]
-- https://github.com/clojure-emacs/logjam[Logjam]
-
-If someone has better ideas how to isolate our runtime dependencies -
-we're all ears!
-
 === Deferred Middleware Loading
 
 To improve the startup time of the nREPL server all of cider-nrepl's

--- a/doc/modules/ROOT/pages/internals.adoc
+++ b/doc/modules/ROOT/pages/internals.adoc
@@ -40,18 +40,3 @@ through some hoops to evaluate ClojureScript code from it (e.g. pipe it to
 Piggieback's `eval` or evaluate it against the ClojureScript runtime directly as
 a string). Hopefully this will change down the road.
 
-== Dependency obfuscation
-
-cider-nrepl's dependency would conflict with the dependencies of the application using it,
-so we have to take some care to avoid such situation.
-
-Most of cider-nrepl's dependencies are processed with
-https://github.com/benedekfazekas/mranderson[mranderson], so that
-they won't collide with the dependencies of your own projects. This
-basically means that cider-nrepl doesn't have any runtime dependencies in
-the production artifact - just copies of the deps inlined with changed
-namespaces/packages.
-
-This means that `cider-nrepl` has to also take some steps to hide the inlined namespaces,
-so they won't pollute the results users would be interested in. Pretty much all of cider-nrepl's
-ops would filter out the inlined namespaces.

--- a/project.clj
+++ b/project.clj
@@ -28,11 +28,11 @@
              [org.rksm/suitable "0.6.2" :exclusions [org.clojure/clojure
                                                      org.clojure/clojurescript
                                                      compliment]]
-             ^:inline-dep [cljfmt "0.9.2" :exclusions [org.clojure/clojurescript
-                                                       org.clojure/tools.cli]]
-             ^:inline-dep [org.clojure/tools.namespace "1.5.0" :exclusions [org.clojure/clojurescript
-                                                                            org.clojure/tools.cli]]
-             ^:inline-dep [org.clojure/tools.reader "1.4.1"]]
+             [cljfmt "0.9.2" :exclusions [org.clojure/clojurescript
+                                          org.clojure/tools.cli]]
+             [org.clojure/tools.namespace "1.5.0" :exclusions [org.clojure/clojurescript
+                                                               org.clojure/tools.cli]]
+             [org.clojure/tools.reader "1.4.1"]]
      ;; This is the only working way to include nREPL into published jar and
      ;; still be able to test different nREPL versions.
      (System/getenv "CIDER_RELEASE") (conj '[nrepl/nrepl "1.5.2"]))
@@ -42,15 +42,6 @@
                 :abort
                 ;; :pedantic? can be problematic for certain local dev workflows:
                 false)
-
-  ;; mranderson cannot be put in a profile (as the other plugins),
-  ;; so we conditionally disable it, because otherwise clj-kondo cannot run.
-  :plugins ~(if (System/getenv "CIDER_NO_MRANDERSON")
-              []
-              '[[thomasa/mranderson "0.5.4-SNAPSHOT"]])
-
-  :mranderson {:project-prefix "cider.nrepl.inlined.deps"
-               :unresolved-tree false}
 
   :filespecs [{:type :bytes :path "cider/cider-nrepl/project.clj" :bytes ~(slurp "project.clj")}]
 
@@ -71,7 +62,6 @@
                    :debugger :debugger}
 
   :aliases {"bump-version" ["change" "version" "leiningen.release/bump-version"]
-            "mranderson"   ["with-profile" "+plugin.mranderson/config"]
             "docs" ["with-profile" "+maint" "run" "-m" "cider.nrepl.impl.docs" "--file"
                     ~(clojure.java.io/as-relative-path
                       (clojure.java.io/file "doc" "modules" "ROOT" "pages" "nrepl-api" "ops.adoc"))]}

--- a/src/cider/nrepl/middleware/refresh.clj
+++ b/src/cider/nrepl/middleware/refresh.clj
@@ -20,23 +20,18 @@
 
   See `clojure.tools.namespace.repl/set-refresh-dirs`.
 
-  The var is resolved at runtime to get the \"real\" clojure.tools.namespace,
-  not the mranderson-ized version bundled with CIDER. Returns `nil` if c.t.n.r
-  isn't loaded. Returns `[]` if c.t.n.r is loaded but no custom dirs have been
-  set."
+  The var is resolved at runtime to get the user's clojure.tools.namespace.repl,
+  which may or may not be loaded. Returns `nil` if c.t.n.r isn't loaded.
+  Returns `[]` if c.t.n.r is loaded but no custom dirs have been set."
   []
   (some-> (symbol "clojure.tools.namespace.repl" "refresh-dirs")
           resolve
           deref))
 
-;; We construct the keyword at runtime here because namespaced keyword literals
-;; in clojure.tools.namespace.repl itself might be rewritten by mranderson - in
-;; this case, we still want to disable reloading of namespaces that a user has
-;; added the (non-rewritten) metadata to.
 (defn- load-disabled?
   [sym]
   (false? (get (meta (find-ns sym))
-               (keyword "clojure.tools.namespace.repl" "load"))))
+               :clojure.tools.namespace.repl/load)))
 
 ;; As documented in clojure.tools.namespace.repl/disable-reload!,
 ;; ^{:c.t.n.r/load false} implies ^{:c.t.n.r/unload false}
@@ -44,7 +39,7 @@
   [sym]
   (or (load-disabled? sym)
       (false? (get (meta (find-ns sym))
-                   (keyword "clojure.tools.namespace.repl" "unload")))))
+                   :clojure.tools.namespace.repl/unload))))
 
 (defn- remove-disabled
   [tracker]

--- a/src/cider/nrepl/middleware/reload.clj
+++ b/src/cider/nrepl/middleware/reload.clj
@@ -15,13 +15,12 @@
 (defn- user-reload
   "Resolve clj-reload.core/<sym> from the user project or return fallback."
   [sym fallback]
-  (or (some-> (symbol "clj-reload.core" (str sym)) ;; Don't use mrandorsenized version
+  (or (some-> (symbol "clj-reload.core" (str sym))
               resolve)
       fallback))
 
 (defn- init
-  "Initialize clj-reload with dirs.
-  Only used for test, but necessary because of mranderson."
+  "Initialize clj-reload with dirs."
   [dirs]
   (reload/init {:dirs dirs}))
 

--- a/src/cider/nrepl/middleware/util/instrument.clj
+++ b/src/cider/nrepl/middleware/util/instrument.clj
@@ -430,10 +430,6 @@
       [form trimmed-string])))
 
 ;;; Instrumentation test support
-;;;
-;;; This code migrated out of the test namespace to avoid a dependency
-;;; on orchard.meta, because mranderson rewriting does not occur on
-;;; the tests.
 
 (def bp-tracker (atom #{}))
 (defmacro bp [value coor & _]

--- a/test/clj/cider/nrepl/middleware/ns_test.clj
+++ b/test/clj/cider/nrepl/middleware/ns_test.clj
@@ -22,9 +22,7 @@
 
   (testing "Removal of namespaces created by source rewriting"
     (let [ns-list (:ns-list (session/message {:op "cider/ns-list"}))]
-      (is (not-any? #(or (.startsWith ^String % "deps.")
-                         (.startsWith ^String % "mranderson")
-                         (.startsWith ^String % "eastwood.copieddeps"))
+      (is (not-any? #(.startsWith ^String % "eastwood.copieddeps")
                     ns-list))))
 
   (testing "Removal of namespaces with `filter-regexps`"

--- a/test/clj/cider/nrepl/middleware/refresh_test.clj
+++ b/test/clj/cider/nrepl/middleware/refresh_test.clj
@@ -5,6 +5,7 @@
    [cider.nrepl.test-session :as session]
    [cider.test-helpers :refer :all]
    [clojure.test :refer :all]
+   [clojure.tools.namespace.repl :as c.t.n.r]
    [matcher-combinators.matchers :as mc]))
 
 (use-fixtures :each session/session-fixture)
@@ -130,17 +131,12 @@
     (with-redefs [resolve (constantly nil)]
       (is (nil? (#'r/user-refresh-dirs)))))
 
-  ;; The real c.t.n.r is only on the classpath when not running with
-  ;; mranderson-inlined deps (i.e. not in full-test CI builds).
-  (when (try (require 'clojure.tools.namespace.repl) true
-             (catch Exception _ false))
-    (testing "honors set-refresh-dirs"
-      (let [set-refresh-dirs (resolve 'clojure.tools.namespace.repl/set-refresh-dirs)]
-        (set-refresh-dirs "foo" "bar")
-        (try
-          (is (= ["foo" "bar"] (#'r/user-refresh-dirs)))
-          (finally
-            (set-refresh-dirs)))))))
+  (testing "honors set-refresh-dirs"
+    (c.t.n.r/set-refresh-dirs "foo" "bar")
+    (try
+      (is (= ["foo" "bar"] (#'r/user-refresh-dirs)))
+      (finally
+        (c.t.n.r/set-refresh-dirs)))))
 
 (deftest load-disabled-test
   (testing "is false by default"

--- a/test/clj/cider/nrepl/middleware/reload_test.clj
+++ b/test/clj/cider/nrepl/middleware/reload_test.clj
@@ -15,8 +15,6 @@
   ;; unloaded, which breaks session-fixture, and hence all of the below tests.
   ["test/clj/cider/nrepl/middleware/util"])
 
-;; Calling init from reload ns to work around mrandersonized version
-;; See cider.nrepl.middleware.refresh-test for another test that suffers from this.
 (#'rl/init dirs-to-reload)
 
 (deftest user-reload


### PR DESCRIPTION
I've been frustrated with MrAnderson for a while now, and I think the time has come to just drop it.

It served us well over the years, but it adds a lot of complexity for diminishing returns — a SNAPSHOT plugin dependency, dual CI test matrices, runtime workarounds (dynamic keyword/symbol construction to sidestep namespace rewriting), build hacks (manually deleting files post-inlining), and conditional env vars for tooling compatibility. The three remaining inlined deps (cljfmt, tools.namespace, tools.reader) are all stable Clojure libraries with strong backwards compatibility, and we already un-inlined orchard, compliment, clj-reload, and suitable without issues.

This PR makes cljfmt, tools.namespace, and tools.reader regular dependencies and removes all the MrAnderson machinery — plugin config, `target/srcdeps` build step, `full-test` CI job, `CIDER_NO_MRANDERSON` env var, runtime keyword construction workarounds, and the associated docs.