### PR TITLE
Fix NPE in slurp for directory URLs on JDK 8

### DIFF
--- a/src/cider/nrepl/middleware/slurp.clj
+++ b/src/cider/nrepl/middleware/slurp.clj
@@ -85,9 +85,13 @@
                            (catch MalformedURLException _e nil))]
     (if (= (.getProtocol url) "file") ;; expected common case
       (let [^Path p (Paths/get (.toURI url))
-            content-type (normalize-content-type (get-file-content-type p))
-            buff (when-not (.isDirectory (io/as-file url)) (Files/readAllBytes p))]
-        (slurp-reply p content-type buff))
+            dir? (.isDirectory (io/as-file url))]
+        (if dir?
+          {:content-type (normalize-content-type "application/octet-stream")
+           :body (str "#binary[location=" p ",size=0]")}
+          (let [content-type (normalize-content-type (get-file-content-type p))
+                buff (Files/readAllBytes p)]
+            (slurp-reply p content-type buff))))
 
       ;; It's not a file, so just try to open it on up
       (let [^URLConnection conn (.openConnection url)


### PR DESCRIPTION
On JDK 8, `Files/probeContentType` can return a non-null content type for directories (e.g. `inode/directory`), which causes `slurp-reply` to hit the `:else` branch and attempt to base64-encode a nil buffer.

The fix handles directories explicitly before calling `slurp-reply`, returning the binary placeholder response directly.

Found while investigating CI failures in benedekfazekas/mranderson#94.