### PR TITLE
Bump orchard to 0.42.0 and drop the inspector analytics hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#979](https://github.com/clojure-emacs/cider-nrepl/pull/979): Bump `orchard` to 0.42.0 and adapt to its removal of the inspector analytics hint (the `:display-analytics-hint` inspect option is gone; use the `cider/inspect-display-analytics` op to show analytics on demand).
+
 ## 0.59.0 (2026-04-14)
 
 * Bump `nrepl` to [1.7.0](https://github.com/nrepl/nrepl/blob/master/CHANGELOG.md#170-2026-04-14).

--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/clojure-emacs/cider-nrepl"}
   :dependencies
-  ~(cond-> '[[cider/orchard "0.41.0" :exclusions [org.clojure/clojure]]
+  ~(cond-> '[[cider/orchard "0.42.0" :exclusions [org.clojure/clojure]]
              [compliment "0.7.1"]
              [io.github.tonsky/clj-reload "1.0.0" :exclusions [org.clojure/clojure]]
              [mx.cider/logjam "0.3.0" :exclusions [org.clojure/clojure]]

--- a/src/cider/nrepl/middleware/inspect.clj
+++ b/src/cider/nrepl/middleware/inspect.clj
@@ -42,7 +42,7 @@
   (as-> msg config
     (select-keys config [:page-size :sort-maps :max-atom-length :max-coll-size
                          :max-value-length :max-nested-depth :pretty-print
-                         :display-analytics-hint :only-diff])
+                         :only-diff])
     (booleanize config [:pretty-print :sort-maps :only-diff])
     (let [pov-ns (when (= (:tidy-qualified-keywords msg) "true")
                    (some-> msg :ns symbol))]

--- a/test/clj/cider/nrepl/middleware/inspect_test.clj
+++ b/test/clj/cider/nrepl/middleware/inspect_test.clj
@@ -458,15 +458,7 @@
     (is+ (mc/prefix ["--- Analytics:" [:newline]
                      "  " [:value ":count" pos?] " = " [:value "100" pos?] [:newline]
                      "  " [:value ":types" pos?] " = " [:value "{java.lang.Long 100}" pos?] [:newline]])
-         (value-skip-header (session/message {:op "cider/inspect-display-analytics"}))))
-
-  (testing "analytics hint is displayed when requested"
-    (session/message {:op "cider/inspect-clear"})
-    (is+ (mc/prefix ["--- Analytics:" [:newline] #"Press 'y' or M-x"])
-         (value-skip-header (session/message {:op      "eval"
-                                              :inspect "true"
-                                              :code    "(range 100)"
-                                              :display-analytics-hint "true"})))))
+         (value-skip-header (session/message {:op "cider/inspect-display-analytics"})))))
 
 (deftest table-view-mode-integration-test
   (testing "table view-mode is supported for lists of maps"


### PR DESCRIPTION
orchard removed the inspector hints upstream (including the analytics hint and its `:display-analytics-hint` option). This bumps orchard and adapts to that: the option is dropped from the inspector config passthrough, and the obsolete "analytics hint" test goes away. Analytics are still available on demand through the `cider/inspect-display-analytics` op.

This lands ahead of the `cider/classify-symbols` work (#978) so that PR can rebase on a clean, green master rather than carry the orchard bump itself.

Tracks orchard 0.42.0 via `0.42.0-SNAPSHOT` until the release is cut, at which point the dep flips to the release.