### PR TITLE
Add the cider/classify-symbols op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 * [#979](https://github.com/clojure-emacs/cider-nrepl/pull/979): Bump `orchard` to 0.42.0 and adapt to its removal of the inspector analytics hint (the `:display-analytics-hint` inspect option is gone; use the `cider/inspect-display-analytics` op to show analytics on demand).
+* [#978](https://github.com/clojure-emacs/cider-nrepl/pull/978): Add the `cider/classify-symbols` op, classifying the given symbols as macros, inline-expandable functions, special forms or plain functions, for both Clojure and ClojureScript.
 
 ## 0.59.0 (2026-04-14)
 

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -393,7 +393,13 @@ If specified, the value will be concatenated to that of `orchard.meta/var-meta-a
              {:doc "Deprecated: use `cider/eldoc-datomic-query` instead. Return a map containing the inputs of the datomic query."
               :requires {"sym" "The symbol to lookup"
                          "ns" "The current namespace"}
-              :returns {"status" "done"}}}})
+              :returns {"status" "done"}}
+             "cider/classify-symbols"
+             {:doc "Classify the given symbols by what kind of operator each is in the given namespace."
+              :requires {"symbols" "A list of symbol strings to classify."}
+              :optional {"ns" "The namespace in which to resolve the symbols. Defaults to 'user."}
+              :returns {"status" "done"
+                        "classification" "A map from each symbol to its kind (\"macro\", \"inline\", \"special\" or \"function\"). Symbols that don't resolve are omitted."}}}})
 
 (def inspector-returns
   {"status" "\"done\""

--- a/src/cider/nrepl/middleware/info.clj
+++ b/src/cider/nrepl/middleware/info.clj
@@ -6,6 +6,7 @@
    [cider.nrepl.middleware.util.cljs :as cljs]
    [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
    [clojure.string :as str]
+   [orchard.cljs.analysis :as cljs-ana]
    [orchard.eldoc :as eldoc]
    [orchard.info :as info]
    [orchard.java.source-files :as src-files]
@@ -166,6 +167,59 @@
     (eldoc/datomic-query ns (or sym symbol))
     (catch Throwable _ {:status :no-eldoc})))
 
+(defn- classify-symbols-clj
+  "Return a map from each symbol string in `symbols` to its classification in
+  `ns` (see `orchard.meta/classify-symbol`), omitting symbols that don't
+  resolve."
+  [ns symbols]
+  (let [ns (or (misc/as-sym ns) 'user)]
+    (reduce (fn [acc s]
+              (if-let [kind (meta/classify-symbol ns (symbol s))]
+                (assoc acc s (name kind))
+                acc))
+            {}
+            symbols)))
+
+(defn- classify-symbol-cljs
+  "Classify the symbol `sym` resolved in the ClojureScript namespace `ns`.
+  Uses read-only `orchard.cljs.analysis` lookups (rather than the heavier
+  `orchard.info/info*`, which mutates the shared compiler env).  ClojureScript
+  has no inline functions, so a resolved var that isn't a macro is a function.
+  Namespace-qualified macros aren't recognized yet."
+  [env ns sym]
+  (cond
+    (or (get (cljs-ana/core-macros env ns) sym)
+        (get (cljs-ana/referred-macros env ns) sym)) "macro"
+    (or (cljs-ana/ns-resolve env ns sym)
+        (get (cljs-ana/core-vars env ns) sym)) "function"
+    (cljs-ana/special-meta env sym) "special"))
+
+(defn- classify-symbols-cljs
+  "Return a map from each macroexpandable symbol string in `symbols` to its
+  classification in the ClojureScript namespace `ns`, omitting symbols that
+  don't resolve."
+  [env ns symbols]
+  (let [ns (or (misc/as-sym ns) 'cljs.user)]
+    (reduce (fn [acc s]
+              (if-let [kind (try (classify-symbol-cljs env ns (symbol s))
+                                 (catch Exception _ nil))]
+                (assoc acc s kind)
+                acc))
+            {}
+            symbols)))
+
+(defn classify-symbols
+  "Classify each symbol string in `:symbols`, resolved in `:ns`.
+  Returns a map from symbol string to its kind (\"macro\", \"inline\",
+  \"special\" or \"function\"); symbols that don't resolve are omitted."
+  [{:keys [symbols] :as msg}]
+  (if-let [env (cljs/grab-cljs-env msg)]
+    (classify-symbols-cljs env (:ns msg) symbols)
+    (classify-symbols-clj (:ns msg) symbols)))
+
+(defn classify-symbols-reply [msg]
+  {:classification (classify-symbols msg)})
+
 (defn handle-info [handler msg]
   (with-safe-transport handler msg
     "cider/info" info-reply
@@ -173,4 +227,5 @@
     "cider/eldoc" eldoc-reply
     "eldoc" eldoc-reply
     "cider/eldoc-datomic-query" eldoc-datomic-query-reply
-    "eldoc-datomic-query" eldoc-datomic-query-reply))
+    "eldoc-datomic-query" eldoc-datomic-query-reply
+    "cider/classify-symbols" classify-symbols-reply))

--- a/test/clj/cider/nrepl/middleware/classify_symbols_test.clj
+++ b/test/clj/cider/nrepl/middleware/classify_symbols_test.clj
@@ -1,0 +1,38 @@
+(ns cider.nrepl.middleware.classify-symbols-test
+  (:require
+   [cider.nrepl.test-session :as session]
+   [clojure.test :refer :all]))
+
+(use-fixtures :once session/session-fixture)
+
+(deftest classify-symbols-test
+  (testing "classifies macros, inline fns, special forms and plain functions"
+    (let [{:keys [classification status]}
+          (session/message {:op "cider/classify-symbols"
+                            :ns "clojure.core"
+                            :symbols ["when" "+" "if" "map" "no-such-var-here"]})]
+      (is (= #{"done"} status))
+      (is (= {:when "macro" :+ "inline" :if "special" :map "function"}
+             classification))))
+
+  (testing "resolves namespace-qualified symbols"
+    (let [{:keys [classification]}
+          (session/message {:op "cider/classify-symbols"
+                            :ns "clojure.core"
+                            :symbols ["clojure.core/when" "clojure.string/upper-case"]})]
+      (is (= {(keyword "clojure.core/when") "macro"
+              (keyword "clojure.string/upper-case") "function"}
+             classification))))
+
+  (testing "defaults the namespace to user when none is given"
+    (let [{:keys [classification]}
+          (session/message {:op "cider/classify-symbols"
+                            :symbols ["when"]})]
+      (is (= {:when "macro"} classification))))
+
+  (testing "omits symbols that don't resolve"
+    (let [{:keys [classification]}
+          (session/message {:op "cider/classify-symbols"
+                            :ns "clojure.core"
+                            :symbols ["no-such-var-here"]})]
+      (is (empty? classification)))))

--- a/test/cljs/cider/nrepl/middleware/cljs_info_test.clj
+++ b/test/cljs/cider/nrepl/middleware/cljs_info_test.clj
@@ -2,7 +2,8 @@
   (:require
    [cider.nrepl.piggieback-test :refer [piggieback-fixture]]
    [cider.nrepl.test-session :as session]
-   [clojure.test :refer :all]))
+   [clojure.test :refer :all]
+   [nrepl.core :as nrepl]))
 
 (use-fixtures :once piggieback-fixture)
 
@@ -30,3 +31,22 @@
                                    :sym "println"})]
     (is (= [["&" "objs"]] (:eldoc response)))
     (is (= #{"done"} (:status response)))))
+
+(deftest cljs-classify-symbols-test
+  (testing "classifies macros, special forms and functions in a cljs ns"
+    (let [{:keys [classification status]}
+          (session/message {:op "cider/classify-symbols"
+                            :ns "cljs.core"
+                            :symbols ["when" "defn" "if" "map" "no-such-var-here"]})]
+      (is (= #{"done"} status))
+      ;; `when'/`defn' are cljs.core macros, `if' is a special form, `map' is a
+      ;; function; the unresolved symbol is omitted.
+      (is (= {:when "macro" :defn "macro" :if "special" :map "function"}
+             classification))))
+
+  (testing "classifying leaves the cljs session intact (still resolves as cljs)"
+    (let [response (session/message {:op "eval"
+                                     :code (nrepl/code (map even? (range 3)))})]
+      (is (= "cljs.user" (:ns response)))
+      (is (= ["(true false true)"] (:value response)))
+      (is (= #{"done"} (:status response))))))


### PR DESCRIPTION
Adds `cider/classify-symbols` to the info middleware. Given a batch of symbols and a namespace, it classifies each as a `macro`, `inline` (inline-expandable function), `special` (special form) or `function`, in a single round-trip. Symbols that don't resolve are omitted.

```
req: {:ns "clojure.core" :symbols ["when" "+" "if" "map"]}
res: {:classification {"when" "macro", "+" "inline", "if" "special", "map" "function"}}
```

The motivating use is letting a client highlight and navigate the macroexpandable sub-forms of a form without calling `info` once per head. It's backed by `orchard.meta/classify-symbol` (clojure-emacs/orchard#399).

Depends on orchard 0.42.0, currently referenced as `0.42.0-SNAPSHOT`; that'll become the release once orchard cuts it. ClojureScript support is a follow-up - a CLJS session classifies nothing for now, so a client degrades to no highlighting rather than wrong highlighting.