### PR TITLE
Stop using tools.reader functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#959](https://github.com/clojure-emacs/cider-nrepl/pull/959): Stop shading Compliment and clj-reload.
 * [#710](https://github.com/clojure-emacs/cider-nrepl/issues/710): Make namespaced ops (e.g., `cider/complete`) the default and keep the old names as deprecated aliases.
 * [#965](https://github.com/clojure-emacs/cider-nrepl/issues/965): Stop losing quotes in matcher-combinators test output.
+* [#972](https://github.com/clojure-emacs/cider-nrepl/issues/972): Stop relying on tools.reader functions in our code.
 
 ## 0.58.0 (2025-10-16)
 

--- a/project.clj
+++ b/project.clj
@@ -33,6 +33,8 @@
              ^:inline-dep [org.clojure/tools.namespace "1.5.1" :exclusions [org.clojure/clojure
                                                                             org.clojure/clojurescript
                                                                             org.clojure/tools.cli]]
+             ;; Not used directly but brought by both cljfmt and
+             ;; tools.namespace, so it is necessary to have it here.
              ^:inline-dep [org.clojure/tools.reader "1.6.0" :exclusions [org.clojure/clojure]]]
      ;; This is the only working way to include nREPL into published jar and
      ;; still be able to test different nREPL versions.

--- a/src/cider/nrepl/middleware/format.clj
+++ b/src/cider/nrepl/middleware/format.clj
@@ -5,12 +5,11 @@
    [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
    [cljfmt.core :as fmt]
    [clojure.string :as str]
-   [clojure.tools.reader.edn :as edn]
-   [clojure.tools.reader.reader-types :as readers]
+   [clojure.edn :as edn]
    [clojure.walk :as walk]
    [nrepl.middleware.print :as print])
   (:import
-   (java.io StringWriter)))
+   (java.io PushbackReader StringReader StringWriter)))
 
 ;;; Code formatting
 (defn- keyword->symbol [kw]
@@ -37,7 +36,7 @@
 (defn- read-edn
   "Returns a vector of EDN forms, read from the string s."
   [s]
-  (let [reader (readers/string-push-back-reader s)
+  (let [reader (PushbackReader. (StringReader. s))
         sentinel (Object.)]
     (loop [forms []]
       (let [form (edn/read {:eof sentinel

--- a/src/cider/nrepl/middleware/macroexpand.clj
+++ b/src/cider/nrepl/middleware/macroexpand.clj
@@ -9,7 +9,6 @@
    [orchard.cljs.analysis :as cljs-ana]
    [nrepl.transport :as transport]
    [clojure.pprint :as pp]
-   [clojure.tools.reader :as reader]
    [clojure.walk :as walk]
    [orchard.misc :as misc])
   (:import
@@ -247,7 +246,7 @@
   and :display-namespaces options."
   [{:keys [code ns] :as msg}]
   (let [expander-fn (resolve-expander-cljs msg)
-        code (reader/read-string code)]
+        code (read-string code)]
     (walk/prewalk (post-expansion-walker-cljs msg)
                   (cljs/with-cljs-env msg
                     (cljs/with-cljs-ns ns

--- a/test/clj/cider/nrepl/middleware/format_test.clj
+++ b/test/clj/cider/nrepl/middleware/format_test.clj
@@ -123,7 +123,7 @@
 
   (testing "format-edn returns an error if the given EDN is malformed"
     (is+ {:status #{"cider/format-edn-error" "done"}
-          :err #"^clojure.lang.ExceptionInfo: Unmatched delimiter"
+          :err #"^java.lang.RuntimeException: Unmatched delimiter"
           :pp-stacktrace some?}
          (session/message {:op "cider/format-edn"
                            :edn unmatched-delimiter-edn-sample})))


### PR DESCRIPTION
It looks to me like we don't use `tools.reader` enough to justify keeping it as a dependency. Regular Clojure's `read` and `clojure.edn` should be sufficient.

---

- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
