### PR TITLE
Add list-traced and untrace-all trace ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* [#981](https://github.com/clojure-emacs/cider-nrepl/pull/981): Add the `cider/list-traced` op (listing the currently traced vars and namespaces) and the `cider/untrace-all` op (untracing everything at once).
 * [#979](https://github.com/clojure-emacs/cider-nrepl/pull/979): Bump `orchard` to 0.42.0 and adapt to its removal of the inspector analytics hint (the `:display-analytics-hint` inspect option is gone; use the `cider/inspect-display-analytics` op to show analytics on demand).
 * [#978](https://github.com/clojure-emacs/cider-nrepl/pull/978): Add the `cider/classify-symbols` op, classifying the given symbols as macros, inline-expandable functions, special forms or plain functions, for both Clojure and ClojureScript.
 

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -1406,6 +1406,24 @@ Returns::
 
 
 
+=== `cider/classify-symbols`
+
+Classify the given symbols by what kind of operator each is in the given namespace.
+
+Required parameters::
+* `:symbols` A list of symbol strings to classify.
+
+
+Optional parameters::
+* `:ns` The namespace in which to resolve the symbols. Defaults to 'user.
+
+
+Returns::
+* `:classification` A map from each symbol to its kind ("macro", "inline", "special" or "function"). Symbols that don't resolve are omitted.
+* `:status` done
+
+
+
 === `cider/classpath`
 
 Obtain a list of entries in the Java classpath.
@@ -2149,6 +2167,22 @@ Returns::
 * `:path` Printed representation of current inspector path.
 * `:status` "done"
 * `:value` The inspector result. Contains a specially-formatted string that can be ``read`` and then rendered client-side.
+
+
+
+=== `cider/list-traced`
+
+List the vars and namespaces that are currently traced.
+
+Required parameters::
+{blank}
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:traced-nses` A list of the names of the traced namespaces
+* `:traced-vars` A list of the fully-qualified names of the traced vars
 
 
 
@@ -3058,6 +3092,21 @@ Optional parameters::
 
 Returns::
 * `:status` done
+
+
+
+=== `cider/untrace-all`
+
+Untrace every currently traced var and namespace.
+
+Required parameters::
+{blank}
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:untraced-count` The number of vars that were untraced
 
 
 

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -1068,7 +1068,14 @@ stack frame of the most recent exception."
              "toggle-trace-ns"
              {:doc      "Deprecated: use `cider/toggle-trace-ns` instead. Toggle tracing of a given ns."
               :requires {"ns" "The namespace to trace"}
-              :returns  {"ns-status" "The result of tracing operation"}}}})
+              :returns  {"ns-status" "The result of tracing operation"}}
+             "cider/list-traced"
+             {:doc     "List the vars and namespaces that are currently traced."
+              :returns {"traced-vars" "A list of the fully-qualified names of the traced vars"
+                        "traced-nses" "A list of the names of the traced namespaces"}}
+             "cider/untrace-all"
+             {:doc     "Untrace every currently traced var and namespace."
+              :returns {"untraced-count" "The number of vars that were untraced"}}}})
 
 (def-wrapper wrap-tracker cider.nrepl.middleware.track-state/handle-tracker
   mw/ops-that-can-eval

--- a/src/cider/nrepl/middleware/trace.clj
+++ b/src/cider/nrepl/middleware/trace.clj
@@ -15,8 +15,6 @@
       {:var-name (str v) :var-status "not-traceable"})
     {:status #{:toggle-trace-error :done} :var-status "not-found"}))
 
-(def traced-ns (atom #{}))
-
 (defn toggle-trace-ns
   [{:keys [ns]}]
   (if-let [ns (find-ns (symbol ns))]
@@ -27,9 +25,25 @@
           {:ns-status "traced"}))
     {:ns-status "not-found"}))
 
+(defn list-traced
+  "Return the currently traced vars and namespaces, as strings."
+  [_msg]
+  {:traced-vars (mapv str @@#'trace/traced-vars)
+   :traced-nses (mapv str @@#'trace/traced-nses)})
+
+(defn untrace-all
+  "Untrace every currently traced var and namespace.
+  Returns the number of vars that were untraced."
+  [_msg]
+  (let [untraced-count (count @@#'trace/traced-vars)]
+    (trace/untrace-all)
+    {:untraced-count untraced-count}))
+
 (defn handle-trace [handler msg]
   (with-safe-transport handler msg
     "cider/toggle-trace-var" [toggle-trace-var :toggle-trace-error]
     "toggle-trace-var" [toggle-trace-var :toggle-trace-error]
     "cider/toggle-trace-ns" [toggle-trace-ns :toggle-trace-error]
-    "toggle-trace-ns" [toggle-trace-ns :toggle-trace-error]))
+    "toggle-trace-ns" [toggle-trace-ns :toggle-trace-error]
+    "cider/list-traced" [list-traced :list-traced-error]
+    "cider/untrace-all" [untrace-all :untrace-all-error]))

--- a/test/clj/cider/nrepl/middleware/trace_test.clj
+++ b/test/clj/cider/nrepl/middleware/trace_test.clj
@@ -72,6 +72,40 @@
       (is (= (:status ns-err)  #{"done"}))
       (is (= (:ns-status ns-err) "not-found")))))
 
+(deftest list-traced-test
+  (testing "lists the currently traced vars and namespaces"
+    (untrace-all {}) ; start from a clean slate
+    (is (= {:traced-vars [] :traced-nses []} (list-traced {})))
+    (toggle-trace-var {:ns "clojure.core" :sym "zipmap"})
+    (is (= ["#'clojure.core/zipmap"] (:traced-vars (list-traced {}))))
+    (untrace-all {})))
+
+(deftest untrace-all-test
+  (testing "untraces every var and namespace and reports the count"
+    (untrace-all {}) ; start from a clean slate
+    (toggle-trace-var {:ns "clojure.core" :sym "zipmap"})
+    (toggle-trace-ns {:ns "cider.test-ns.first-test-ns"})
+    (is (pos? (:untraced-count (untrace-all {}))))
+    (is (= {:traced-vars [] :traced-nses []} (list-traced {})))))
+
+(deftest integration-test-list-and-untrace-all
+  (testing "listing and clearing traces over the session"
+    (session/message {:op "cider/untrace-all"}) ; clean slate
+    (session/message {:op "cider/toggle-trace-var"
+                      :ns "cider.test-ns.first-test-ns"
+                      :sym "same-name-testing-function"})
+    (let [listed (session/message {:op "cider/list-traced"})]
+      (is (= (:status listed) #{"done"}))
+      (is (= (:traced-vars listed)
+             ["#'cider.test-ns.first-test-ns/same-name-testing-function"])))
+    (let [cleared (session/message {:op "cider/untrace-all"})]
+      (is (= (:status cleared) #{"done"}))
+      (is (= (:untraced-count cleared) 1)))
+    (let [listed (session/message {:op "cider/list-traced"})]
+      (is (= (:status listed) #{"done"}))
+      (is (empty? (:traced-vars listed)))
+      (is (empty? (:traced-nses listed))))))
+
 (deftest deprecated-ops-test
   (testing "Deprecated 'toggle-trace-var' op still works"
     (let [on  (session/message {:op "toggle-trace-var"


### PR DESCRIPTION
CIDER can toggle tracing per var or namespace, but there was no way to see what's currently traced or to clear it all at once. This adds two ops, backed by state `orchard.trace` already keeps:

- `cider/list-traced` - returns the currently traced vars and namespaces.
- `cider/untrace-all` - untraces everything and reports how many vars were cleared.

These unblock `cider-list-traced` and `cider-untrace-all` on the CIDER side. Also drops a dead `traced-ns` atom that nothing referenced, and regenerates the ops docs.
