### PR TITLE
[middleware] Refactor how piggieback dependencies are established

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#710](https://github.com/clojure-emacs/cider-nrepl/issues/710): Make namespaced ops (e.g., `cider/complete`) the default and keep the old names as deprecated aliases.
 * [#965](https://github.com/clojure-emacs/cider-nrepl/issues/965): Stop losing quotes in matcher-combinators test output.
 * [#972](https://github.com/clojure-emacs/cider-nrepl/issues/972): Stop relying on tools.reader functions in our code.
+* [#971](https://github.com/clojure-emacs/cider-nrepl/issues/971): Middleware: refactor how piggieback dependencies are established.
 
 ## 0.58.0 (2025-10-16)
 

--- a/project.clj
+++ b/project.clj
@@ -137,7 +137,8 @@
                                                               cider.nrepl/wrap-tracker
                                                               cider.nrepl/wrap-undef
                                                               cider.nrepl/wrap-version
-                                                              cider.nrepl/wrap-xref]}}]
+                                                              cider.nrepl/wrap-xref
+                                                              cider.piggieback/wrap-cljs-repl]}}]
 
              :cljfmt-base {:plugins [[dev.weavejester/lein-cljfmt "0.15.6"]]
                            :cljfmt {:extra-indents {timing [[:inner 0]]

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -44,9 +44,8 @@
       (finally (throw (ex-info msg {}))))))
 
 ;; Perform the underlying dynamic `require`s asap, and also not within a
-;; separate thread (note the `future` used in `#'initializer`), since `require`
-;; is not thread-safe. We try it on LruMap which we know to be on the classpath,
-;; shipped with Orchard.
+;; separate thread, since `require` is not thread-safe. We try it on LruMap
+;; which we know to be on the classpath, shipped with Orchard.
 (try (orchard.java/source-info 'mx.cider.orchard.LruMap)
      (catch Exception _))
 
@@ -200,91 +199,89 @@ Depending on the type of the return value of the evaluation this middleware may 
               :returns {"classpath" "A list of the Java classpath entries."}}}})
 
 (def-wrapper wrap-complete cider.nrepl.middleware.complete/handle-complete
-  (cljs/requires-piggieback
-   {:doc "Middleware providing completion support."
-    :requires #{#'session}
-    :handles {"cider/complete"
-              {:doc "Return a list of symbols matching the specified (partial) symbol."
-               :requires {"ns" "The namespace is which to look for completions (falls back to *ns* if not specified)"
-                          "prefix" "The prefix for completion candidates"
-                          "session" "The current session"}
-               :optional {"context" "Completion context for compliment."
-                          "sort-order" "Sorting order of candidates. Possible values: by-name, by-length."
-                          "extra-metadata" "List of extra-metadata fields. Possible values: arglists, doc."}
-               :returns {"completions" "A list of possible completions"}}
-              "complete"
-              {:doc "Deprecated: use `cider/complete` instead. Return a list of symbols matching the specified (partial) symbol."
-               :requires {"ns" "The namespace is which to look for completions (falls back to *ns* if not specified)"
-                          "prefix" "The prefix for completion candidates"
-                          "session" "The current session"}
-               :optional {"context" "Completion context for compliment."
-                          "sort-order" "Sorting order of candidates. Possible values: by-name, by-length."
-                          "extra-metadata" "List of extra-metadata fields. Possible values: arglists, doc."}
-               :returns {"completions" "A list of possible completions"}}
-              "cider/complete-doc"
-              {:doc "Retrieve documentation suitable for display in completion popup"
-               :requires {"ns" "The symbol's namespace"
-                          "sym" "The symbol to lookup"}
-               :returns {"completion-doc" "Symbol's documentation"}}
-              "complete-doc"
-              {:doc "Deprecated: use `cider/complete-doc` instead. Retrieve documentation suitable for display in completion popup"
-               :requires {"ns" "The symbol's namespace"
-                          "sym" "The symbol to lookup"}
-               :returns {"completion-doc" "Symbol's documentation"}}
-              "cider/complete-flush-caches"
-              {:doc "Forces the completion backend to repopulate all its caches"}
-              "complete-flush-caches"
-              {:doc "Deprecated: use `cider/complete-flush-caches` instead. Forces the completion backend to repopulate all its caches"}}}))
+  {:doc "Middleware providing completion support."
+   :requires (cljs/maybe-add-piggieback #{#'session})
+   :handles {"cider/complete"
+             {:doc "Return a list of symbols matching the specified (partial) symbol."
+              :requires {"ns" "The namespace is which to look for completions (falls back to *ns* if not specified)"
+                         "prefix" "The prefix for completion candidates"
+                         "session" "The current session"}
+              :optional {"context" "Completion context for compliment."
+                         "sort-order" "Sorting order of candidates. Possible values: by-name, by-length."
+                         "extra-metadata" "List of extra-metadata fields. Possible values: arglists, doc."}
+              :returns {"completions" "A list of possible completions"}}
+             "complete"
+             {:doc "Deprecated: use `cider/complete` instead. Return a list of symbols matching the specified (partial) symbol."
+              :requires {"ns" "The namespace is which to look for completions (falls back to *ns* if not specified)"
+                         "prefix" "The prefix for completion candidates"
+                         "session" "The current session"}
+              :optional {"context" "Completion context for compliment."
+                         "sort-order" "Sorting order of candidates. Possible values: by-name, by-length."
+                         "extra-metadata" "List of extra-metadata fields. Possible values: arglists, doc."}
+              :returns {"completions" "A list of possible completions"}}
+             "cider/complete-doc"
+             {:doc "Retrieve documentation suitable for display in completion popup"
+              :requires {"ns" "The symbol's namespace"
+                         "sym" "The symbol to lookup"}
+              :returns {"completion-doc" "Symbol's documentation"}}
+             "complete-doc"
+             {:doc "Deprecated: use `cider/complete-doc` instead. Retrieve documentation suitable for display in completion popup"
+              :requires {"ns" "The symbol's namespace"
+                         "sym" "The symbol to lookup"}
+              :returns {"completion-doc" "Symbol's documentation"}}
+             "cider/complete-flush-caches"
+             {:doc "Forces the completion backend to repopulate all its caches"}
+             "complete-flush-caches"
+             {:doc "Deprecated: use `cider/complete-flush-caches` instead. Forces the completion backend to repopulate all its caches"}}})
 
 ;; `wrap-debug` has to be sandwiched between `load-file` and `eval`. First
 ;; `load-file` transforms its message into an `eval`, then `wrap-debug` attaches
 ;; its instrumenting functions to the message, and finally `eval` does the work.
 (def-wrapper wrap-debug cider.nrepl.middleware.debug/handle-debug
   #{"eval"}
-  (cljs/requires-piggieback
-   {:doc "Provide instrumentation and debugging functionality."
-    :expects  #{"eval"}
-    :requires #{#'wrap-print #'session "load-file"}
-    :handles {"cider/debug-input"
-              {:doc "Read client input on debug action."
-               :requires {"input" "The user's reply to the input request."
-                          "key" "The corresponding input request key."}
-               :returns  {"status" "done"}}
-              "debug-input"
-              {:doc "Deprecated: use `cider/debug-input` instead. Read client input on debug action."
-               :requires {"input" "The user's reply to the input request."
-                          "key" "The corresponding input request key."}
-               :returns  {"status" "done"}}
-              "cider/init-debugger"
-              {:doc "Initialize the debugger so that `breakpoint` works correctly. This usually does not respond immediately. It sends a response when a breakpoint is reached or when the message is discarded."
-               :requires {"id" "A message id that will be responded to when a breakpoint is reached."}}
-              "init-debugger"
-              {:doc "Deprecated: use `cider/init-debugger` instead. Initialize the debugger so that `breakpoint` works correctly. This usually does not respond immediately. It sends a response when a breakpoint is reached or when the message is discarded."
-               :requires {"id" "A message id that will be responded to when a breakpoint is reached."}}
-              "cider/debug-instrumented-defs"
-              {:doc "Return an alist of definitions currently thought to be instrumented on each namespace. Due to Clojure's versatility, this could include false positives, but there will not be false negatives. Instrumentations inside protocols are not listed."
-               :returns {"status" "done"
-                         "list"   "The alist of (NAMESPACE . VARS) that are thought to be instrumented."}}
-              "debug-instrumented-defs"
-              {:doc "Deprecated: use `cider/debug-instrumented-defs` instead. Return an alist of definitions currently thought to be instrumented on each namespace. Due to Clojure's versatility, this could include false positives, but there will not be false negatives. Instrumentations inside protocols are not listed."
-               :returns {"status" "done"
-                         "list"   "The alist of (NAMESPACE . VARS) that are thought to be instrumented."}}
-              "cider/debug-middleware"
-              {:doc "Debug a code form or fall back on regular eval."
-               :requires {"id"    "A message id that will be responded to when a breakpoint is reached."
-                          "code"  "Code to debug, there must be a #dbg or a #break reader macro in it, or nothing will happen."
-                          "file"  "File where the code is located."
-                          "ns"    "Passed to \"eval\"."
-                          "point" "Position in the file where the provided code begins."}
-               :returns {"status" "\"done\" if the message will no longer be used, or \"need-debug-input\" during debugging sessions"}}
-              "debug-middleware"
-              {:doc "Deprecated: use `cider/debug-middleware` instead. Debug a code form or fall back on regular eval."
-               :requires {"id"    "A message id that will be responded to when a breakpoint is reached."
-                          "code"  "Code to debug, there must be a #dbg or a #break reader macro in it, or nothing will happen."
-                          "file"  "File where the code is located."
-                          "ns"    "Passed to \"eval\"."
-                          "point" "Position in the file where the provided code begins."}
-               :returns {"status" "\"done\" if the message will no longer be used, or \"need-debug-input\" during debugging sessions"}}}}))
+  {:doc "Provide instrumentation and debugging functionality."
+   :expects  #{"eval"}
+   :requires (cljs/maybe-add-piggieback #{#'wrap-print #'session "load-file"})
+   :handles {"cider/debug-input"
+             {:doc "Read client input on debug action."
+              :requires {"input" "The user's reply to the input request."
+                         "key" "The corresponding input request key."}
+              :returns  {"status" "done"}}
+             "debug-input"
+             {:doc "Deprecated: use `cider/debug-input` instead. Read client input on debug action."
+              :requires {"input" "The user's reply to the input request."
+                         "key" "The corresponding input request key."}
+              :returns  {"status" "done"}}
+             "cider/init-debugger"
+             {:doc "Initialize the debugger so that `breakpoint` works correctly. This usually does not respond immediately. It sends a response when a breakpoint is reached or when the message is discarded."
+              :requires {"id" "A message id that will be responded to when a breakpoint is reached."}}
+             "init-debugger"
+             {:doc "Deprecated: use `cider/init-debugger` instead. Initialize the debugger so that `breakpoint` works correctly. This usually does not respond immediately. It sends a response when a breakpoint is reached or when the message is discarded."
+              :requires {"id" "A message id that will be responded to when a breakpoint is reached."}}
+             "cider/debug-instrumented-defs"
+             {:doc "Return an alist of definitions currently thought to be instrumented on each namespace. Due to Clojure's versatility, this could include false positives, but there will not be false negatives. Instrumentations inside protocols are not listed."
+              :returns {"status" "done"
+                        "list"   "The alist of (NAMESPACE . VARS) that are thought to be instrumented."}}
+             "debug-instrumented-defs"
+             {:doc "Deprecated: use `cider/debug-instrumented-defs` instead. Return an alist of definitions currently thought to be instrumented on each namespace. Due to Clojure's versatility, this could include false positives, but there will not be false negatives. Instrumentations inside protocols are not listed."
+              :returns {"status" "done"
+                        "list"   "The alist of (NAMESPACE . VARS) that are thought to be instrumented."}}
+             "cider/debug-middleware"
+             {:doc "Debug a code form or fall back on regular eval."
+              :requires {"id"    "A message id that will be responded to when a breakpoint is reached."
+                         "code"  "Code to debug, there must be a #dbg or a #break reader macro in it, or nothing will happen."
+                         "file"  "File where the code is located."
+                         "ns"    "Passed to \"eval\"."
+                         "point" "Position in the file where the provided code begins."}
+              :returns {"status" "\"done\" if the message will no longer be used, or \"need-debug-input\" during debugging sessions"}}
+             "debug-middleware"
+             {:doc "Deprecated: use `cider/debug-middleware` instead. Debug a code form or fall back on regular eval."
+              :requires {"id"    "A message id that will be responded to when a breakpoint is reached."
+                         "code"  "Code to debug, there must be a #dbg or a #break reader macro in it, or nothing will happen."
+                         "file"  "File where the code is located."
+                         "ns"    "Passed to \"eval\"."
+                         "point" "Position in the file where the provided code begins."}
+              :returns {"status" "\"done\" if the message will no longer be used, or \"need-debug-input\" during debugging sessions"}}}})
 
 (def-wrapper wrap-enlighten cider.nrepl.middleware.enlighten/handle-enlighten
   :enlighten
@@ -370,34 +367,33 @@ If specified, the value will be concatenated to that of `orchard.meta/var-meta-a
    "status"    "done"})
 
 (def-wrapper wrap-info cider.nrepl.middleware.info/handle-info
-  (cljs/requires-piggieback
-   {:requires #{#'session}
-    :handles {"cider/info"
-              {:doc "Return a map of information about the specified symbol."
-               :optional info-params
-               :returns (merge info-returns fragments-doc)}
-              "info"
-              {:doc "Deprecated: use `cider/info` instead. Return a map of information about the specified symbol."
-               :optional info-params
-               :returns (merge info-returns fragments-doc)}
-              "cider/eldoc"
-              {:doc "Return a map of eldoc information about the specified symbol, suitable for displaying function signatures and short documentation in the editor."
-               :optional info-params
-               :returns (merge eldoc-returns fragments-doc)}
-              "eldoc"
-              {:doc "Deprecated: use `cider/eldoc` instead. Return a map of eldoc information about the specified symbol, suitable for displaying function signatures and short documentation in the editor."
-               :optional info-params
-               :returns (merge eldoc-returns fragments-doc)}
-              "cider/eldoc-datomic-query"
-              {:doc "Return a map containing the inputs of the datomic query."
-               :requires {"sym" "The symbol to lookup"
-                          "ns" "The current namespace"}
-               :returns {"status" "done"}}
-              "eldoc-datomic-query"
-              {:doc "Deprecated: use `cider/eldoc-datomic-query` instead. Return a map containing the inputs of the datomic query."
-               :requires {"sym" "The symbol to lookup"
-                          "ns" "The current namespace"}
-               :returns {"status" "done"}}}}))
+  {:requires (cljs/maybe-add-piggieback #{#'session})
+   :handles {"cider/info"
+             {:doc "Return a map of information about the specified symbol."
+              :optional info-params
+              :returns (merge info-returns fragments-doc)}
+             "info"
+             {:doc "Deprecated: use `cider/info` instead. Return a map of information about the specified symbol."
+              :optional info-params
+              :returns (merge info-returns fragments-doc)}
+             "cider/eldoc"
+             {:doc "Return a map of eldoc information about the specified symbol, suitable for displaying function signatures and short documentation in the editor."
+              :optional info-params
+              :returns (merge eldoc-returns fragments-doc)}
+             "eldoc"
+             {:doc "Deprecated: use `cider/eldoc` instead. Return a map of eldoc information about the specified symbol, suitable for displaying function signatures and short documentation in the editor."
+              :optional info-params
+              :returns (merge eldoc-returns fragments-doc)}
+             "cider/eldoc-datomic-query"
+             {:doc "Return a map containing the inputs of the datomic query."
+              :requires {"sym" "The symbol to lookup"
+                         "ns" "The current namespace"}
+              :returns {"status" "done"}}
+             "eldoc-datomic-query"
+             {:doc "Deprecated: use `cider/eldoc-datomic-query` instead. Return a map containing the inputs of the datomic query."
+              :requires {"sym" "The symbol to lookup"
+                         "ns" "The current namespace"}
+              :returns {"status" "done"}}}})
 
 (def inspector-returns
   {"status" "\"done\""
@@ -406,203 +402,202 @@ If specified, the value will be concatenated to that of `orchard.meta/var-meta-a
 
 (def-wrapper wrap-inspect cider.nrepl.middleware.inspect/handle-inspect
   #{"eval"}
-  (cljs/expects-piggieback
-   {:doc "Add a value inspector option to the eval op. Passing a non-nil value
+  {:doc "Add a value inspector option to the eval op. Passing a non-nil value
            in the `:inspect` slot will cause the last value returned by eval to
            be inspected. Returns a string representation of the resulting
            inspector's state in the `:value` slot."
-    :requires #{"clone" #'wrap-caught #'wrap-print}
-    :expects #{"eval"}
-    :handles {"cider/inspect-print-current-value"
-              {:doc "Print the current value of the inspector."
-               :requires {"session" "The current session"}
-               :optional wrap-print-optional-arguments
-               :returns inspector-returns}
-              "inspect-print-current-value"
-              {:doc "Deprecated: use `cider/inspect-print-current-value` instead. Print the current value of the inspector."
-               :requires {"session" "The current session"}
-               :optional wrap-print-optional-arguments
-               :returns inspector-returns}
-              "cider/inspect-pop"
-              {:doc "Moves one level up in the inspector stack."
-               :requires {"session" "The current session"}
-               :returns inspector-returns}
-              "inspect-pop"
-              {:doc "Deprecated: use `cider/inspect-pop` instead. Moves one level up in the inspector stack."
-               :requires {"session" "The current session"}
-               :returns inspector-returns}
-              "cider/inspect-push"
-              {:doc "Inspects the inside value specified by index."
-               :requires {"idx" "Index of the internal value currently rendered."
-                          "session" "The current session"}
-               :returns inspector-returns}
-              "inspect-push"
-              {:doc "Deprecated: use `cider/inspect-push` instead. Inspects the inside value specified by index."
-               :requires {"idx" "Index of the internal value currently rendered."
-                          "session" "The current session"}
-               :returns inspector-returns}
-              "cider/inspect-next-sibling"
-              {:doc "Increment the index of the last 'nth in the path by 1,
+   :requires #{"clone" #'wrap-caught #'wrap-print}
+   :expects (cljs/maybe-add-piggieback #{"eval"})
+   :handles {"cider/inspect-print-current-value"
+             {:doc "Print the current value of the inspector."
+              :requires {"session" "The current session"}
+              :optional wrap-print-optional-arguments
+              :returns inspector-returns}
+             "inspect-print-current-value"
+             {:doc "Deprecated: use `cider/inspect-print-current-value` instead. Print the current value of the inspector."
+              :requires {"session" "The current session"}
+              :optional wrap-print-optional-arguments
+              :returns inspector-returns}
+             "cider/inspect-pop"
+             {:doc "Moves one level up in the inspector stack."
+              :requires {"session" "The current session"}
+              :returns inspector-returns}
+             "inspect-pop"
+             {:doc "Deprecated: use `cider/inspect-pop` instead. Moves one level up in the inspector stack."
+              :requires {"session" "The current session"}
+              :returns inspector-returns}
+             "cider/inspect-push"
+             {:doc "Inspects the inside value specified by index."
+              :requires {"idx" "Index of the internal value currently rendered."
+                         "session" "The current session"}
+              :returns inspector-returns}
+             "inspect-push"
+             {:doc "Deprecated: use `cider/inspect-push` instead. Inspects the inside value specified by index."
+              :requires {"idx" "Index of the internal value currently rendered."
+                         "session" "The current session"}
+              :returns inspector-returns}
+             "cider/inspect-next-sibling"
+             {:doc "Increment the index of the last 'nth in the path by 1,
 if applicable, and re-render the updated value."
-               :requires {"session" "The current session"}
-               :returns inspector-returns}
-              "inspect-next-sibling"
-              {:doc "Deprecated: use `cider/inspect-next-sibling` instead. Increment the index of the last 'nth in the path by 1,
+              :requires {"session" "The current session"}
+              :returns inspector-returns}
+             "inspect-next-sibling"
+             {:doc "Deprecated: use `cider/inspect-next-sibling` instead. Increment the index of the last 'nth in the path by 1,
 if applicable, and re-render the updated value."
-               :requires {"session" "The current session"}
-               :returns inspector-returns}
-              "cider/inspect-previous-sibling"
-              {:doc "Decrement the index of the last 'nth in the path by 1,
+              :requires {"session" "The current session"}
+              :returns inspector-returns}
+             "cider/inspect-previous-sibling"
+             {:doc "Decrement the index of the last 'nth in the path by 1,
 if applicable, and re-render the updated value."
-               :requires {"session" "The current session"}
-               :returns inspector-returns}
-              "inspect-previous-sibling"
-              {:doc "Deprecated: use `cider/inspect-previous-sibling` instead. Decrement the index of the last 'nth in the path by 1,
+              :requires {"session" "The current session"}
+              :returns inspector-returns}
+             "inspect-previous-sibling"
+             {:doc "Deprecated: use `cider/inspect-previous-sibling` instead. Decrement the index of the last 'nth in the path by 1,
 if applicable, and re-render the updated value."
-               :requires {"session" "The current session"}
-               :returns inspector-returns}
-              "cider/inspect-refresh"
-              {:doc "Updates inspector with the provided config and re-renders the current value."
-               :requires {"session" "The current session"}
-               :optional {"page-size" "New page size"
-                          "max-atom-length" "New max length of single rendered value"
-                          "max-coll-size" "New max size of rendered collection"
-                          "max-nested-depth" "New max nested depth of rendered collection"
-                          "view-mode" "Mode of viewing the value - either `:normal` or `:object`"
-                          "pretty-print" "Set to true to pretty-print values within the inspector"
-                          "sort-maps" "Set to true to sort maps by their keys when inspecting a map"
-                          "only-diff" "Set to true to only display values that differ when inspecting a diff"}
-               :returns inspector-returns}
-              "inspect-refresh"
-              {:doc "Deprecated: use `cider/inspect-refresh` instead. Updates inspector with the provided config and re-renders the current value."
-               :requires {"session" "The current session"}
-               :optional {"page-size" "New page size"
-                          "max-atom-length" "New max length of single rendered value"
-                          "max-coll-size" "New max size of rendered collection"
-                          "max-nested-depth" "New max nested depth of rendered collection"
-                          "view-mode" "Mode of viewing the value - either `:normal` or `:object`"
-                          "pretty-print" "Set to true to pretty-print values within the inspector"
-                          "sort-maps" "Set to true to sort maps by their keys when inspecting a map"
-                          "only-diff" "Set to true to only display values that differ when inspecting a diff"}
-               :returns inspector-returns}
-              "cider/inspect-toggle-pretty-print"
-              {:doc "Toggles the pretty printing of values in the inspector."
-               :requires {"session" "The current session"}
-               :returns inspector-returns}
-              "inspect-toggle-pretty-print"
-              {:doc "Deprecated: use `cider/inspect-toggle-pretty-print` instead. Toggles the pretty printing of values in the inspector."
-               :requires {"session" "The current session"}
-               :returns inspector-returns}
-              "cider/inspect-toggle-view-mode"
-              {:doc "Toggles the viewing mode of the inspector. This influences the way how inspector is rendering the current value. `:normal` is the default. When view mode is `:table`, the value will be rendered as a table (only supported for sequences of maps or tuples). When view mode is `:object`, any value will be rendered as a Java object (fields shown as is). View mode is automatically reset back to normal when navigating to child values."
-               :requires {"session" "The current session"}
-               :returns inspector-returns}
-              "inspect-toggle-view-mode"
-              {:doc "Deprecated: use `cider/inspect-toggle-view-mode` instead. Toggles the viewing mode of the inspector. This influences the way how inspector is rendering the current value. `:normal` is the default. When view mode is `:table`, the value will be rendered as a table (only supported for sequences of maps or tuples). When view mode is `:object`, any value will be rendered as a Java object (fields shown as is). View mode is automatically reset back to normal when navigating to child values."
-               :requires {"session" "The current session"}
-               :returns inspector-returns}
-              "cider/inspect-display-analytics"
-              {:doc "Calculate and render analytics section for the currently inspected object."
-               :requires {"session" "The current session"}
-               :returns inspector-returns}
-              "inspect-display-analytics"
-              {:doc "Deprecated: use `cider/inspect-display-analytics` instead. Calculate and render analytics section for the currently inspected object."
-               :requires {"session" "The current session"}
-               :returns inspector-returns}
-              "cider/inspect-next-page"
-              {:doc "Jumps to the next page in paginated collection view."
-               :requires {"session" "The current session"}
-               :returns inspector-returns}
-              "inspect-next-page"
-              {:doc "Deprecated: use `cider/inspect-next-page` instead. Jumps to the next page in paginated collection view."
-               :requires {"session" "The current session"}
-               :returns inspector-returns}
-              "cider/inspect-prev-page"
-              {:doc "Jumps to the previous page in paginated collection view."
-               :requires {"session" "The current session"}
-               :returns inspector-returns}
-              "inspect-prev-page"
-              {:doc "Deprecated: use `cider/inspect-prev-page` instead. Jumps to the previous page in paginated collection view."
-               :requires {"session" "The current session"}
-               :returns inspector-returns}
-              "cider/inspect-set-page-size"
-              {:doc "[DEPRECATED - use `cider/inspect-refresh` instead] Sets the page size in paginated view to specified value."
-               :requires {"page-size" "New page size."
-                          "session" "The current session"}
-               :returns inspector-returns}
-              "inspect-set-page-size"
-              {:doc "[DEPRECATED - use `cider/inspect-refresh` instead] Sets the page size in paginated view to specified value."
-               :requires {"page-size" "New page size."
-                          "session" "The current session"}
-               :returns inspector-returns}
-              "cider/inspect-set-max-atom-length"
-              {:doc "[DEPRECATED - use `cider/inspect-refresh` instead] Set the max length of nested atoms to specified value."
-               :requires {"max-atom-length" "New max length."
-                          "session" "The current session"}
-               :returns inspector-returns}
-              "inspect-set-max-atom-length"
-              {:doc "[DEPRECATED - use `cider/inspect-refresh` instead] Set the max length of nested atoms to specified value."
-               :requires {"max-atom-length" "New max length."
-                          "session" "The current session"}
-               :returns inspector-returns}
-              "cider/inspect-set-max-coll-size"
-              {:doc "[DEPRECATED - use `cider/inspect-refresh` instead] Set the number of nested collection members to display before truncating."
-               :requires {"max-coll-size" "New collection size."
-                          "session" "The current session"}
-               :returns inspector-returns}
-              "inspect-set-max-coll-size"
-              {:doc "[DEPRECATED - use `cider/inspect-refresh` instead] Set the number of nested collection members to display before truncating."
-               :requires {"max-coll-size" "New collection size."
-                          "session" "The current session"}
-               :returns inspector-returns}
-              "cider/inspect-set-max-nested-depth"
-              {:doc "[DEPRECATED - use `cider/inspect-refresh` instead] Set the maximum nested levels to display before truncating."
-               :requires {"max-nested-depth" "New nested depth."
-                          "session" "The current session"}
-               :returns inspector-returns}
-              "inspect-set-max-nested-depth"
-              {:doc "[DEPRECATED - use `cider/inspect-refresh` instead] Set the maximum nested levels to display before truncating."
-               :requires {"max-nested-depth" "New nested depth."
-                          "session" "The current session"}
-               :returns inspector-returns}
-              "cider/inspect-clear"
-              {:doc "Clears the state state of the inspector."
-               :requires {"session" "The current session"}
-               :returns inspector-returns}
-              "inspect-clear"
-              {:doc "Deprecated: use `cider/inspect-clear` instead. Clears the state state of the inspector."
-               :requires {"session" "The current session"}
-               :returns inspector-returns}
-              "cider/inspect-def-current-value"
-              {:doc "Define the currently inspected value as a var with the given var-name in the provided namespace."
-               :requires {"session" "The current session"
-                          "ns" "Namespace to define var on"
-                          "var-name" "The var name"}
-               :returns inspector-returns}
-              "inspect-def-current-value"
-              {:doc "Deprecated: use `cider/inspect-def-current-value` instead. Define the currently inspected value as a var with the given var-name in the provided namespace."
-               :requires {"session" "The current session"
-                          "ns" "Namespace to define var on"
-                          "var-name" "The var name"}
-               :returns inspector-returns}
-              "cider/inspect-tap-current-value"
-              {:doc "Send the currently inspected value to the Clojure tap>."
-               :requires {"session" "The current session"}
-               :returns inspector-returns}
-              "inspect-tap-current-value"
-              {:doc "Deprecated: use `cider/inspect-tap-current-value` instead. Send the currently inspected value to the Clojure tap>."
-               :requires {"session" "The current session"}
-               :returns inspector-returns}
-              "cider/inspect-tap-indexed"
-              {:doc "Send the currently inspected sub-value at `idx` to the Clojure tap>."
-               :requires {"session" "The current session"
-                          "idx" "Index of the internal value to be tapped"}
-               :returns inspector-returns}
-              "inspect-tap-indexed"
-              {:doc "Deprecated: use `cider/inspect-tap-indexed` instead. Send the currently inspected sub-value at `idx` to the Clojure tap>."
-               :requires {"session" "The current session"
-                          "idx" "Index of the internal value to be tapped"}
-               :returns inspector-returns}}}))
+              :requires {"session" "The current session"}
+              :returns inspector-returns}
+             "cider/inspect-refresh"
+             {:doc "Updates inspector with the provided config and re-renders the current value."
+              :requires {"session" "The current session"}
+              :optional {"page-size" "New page size"
+                         "max-atom-length" "New max length of single rendered value"
+                         "max-coll-size" "New max size of rendered collection"
+                         "max-nested-depth" "New max nested depth of rendered collection"
+                         "view-mode" "Mode of viewing the value - either `:normal` or `:object`"
+                         "pretty-print" "Set to true to pretty-print values within the inspector"
+                         "sort-maps" "Set to true to sort maps by their keys when inspecting a map"
+                         "only-diff" "Set to true to only display values that differ when inspecting a diff"}
+              :returns inspector-returns}
+             "inspect-refresh"
+             {:doc "Deprecated: use `cider/inspect-refresh` instead. Updates inspector with the provided config and re-renders the current value."
+              :requires {"session" "The current session"}
+              :optional {"page-size" "New page size"
+                         "max-atom-length" "New max length of single rendered value"
+                         "max-coll-size" "New max size of rendered collection"
+                         "max-nested-depth" "New max nested depth of rendered collection"
+                         "view-mode" "Mode of viewing the value - either `:normal` or `:object`"
+                         "pretty-print" "Set to true to pretty-print values within the inspector"
+                         "sort-maps" "Set to true to sort maps by their keys when inspecting a map"
+                         "only-diff" "Set to true to only display values that differ when inspecting a diff"}
+              :returns inspector-returns}
+             "cider/inspect-toggle-pretty-print"
+             {:doc "Toggles the pretty printing of values in the inspector."
+              :requires {"session" "The current session"}
+              :returns inspector-returns}
+             "inspect-toggle-pretty-print"
+             {:doc "Deprecated: use `cider/inspect-toggle-pretty-print` instead. Toggles the pretty printing of values in the inspector."
+              :requires {"session" "The current session"}
+              :returns inspector-returns}
+             "cider/inspect-toggle-view-mode"
+             {:doc "Toggles the viewing mode of the inspector. This influences the way how inspector is rendering the current value. `:normal` is the default. When view mode is `:table`, the value will be rendered as a table (only supported for sequences of maps or tuples). When view mode is `:object`, any value will be rendered as a Java object (fields shown as is). View mode is automatically reset back to normal when navigating to child values."
+              :requires {"session" "The current session"}
+              :returns inspector-returns}
+             "inspect-toggle-view-mode"
+             {:doc "Deprecated: use `cider/inspect-toggle-view-mode` instead. Toggles the viewing mode of the inspector. This influences the way how inspector is rendering the current value. `:normal` is the default. When view mode is `:table`, the value will be rendered as a table (only supported for sequences of maps or tuples). When view mode is `:object`, any value will be rendered as a Java object (fields shown as is). View mode is automatically reset back to normal when navigating to child values."
+              :requires {"session" "The current session"}
+              :returns inspector-returns}
+             "cider/inspect-display-analytics"
+             {:doc "Calculate and render analytics section for the currently inspected object."
+              :requires {"session" "The current session"}
+              :returns inspector-returns}
+             "inspect-display-analytics"
+             {:doc "Deprecated: use `cider/inspect-display-analytics` instead. Calculate and render analytics section for the currently inspected object."
+              :requires {"session" "The current session"}
+              :returns inspector-returns}
+             "cider/inspect-next-page"
+             {:doc "Jumps to the next page in paginated collection view."
+              :requires {"session" "The current session"}
+              :returns inspector-returns}
+             "inspect-next-page"
+             {:doc "Deprecated: use `cider/inspect-next-page` instead. Jumps to the next page in paginated collection view."
+              :requires {"session" "The current session"}
+              :returns inspector-returns}
+             "cider/inspect-prev-page"
+             {:doc "Jumps to the previous page in paginated collection view."
+              :requires {"session" "The current session"}
+              :returns inspector-returns}
+             "inspect-prev-page"
+             {:doc "Deprecated: use `cider/inspect-prev-page` instead. Jumps to the previous page in paginated collection view."
+              :requires {"session" "The current session"}
+              :returns inspector-returns}
+             "cider/inspect-set-page-size"
+             {:doc "[DEPRECATED - use `cider/inspect-refresh` instead] Sets the page size in paginated view to specified value."
+              :requires {"page-size" "New page size."
+                         "session" "The current session"}
+              :returns inspector-returns}
+             "inspect-set-page-size"
+             {:doc "[DEPRECATED - use `cider/inspect-refresh` instead] Sets the page size in paginated view to specified value."
+              :requires {"page-size" "New page size."
+                         "session" "The current session"}
+              :returns inspector-returns}
+             "cider/inspect-set-max-atom-length"
+             {:doc "[DEPRECATED - use `cider/inspect-refresh` instead] Set the max length of nested atoms to specified value."
+              :requires {"max-atom-length" "New max length."
+                         "session" "The current session"}
+              :returns inspector-returns}
+             "inspect-set-max-atom-length"
+             {:doc "[DEPRECATED - use `cider/inspect-refresh` instead] Set the max length of nested atoms to specified value."
+              :requires {"max-atom-length" "New max length."
+                         "session" "The current session"}
+              :returns inspector-returns}
+             "cider/inspect-set-max-coll-size"
+             {:doc "[DEPRECATED - use `cider/inspect-refresh` instead] Set the number of nested collection members to display before truncating."
+              :requires {"max-coll-size" "New collection size."
+                         "session" "The current session"}
+              :returns inspector-returns}
+             "inspect-set-max-coll-size"
+             {:doc "[DEPRECATED - use `cider/inspect-refresh` instead] Set the number of nested collection members to display before truncating."
+              :requires {"max-coll-size" "New collection size."
+                         "session" "The current session"}
+              :returns inspector-returns}
+             "cider/inspect-set-max-nested-depth"
+             {:doc "[DEPRECATED - use `cider/inspect-refresh` instead] Set the maximum nested levels to display before truncating."
+              :requires {"max-nested-depth" "New nested depth."
+                         "session" "The current session"}
+              :returns inspector-returns}
+             "inspect-set-max-nested-depth"
+             {:doc "[DEPRECATED - use `cider/inspect-refresh` instead] Set the maximum nested levels to display before truncating."
+              :requires {"max-nested-depth" "New nested depth."
+                         "session" "The current session"}
+              :returns inspector-returns}
+             "cider/inspect-clear"
+             {:doc "Clears the state state of the inspector."
+              :requires {"session" "The current session"}
+              :returns inspector-returns}
+             "inspect-clear"
+             {:doc "Deprecated: use `cider/inspect-clear` instead. Clears the state state of the inspector."
+              :requires {"session" "The current session"}
+              :returns inspector-returns}
+             "cider/inspect-def-current-value"
+             {:doc "Define the currently inspected value as a var with the given var-name in the provided namespace."
+              :requires {"session" "The current session"
+                         "ns" "Namespace to define var on"
+                         "var-name" "The var name"}
+              :returns inspector-returns}
+             "inspect-def-current-value"
+             {:doc "Deprecated: use `cider/inspect-def-current-value` instead. Define the currently inspected value as a var with the given var-name in the provided namespace."
+              :requires {"session" "The current session"
+                         "ns" "Namespace to define var on"
+                         "var-name" "The var name"}
+              :returns inspector-returns}
+             "cider/inspect-tap-current-value"
+             {:doc "Send the currently inspected value to the Clojure tap>."
+              :requires {"session" "The current session"}
+              :returns inspector-returns}
+             "inspect-tap-current-value"
+             {:doc "Deprecated: use `cider/inspect-tap-current-value` instead. Send the currently inspected value to the Clojure tap>."
+              :requires {"session" "The current session"}
+              :returns inspector-returns}
+             "cider/inspect-tap-indexed"
+             {:doc "Send the currently inspected sub-value at `idx` to the Clojure tap>."
+              :requires {"session" "The current session"
+                         "idx" "Index of the internal value to be tapped"}
+              :returns inspector-returns}
+             "inspect-tap-indexed"
+             {:doc "Deprecated: use `cider/inspect-tap-indexed` instead. Send the currently inspected sub-value at `idx` to the Clojure tap>."
+              :requires {"session" "The current session"
+                         "idx" "Index of the internal value to be tapped"}
+              :returns inspector-returns}}})
 
 (def-wrapper wrap-log cider.nrepl.middleware.log/handle-log
   {:doc "Middleware that captures log events and makes them inspect-able."
@@ -728,106 +723,103 @@ if applicable, and re-render the updated value."
                "cider/log-threads" "A map from thread name to event frequency."}}}})
 
 (def-wrapper wrap-macroexpand cider.nrepl.middleware.macroexpand/handle-macroexpand
-  (cljs/requires-piggieback
-   {:doc "Macroexpansion middleware."
-    :requires #{#'session}
-    :expects #{"eval"}
-    :handles {"cider/macroexpand"
-              {:doc "Produces macroexpansion of some form using the given expander."
-               :requires {"code" "The form to macroexpand."}
-               :optional {"ns" "The namespace in which to perform the macroexpansion. Defaults to 'user for Clojure and 'cljs.user for ClojureScript."
-                          "expander" "The macroexpansion function to use. Possible values are \"macroexpand-1\", \"macroexpand\", \"macroexpand-step\", or \"macroexpand-all\". Defaults to \"macroexpand\"."
-                          "display-namespaces" "How to print namespace-qualified symbols in the result. Possible values are \"qualified\" to leave all namespaces qualified, \"none\" to elide all namespaces, or \"tidy\" to replace namespaces with their aliases in the given namespace. Defaults to \"qualified\"."
-                          "print-meta" "If truthy, also print metadata of forms."}
-               :returns {"expansion" "The macroexpanded form."}}
-              "macroexpand"
-              {:doc "Deprecated: use `cider/macroexpand` instead. Produces macroexpansion of some form using the given expander."
-               :requires {"code" "The form to macroexpand."}
-               :optional {"ns" "The namespace in which to perform the macroexpansion. Defaults to 'user for Clojure and 'cljs.user for ClojureScript."
-                          "expander" "The macroexpansion function to use. Possible values are \"macroexpand-1\", \"macroexpand\", \"macroexpand-step\", or \"macroexpand-all\". Defaults to \"macroexpand\"."
-                          "display-namespaces" "How to print namespace-qualified symbols in the result. Possible values are \"qualified\" to leave all namespaces qualified, \"none\" to elide all namespaces, or \"tidy\" to replace namespaces with their aliases in the given namespace. Defaults to \"qualified\"."
-                          "print-meta" "If truthy, also print metadata of forms."}
-               :returns {"expansion" "The macroexpanded form."}}}}))
+  {:doc "Macroexpansion middleware."
+   :requires (cljs/maybe-add-piggieback #{#'session})
+   :expects #{"eval"}
+   :handles {"cider/macroexpand"
+             {:doc "Produces macroexpansion of some form using the given expander."
+              :requires {"code" "The form to macroexpand."}
+              :optional {"ns" "The namespace in which to perform the macroexpansion. Defaults to 'user for Clojure and 'cljs.user for ClojureScript."
+                         "expander" "The macroexpansion function to use. Possible values are \"macroexpand-1\", \"macroexpand\", \"macroexpand-step\", or \"macroexpand-all\". Defaults to \"macroexpand\"."
+                         "display-namespaces" "How to print namespace-qualified symbols in the result. Possible values are \"qualified\" to leave all namespaces qualified, \"none\" to elide all namespaces, or \"tidy\" to replace namespaces with their aliases in the given namespace. Defaults to \"qualified\"."
+                         "print-meta" "If truthy, also print metadata of forms."}
+              :returns {"expansion" "The macroexpanded form."}}
+             "macroexpand"
+             {:doc "Deprecated: use `cider/macroexpand` instead. Produces macroexpansion of some form using the given expander."
+              :requires {"code" "The form to macroexpand."}
+              :optional {"ns" "The namespace in which to perform the macroexpansion. Defaults to 'user for Clojure and 'cljs.user for ClojureScript."
+                         "expander" "The macroexpansion function to use. Possible values are \"macroexpand-1\", \"macroexpand\", \"macroexpand-step\", or \"macroexpand-all\". Defaults to \"macroexpand\"."
+                         "display-namespaces" "How to print namespace-qualified symbols in the result. Possible values are \"qualified\" to leave all namespaces qualified, \"none\" to elide all namespaces, or \"tidy\" to replace namespaces with their aliases in the given namespace. Defaults to \"qualified\"."
+                         "print-meta" "If truthy, also print metadata of forms."}
+              :returns {"expansion" "The macroexpanded form."}}}})
 
 (def-wrapper wrap-ns cider.nrepl.middleware.ns/handle-ns
-  (cljs/requires-piggieback
-   {:doc "Provide ns listing and browsing functionality."
-    :requires #{#'session}
-    :handles {"cider/ns-list"
-              {:doc "Return a sorted list of all namespaces."
-               :returns {"status" "done" "ns-list" "The sorted list of all namespaces."}
-               :optional {"filter-regexps" "All namespaces matching any regexp from this list would be dropped from the result."}}
-              "ns-list"
-              {:doc "Deprecated: use `cider/ns-list` instead. Return a sorted list of all namespaces."
-               :returns {"status" "done" "ns-list" "The sorted list of all namespaces."}
-               :optional {"filter-regexps" "All namespaces matching any regexp from this list would be dropped from the result."}}
-              "cider/ns-list-vars-by-name"
-              {:doc "Return a list of vars named `name` amongst all namespaces."
-               :requires {"name" "The name to use."}
-               :returns {"status" "done" "var-list" "The list obtained."}}
-              "ns-list-vars-by-name"
-              {:doc "Deprecated: use `cider/ns-list-vars-by-name` instead. Return a list of vars named `name` amongst all namespaces."
-               :requires {"name" "The name to use."}
-               :returns {"status" "done" "var-list" "The list obtained."}}
-              "cider/ns-vars"
-              {:doc "Returns a sorted list of public vars in a namespace."
-               :requires {"ns" "The namespace to browse."}
-               :optional {"var-query" "The search query for vars. Only \"private?\" is supported for ClojureScript."}
-               :returns {"status" "done" "ns-vars" "The sorted list of public vars in a namespace."}}
-              "ns-vars"
-              {:doc "Deprecated: use `cider/ns-vars` instead. Returns a sorted list of public vars in a namespace."
-               :requires {"ns" "The namespace to browse."}
-               :optional {"var-query" "The search query for vars. Only \"private?\" is supported for ClojureScript."}
-               :returns {"status" "done" "ns-vars" "The sorted list of public vars in a namespace."}}
-              "cider/ns-vars-with-meta"
-              {:doc "Returns a map of [var-name] to [var-metadata] for public vars in a namespace."
-               :requires {"ns" "The namespace to use."}
-               :optional {"var-query" "The search query for vars. Only \"private?\" is supported for ClojureScript."}
-               :returns {"status" "done" "ns-vars-with-meta" "The map of [var-name] to [var-metadata] for public vars in a namespace."}}
-              "ns-vars-with-meta"
-              {:doc "Deprecated: use `cider/ns-vars-with-meta` instead. Returns a map of [var-name] to [var-metadata] for public vars in a namespace."
-               :requires {"ns" "The namespace to use."}
-               :optional {"var-query" "The search query for vars. Only \"private?\" is supported for ClojureScript."}
-               :returns {"status" "done" "ns-vars-with-meta" "The map of [var-name] to [var-metadata] for public vars in a namespace."}}
-              "cider/ns-path"
-              {:doc "Returns the path to the file containing ns."
-               :requires {"ns" "The namespace to find."}
-               :returns {"status" "done"
-                         "path" "The path to the file containing ns. Please favor `:url` in ClojureScript, but fall back to `:path`."
-                         "url" "The Java URL indicating the file containing ns. Please favor this attribute over `:path` when possible. If this value is nil, you can fall back to `:path`."}}
-              "ns-path"
-              {:doc "Deprecated: use `cider/ns-path` instead. Returns the path to the file containing ns."
-               :requires {"ns" "The namespace to find."}
-               :returns {"status" "done"
-                         "path" "The path to the file containing ns. Please favor `:url` in ClojureScript, but fall back to `:path`."
-                         "url" "The Java URL indicating the file containing ns. Please favor this attribute over `:path` when possible. If this value is nil, you can fall back to `:path`."}}
-              "cider/ns-load-all"
-              {:doc "Loads all project namespaces."
-               :returns {"status" "done" "loaded-ns" "The list of ns that were loaded."}}
-              "ns-load-all"
-              {:doc "Deprecated: use `cider/ns-load-all` instead. Loads all project namespaces."
-               :returns {"status" "done" "loaded-ns" "The list of ns that were loaded."}}
-              "cider/ns-aliases"
-              {:doc "Returns a map of [ns-alias] to [ns-name] in a namespace."
-               :requires {"ns" "The namespace to use."}
-               :returns {"status" "done" "ns-aliases" "The map of [ns-alias] to [ns-name] in a namespace."}}
-              "ns-aliases"
-              {:doc "Deprecated: use `cider/ns-aliases` instead. Returns a map of [ns-alias] to [ns-name] in a namespace."
-               :requires {"ns" "The namespace to use."}
-               :returns {"status" "done" "ns-aliases" "The map of [ns-alias] to [ns-name] in a namespace."}}}}))
+  {:doc "Provide ns listing and browsing functionality."
+   :requires (cljs/maybe-add-piggieback #{#'session})
+   :handles {"cider/ns-list"
+             {:doc "Return a sorted list of all namespaces."
+              :returns {"status" "done" "ns-list" "The sorted list of all namespaces."}
+              :optional {"filter-regexps" "All namespaces matching any regexp from this list would be dropped from the result."}}
+             "ns-list"
+             {:doc "Deprecated: use `cider/ns-list` instead. Return a sorted list of all namespaces."
+              :returns {"status" "done" "ns-list" "The sorted list of all namespaces."}
+              :optional {"filter-regexps" "All namespaces matching any regexp from this list would be dropped from the result."}}
+             "cider/ns-list-vars-by-name"
+             {:doc "Return a list of vars named `name` amongst all namespaces."
+              :requires {"name" "The name to use."}
+              :returns {"status" "done" "var-list" "The list obtained."}}
+             "ns-list-vars-by-name"
+             {:doc "Deprecated: use `cider/ns-list-vars-by-name` instead. Return a list of vars named `name` amongst all namespaces."
+              :requires {"name" "The name to use."}
+              :returns {"status" "done" "var-list" "The list obtained."}}
+             "cider/ns-vars"
+             {:doc "Returns a sorted list of public vars in a namespace."
+              :requires {"ns" "The namespace to browse."}
+              :optional {"var-query" "The search query for vars. Only \"private?\" is supported for ClojureScript."}
+              :returns {"status" "done" "ns-vars" "The sorted list of public vars in a namespace."}}
+             "ns-vars"
+             {:doc "Deprecated: use `cider/ns-vars` instead. Returns a sorted list of public vars in a namespace."
+              :requires {"ns" "The namespace to browse."}
+              :optional {"var-query" "The search query for vars. Only \"private?\" is supported for ClojureScript."}
+              :returns {"status" "done" "ns-vars" "The sorted list of public vars in a namespace."}}
+             "cider/ns-vars-with-meta"
+             {:doc "Returns a map of [var-name] to [var-metadata] for public vars in a namespace."
+              :requires {"ns" "The namespace to use."}
+              :optional {"var-query" "The search query for vars. Only \"private?\" is supported for ClojureScript."}
+              :returns {"status" "done" "ns-vars-with-meta" "The map of [var-name] to [var-metadata] for public vars in a namespace."}}
+             "ns-vars-with-meta"
+             {:doc "Deprecated: use `cider/ns-vars-with-meta` instead. Returns a map of [var-name] to [var-metadata] for public vars in a namespace."
+              :requires {"ns" "The namespace to use."}
+              :optional {"var-query" "The search query for vars. Only \"private?\" is supported for ClojureScript."}
+              :returns {"status" "done" "ns-vars-with-meta" "The map of [var-name] to [var-metadata] for public vars in a namespace."}}
+             "cider/ns-path"
+             {:doc "Returns the path to the file containing ns."
+              :requires {"ns" "The namespace to find."}
+              :returns {"status" "done"
+                        "path" "The path to the file containing ns. Please favor `:url` in ClojureScript, but fall back to `:path`."
+                        "url" "The Java URL indicating the file containing ns. Please favor this attribute over `:path` when possible. If this value is nil, you can fall back to `:path`."}}
+             "ns-path"
+             {:doc "Deprecated: use `cider/ns-path` instead. Returns the path to the file containing ns."
+              :requires {"ns" "The namespace to find."}
+              :returns {"status" "done"
+                        "path" "The path to the file containing ns. Please favor `:url` in ClojureScript, but fall back to `:path`."
+                        "url" "The Java URL indicating the file containing ns. Please favor this attribute over `:path` when possible. If this value is nil, you can fall back to `:path`."}}
+             "cider/ns-load-all"
+             {:doc "Loads all project namespaces."
+              :returns {"status" "done" "loaded-ns" "The list of ns that were loaded."}}
+             "ns-load-all"
+             {:doc "Deprecated: use `cider/ns-load-all` instead. Loads all project namespaces."
+              :returns {"status" "done" "loaded-ns" "The list of ns that were loaded."}}
+             "cider/ns-aliases"
+             {:doc "Returns a map of [ns-alias] to [ns-name] in a namespace."
+              :requires {"ns" "The namespace to use."}
+              :returns {"status" "done" "ns-aliases" "The map of [ns-alias] to [ns-name] in a namespace."}}
+             "ns-aliases"
+             {:doc "Deprecated: use `cider/ns-aliases` instead. Returns a map of [ns-alias] to [ns-name] in a namespace."
+              :requires {"ns" "The namespace to use."}
+              :returns {"status" "done" "ns-aliases" "The map of [ns-alias] to [ns-name] in a namespace."}}}})
 
 (def-wrapper wrap-out cider.nrepl.middleware.out/handle-out
-  (cljs/expects-piggieback
-   {:requires #{#'session}
-    :expects #{"eval"}
-    :handles {"cider/out-subscribe"
-              {:doc "Change #'*out* so that it also prints to active sessions, even outside an eval scope."}
-              "out-subscribe"
-              {:doc "Deprecated: use `cider/out-subscribe` instead. Change #'*out* so that it also prints to active sessions, even outside an eval scope."}
-              "cider/out-unsubscribe"
-              {:doc "Change #'*out* so that it no longer prints to active sessions outside an eval scope."}
-              "out-unsubscribe"
-              {:doc "Deprecated: use `cider/out-unsubscribe` instead. Change #'*out* so that it no longer prints to active sessions outside an eval scope."}}}))
+  {:requires #{#'session}
+   :expects (cljs/maybe-add-piggieback #{"eval"})
+   :handles {"cider/out-subscribe"
+             {:doc "Change #'*out* so that it also prints to active sessions, even outside an eval scope."}
+             "out-subscribe"
+             {:doc "Deprecated: use `cider/out-subscribe` instead. Change #'*out* so that it also prints to active sessions, even outside an eval scope."}
+             "cider/out-unsubscribe"
+             {:doc "Change #'*out* so that it no longer prints to active sessions outside an eval scope."}
+             "out-unsubscribe"
+             {:doc "Deprecated: use `cider/out-unsubscribe` instead. Change #'*out* so that it no longer prints to active sessions outside an eval scope."}}})
 
 (def-wrapper wrap-profile cider.nrepl.middleware.profile/handle-profile
   {:doc     "Middleware for manual profiling"
@@ -937,65 +929,64 @@ those configured directories will be honored."
               :returns {"resources-list" "The list of resources."}}}})
 
 (def-wrapper wrap-spec cider.nrepl.middleware.spec/handle-spec
-  (cljs/requires-piggieback
-   {:doc "Middleware that provides `clojure.spec` browsing functionality."
-    :handles {"cider/spec-list" {:doc "Return a sorted list of all specs in the registry"
-                                 :returns {"status" "done"
-                                           "spec-list" "The sorted list of all specs in the registry with their descriptions"}
-                                 :optional {"filter-regex" "Only the specs that matches filter prefix regex will be returned "}}
-              "spec-list" {:doc "Deprecated: use `cider/spec-list` instead. Return a sorted list of all specs in the registry"
-                           :returns {"status" "done"
-                                     "spec-list" "The sorted list of all specs in the registry with their descriptions"}
-                           :optional {"filter-regex" "Only the specs that matches filter prefix regex will be returned "}}
-              "cider/spec-form" {:doc "Return the form of a given spec"
-                                 :requires {"spec-name" "The spec namespaced keyword we are looking for"}
-                                 :returns {"status" "done"
-                                           "spec-form" "The spec form"}}
-              "spec-form" {:doc "Deprecated: use `cider/spec-form` instead. Return the form of a given spec"
-                           :requires {"spec-name" "The spec namespaced keyword we are looking for"}
-                           :returns {"status" "done"
-                                     "spec-form" "The spec form"}}
-              "cider/spec-example" {:doc "Return a string with a pretty printed example for a spec"
-                                    :requires {"spec-name" "The spec namespaced keyword we want the example for"}
-                                    :returns {"status" "done"
-                                              "example" "The pretty printed spec example string"}}
-              "spec-example" {:doc "Deprecated: use `cider/spec-example` instead. Return a string with a pretty printed example for a spec"
-                              :requires {"spec-name" "The spec namespaced keyword we want the example for"}
-                              :returns {"status" "done"
-                                        "example" "The pretty printed spec example string"}}}}))
+  {:doc "Middleware that provides `clojure.spec` browsing functionality."
+   :requires (cljs/maybe-add-piggieback #{})
+   :handles {"cider/spec-list" {:doc "Return a sorted list of all specs in the registry"
+                                :returns {"status" "done"
+                                          "spec-list" "The sorted list of all specs in the registry with their descriptions"}
+                                :optional {"filter-regex" "Only the specs that matches filter prefix regex will be returned "}}
+             "spec-list" {:doc "Deprecated: use `cider/spec-list` instead. Return a sorted list of all specs in the registry"
+                          :returns {"status" "done"
+                                    "spec-list" "The sorted list of all specs in the registry with their descriptions"}
+                          :optional {"filter-regex" "Only the specs that matches filter prefix regex will be returned "}}
+             "cider/spec-form" {:doc "Return the form of a given spec"
+                                :requires {"spec-name" "The spec namespaced keyword we are looking for"}
+                                :returns {"status" "done"
+                                          "spec-form" "The spec form"}}
+             "spec-form" {:doc "Deprecated: use `cider/spec-form` instead. Return the form of a given spec"
+                          :requires {"spec-name" "The spec namespaced keyword we are looking for"}
+                          :returns {"status" "done"
+                                    "spec-form" "The spec form"}}
+             "cider/spec-example" {:doc "Return a string with a pretty printed example for a spec"
+                                   :requires {"spec-name" "The spec namespaced keyword we want the example for"}
+                                   :returns {"status" "done"
+                                             "example" "The pretty printed spec example string"}}
+             "spec-example" {:doc "Deprecated: use `cider/spec-example` instead. Return a string with a pretty printed example for a spec"
+                             :requires {"spec-name" "The spec namespaced keyword we want the example for"}
+                             :returns {"status" "done"
+                                       "example" "The pretty printed spec example string"}}}})
 
 (def-wrapper wrap-stacktrace cider.nrepl.middleware.stacktrace/handle-stacktrace
-  (cljs/requires-piggieback
-   {:doc "Middleware that handles stacktrace requests, sending
+  {:doc "Middleware that handles stacktrace requests, sending
            cause and stack frame info for the most recent exception."
-    :requires #{#'session #'wrap-print}
-    :expects #{}
-    :handles {"cider/analyze-last-stacktrace" {:doc "Return messages describing each cause and stack frame of the most recent exception."
-                                               :optional wrap-print-optional-arguments
-                                               :returns {"status" "\"done\", or \"no-error\" if `*e` is nil"}}
-              "analyze-last-stacktrace" {:doc "Deprecated: use `cider/analyze-last-stacktrace` instead. Return messages describing each cause and stack frame of the most recent exception."
-                                         :optional wrap-print-optional-arguments
-                                         :returns {"status" "\"done\", or \"no-error\" if `*e` is nil"}}
-              "cider/inspect-last-exception" {:doc "Returns an Inspector response for the last exception that has been processed through `cider/analyze-last-stacktrace` for the current nrepl session.
+   :requires (cljs/maybe-add-piggieback #{#'session #'wrap-print})
+   :expects #{}
+   :handles {"cider/analyze-last-stacktrace" {:doc "Return messages describing each cause and stack frame of the most recent exception."
+                                              :optional wrap-print-optional-arguments
+                                              :returns {"status" "\"done\", or \"no-error\" if `*e` is nil"}}
+             "analyze-last-stacktrace" {:doc "Deprecated: use `cider/analyze-last-stacktrace` instead. Return messages describing each cause and stack frame of the most recent exception."
+                                        :optional wrap-print-optional-arguments
+                                        :returns {"status" "\"done\", or \"no-error\" if `*e` is nil"}}
+             "cider/inspect-last-exception" {:doc "Returns an Inspector response for the last exception that has been processed through `cider/analyze-last-stacktrace` for the current nrepl session.
 Assumes that `cider/analyze-last-stacktrace` has been called first, returning \"no-error\" otherwise."
-                                              :requires {"index" "0 for inspecting the top-level exception, 1 for its ex-cause, 2 for its ex-cause's ex-cause, and so on."}
-                                              :optional {"ex-data" "When equal to \"true\", inspect ex-data of the exception instead of full exception."}
-                                              :returns {"status" "\"done\", or \"no-error\" if `cider/analyze-last-stacktrace` wasn't called beforehand (or the `index` was out of bounds)."
-                                                        "value" "A value, as produced by the Inspector middleware."}}
-              "inspect-last-exception" {:doc "Deprecated: use `cider/inspect-last-exception` instead. Returns an Inspector response for the last exception that has been processed through `analyze-last-stacktrace` for the current nrepl session.
+                                             :requires {"index" "0 for inspecting the top-level exception, 1 for its ex-cause, 2 for its ex-cause's ex-cause, and so on."}
+                                             :optional {"ex-data" "When equal to \"true\", inspect ex-data of the exception instead of full exception."}
+                                             :returns {"status" "\"done\", or \"no-error\" if `cider/analyze-last-stacktrace` wasn't called beforehand (or the `index` was out of bounds)."
+                                                       "value" "A value, as produced by the Inspector middleware."}}
+             "inspect-last-exception" {:doc "Deprecated: use `cider/inspect-last-exception` instead. Returns an Inspector response for the last exception that has been processed through `analyze-last-stacktrace` for the current nrepl session.
 Assumes that `analyze-last-stacktrace` has been called first, returning \"no-error\" otherwise."
-                                        :requires {"index" "0 for inspecting the top-level exception, 1 for its ex-cause, 2 for its ex-cause's ex-cause, and so on."}
-                                        :optional {"ex-data" "When equal to \"true\", inspect ex-data of the exception instead of full exception."}
-                                        :returns {"status" "\"done\", or \"no-error\" if `analyze-last-stacktrace` wasn't called beforehand (or the `index` was out of bounds)."
-                                                  "value" "A value, as produced by the Inspector middleware."}}
-              "cider/stacktrace" {:doc "Deprecated: use `cider/analyze-last-stacktrace` instead. Return messages describing each cause and
+                                       :requires {"index" "0 for inspecting the top-level exception, 1 for its ex-cause, 2 for its ex-cause's ex-cause, and so on."}
+                                       :optional {"ex-data" "When equal to \"true\", inspect ex-data of the exception instead of full exception."}
+                                       :returns {"status" "\"done\", or \"no-error\" if `analyze-last-stacktrace` wasn't called beforehand (or the `index` was out of bounds)."
+                                                 "value" "A value, as produced by the Inspector middleware."}}
+             "cider/stacktrace" {:doc "Deprecated: use `cider/analyze-last-stacktrace` instead. Return messages describing each cause and
 stack frame of the most recent exception."
-                                  :optional wrap-print-optional-arguments
-                                  :returns {"status" "\"done\", or \"no-error\" if `*e` is nil"}}
-              "stacktrace" {:doc "Deprecated: use `cider/analyze-last-stacktrace` instead. Return messages describing each cause and
+                                 :optional wrap-print-optional-arguments
+                                 :returns {"status" "\"done\", or \"no-error\" if `*e` is nil"}}
+             "stacktrace" {:doc "Deprecated: use `cider/analyze-last-stacktrace` instead. Return messages describing each cause and
 stack frame of the most recent exception."
-                            :optional wrap-print-optional-arguments
-                            :returns {"status" "\"done\", or \"no-error\" if `*e` is nil"}}}}))
+                           :optional wrap-print-optional-arguments
+                           :returns {"status" "\"done\", or \"no-error\" if `*e` is nil"}}}})
 
 (def timing-info-return-doc {"status" "Either done or indication of an error"
                              "elapsed-time" "a report of the elapsed time spent running all the given namespaces. The structure is `:elapsed-time {:ms <integer> :humanized <string>}`."
@@ -1075,14 +1066,13 @@ stack frame of the most recent exception."
 
 (def-wrapper wrap-tracker cider.nrepl.middleware.track-state/handle-tracker
   mw/ops-that-can-eval
-  (cljs/expects-piggieback
-   {:doc "Under its normal operation mode, enhances the `eval` op by notifying the client of the current REPL state.
+  {:doc "Under its normal operation mode, enhances the `eval` op by notifying the client of the current REPL state.
 You can also request to compute the info directly by requesting the \"cider/get-state\" op."
-    :requires #{#'session}
-    :expects mw/ops-that-can-eval
-    :handles {"cider/get-state" {}}
-    :returns {"repl-type" "`:clj` or `:cljs`."
-              "changed-namespaces" "A map of namespaces to `{:aliases ,,, :interns ,,,}`"}}))
+   :requires #{#'session}
+   :expects (cljs/maybe-add-piggieback mw/ops-that-can-eval)
+   :handles {"cider/get-state" {}}
+   :returns {"repl-type" "`:clj` or `:cljs`."
+             "changed-namespaces" "A map of namespaces to `{:aliases ,,, :interns ,,,}`"}})
 
 (def-wrapper wrap-undef cider.nrepl.middleware.undef/handle-undef
   {:doc "Middleware to undefine a symbol in a namespace."
@@ -1175,4 +1165,4 @@ You can also request to compute the info directly by requesting the \"cider/get-
 
 (def cider-nrepl-handler
   "CIDER's nREPL handler."
-  (apply nrepl-server/default-handler (map resolve-or-fail mw/cider-middleware)))
+  (apply nrepl-server/default-handler (mapv resolve-or-fail mw/cider-middleware)))

--- a/src/cider/nrepl/middleware/util/cljs.clj
+++ b/src/cider/nrepl/middleware/util/cljs.clj
@@ -1,50 +1,36 @@
 (ns cider.nrepl.middleware.util.cljs)
 
-;; there's a plan to rename the main namespace of
-;; piggieback to piggieback.core and the following code
-;; simply paves the way for this
-(def cider-piggieback?
-  (try (require 'cider.piggieback) true
-       (catch Throwable _ false)))
-
-(def nrepl-piggieback?
-  (try (require 'piggieback.core) true
-       (catch Throwable _ false)))
-
-(defn try-piggieback
-  "If piggieback is loaded, returns `#'cider.piggieback/wrap-cljs-repl`, or
-  false otherwise."
+(defn try-resolve-piggieback
+  "If piggieback is loaded, return `#'cider.piggieback/wrap-cljs-repl`, nil
+  otherwise."
   []
-  (cond
-    cider-piggieback? (resolve 'cider.piggieback/wrap-cljs-repl)
-    nrepl-piggieback? (resolve 'piggieback.core/wrap-cljs-repl)
-    :else false))
-
-(defn- maybe-piggieback
-  [descriptor descriptor-key]
-  (if-let [piggieback (try-piggieback)]
-    (update-in descriptor [descriptor-key] #(set (conj % piggieback)))
-    descriptor))
+  (try (requiring-resolve 'cider.piggieback/wrap-cljs-repl)
+       (catch Exception _)))
 
 (defn expects-piggieback
-  "If piggieback is loaded, returns the descriptor with piggieback's
-  `wrap-cljs-repl` handler assoc'd into its `:expects` set."
+  "Deprecated: returns the descriptor unchanged."
+  {:deprecated "0.59.0"}
   [descriptor]
-  (maybe-piggieback descriptor :expects))
+  descriptor)
 
 (defn requires-piggieback
-  "If piggieback is loaded, returns the descriptor with piggieback's
-  `wrap-cljs-repl` handler assoc'd into its `:requires` set."
+  "Deprecated: returns the descriptor unchanged."
+  {:deprecated "0.59.0"}
   [descriptor]
-  (maybe-piggieback descriptor :requires))
+  descriptor)
+
+(defn maybe-add-piggieback
+  "If piggieback is loaded, conj piggieback mw var to the provided collection."
+  [coll]
+  (if-some [pb (try-resolve-piggieback)]
+    (conj coll pb)
+    coll))
 
 (defn- cljs-env-path
   "Returns the path in the session map for the ClojureScript compiler
   environment used by piggieback."
   []
-  [(if nrepl-piggieback?
-     (resolve 'piggieback.core/*cljs-compiler-env*)
-     (resolve 'cider.piggieback/*cljs-compiler-env*))])
+  [(resolve 'cider.piggieback/*cljs-compiler-env*)])
 
 (defn- maybe-deref
   [x]


### PR DESCRIPTION
This PR achieves several things:

### 1

Deprecate `requires-piggieback` and `expects-piggieback`. Instead, apply a much more pinpointed function `maybe-add-piggieback` directly to require/expect sets.

### 2 

Since nREPL 1.6 now complains that the require/middleware sets refer to middleware not being explicitly included (but still begrudgingly includes it), it is now the job for cider-nrepl to add Piggieback to the middleware list if it is present on the classpath. Is it really the resposibility of cider-nrepl? No. But I think too many setups have this in their deps.edn:

    --middleware "[cider.nrepl/cider-middleware]"

and not

    --middleware "[cider.nrepl/cider-middleware, cider.piggieback/wrap-cljs-repl]"

So, in order for their setups to continue to "just work" without warnings, somebody has to be putting Piggieback onto the mw list.

### 3

Remove mentions and support for `piggieback.core` namespace that never came up to be, and will unlikely ever.

---

- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] Middleware documentation is up to date