### PR TITLE
Add trace-subscribe/unsubscribe streaming ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* [#982](https://github.com/clojure-emacs/cider-nrepl/pull/982): Add the `cider/trace-subscribe` and `cider/trace-unsubscribe` ops, streaming a structured event for every traced call and return so clients can render trace output in a dedicated buffer instead of the REPL (requires `orchard` 0.43.0).
 * [#981](https://github.com/clojure-emacs/cider-nrepl/pull/981): Add the `cider/list-traced` op (listing the currently traced vars and namespaces) and the `cider/untrace-all` op (untracing everything at once).
 * [#979](https://github.com/clojure-emacs/cider-nrepl/pull/979): Bump `orchard` to 0.42.0 and adapt to its removal of the inspector analytics hint (the `:display-analytics-hint` inspect option is gone; use the `cider/inspect-display-analytics` op to show analytics on demand).
 * [#978](https://github.com/clojure-emacs/cider-nrepl/pull/978): Add the `cider/classify-symbols` op, classifying the given symbols as macros, inline-expandable functions, special forms or plain functions, for both Clojure and ClojureScript.

--- a/doc/modules/ROOT/pages/nrepl-api/ops.adoc
+++ b/doc/modules/ROOT/pages/nrepl-api/ops.adoc
@@ -3062,6 +3062,38 @@ Returns::
 
 
 
+=== `cider/trace-subscribe`
+
+Open a streaming subscription that delivers a message for each traced call and return until ``cider/trace-unsubscribe``. While subscribed, trace output is routed to the subscriber instead of the REPL.
+
+Required parameters::
+{blank}
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:cider/trace-event` A trace event, with ``id``, ``phase`` ("call" or "return"), ``name``, ``depth``, and ``args`` (on a call) or ``value`` (on a return)
+* `:cider/trace-subscribe` The id of the subscription, to be passed to ``cider/trace-unsubscribe``
+
+
+
+=== `cider/trace-unsubscribe`
+
+Stop streaming trace events for the given subscription.
+
+Required parameters::
+* `:subscription` The id of the subscription to remove
+
+
+Optional parameters::
+{blank}
+
+Returns::
+* `:cider/trace-unsubscribe` The id of the removed subscription
+
+
+
 === `cider/undef`
 
 Undefine a symbol

--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/clojure-emacs/cider-nrepl"}
   :dependencies
-  ~(cond-> '[[cider/orchard "0.42.0" :exclusions [org.clojure/clojure]]
+  ~(cond-> '[[cider/orchard "0.43.0-alpha1" :exclusions [org.clojure/clojure]]
              [compliment "0.7.1"]
              [io.github.tonsky/clj-reload "1.0.0" :exclusions [org.clojure/clojure]]
              [mx.cider/logjam "0.3.0" :exclusions [org.clojure/clojure]]

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -1075,7 +1075,15 @@ stack frame of the most recent exception."
                         "traced-nses" "A list of the names of the traced namespaces"}}
              "cider/untrace-all"
              {:doc     "Untrace every currently traced var and namespace."
-              :returns {"untraced-count" "The number of vars that were untraced"}}}})
+              :returns {"untraced-count" "The number of vars that were untraced"}}
+             "cider/trace-subscribe"
+             {:doc     "Open a streaming subscription that delivers a message for each traced call and return until `cider/trace-unsubscribe`. While subscribed, trace output is routed to the subscriber instead of the REPL."
+              :returns {"cider/trace-subscribe" "The id of the subscription, to be passed to `cider/trace-unsubscribe`"
+                        "cider/trace-event" "A trace event, with `id`, `phase` (\"call\" or \"return\"), `name`, `depth`, and `args` (on a call) or `value` (on a return)"}}
+             "cider/trace-unsubscribe"
+             {:doc      "Stop streaming trace events for the given subscription."
+              :requires {"subscription" "The id of the subscription to remove"}
+              :returns  {"cider/trace-unsubscribe" "The id of the removed subscription"}}}})
 
 (def-wrapper wrap-tracker cider.nrepl.middleware.track-state/handle-tracker
   mw/ops-that-can-eval

--- a/src/cider/nrepl/middleware/trace.clj
+++ b/src/cider/nrepl/middleware/trace.clj
@@ -1,7 +1,10 @@
 (ns cider.nrepl.middleware.trace
   (:require
+   [cider.nrepl.middleware.util :refer [respond-to]]
    [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
-   [orchard.trace :as trace]))
+   [orchard.trace :as trace])
+  (:import
+   [java.util UUID]))
 
 (defn toggle-trace-var
   [{:keys [ns sym]}]
@@ -39,6 +42,41 @@
     (trace/untrace-all)
     {:untraced-count untraced-count}))
 
+(def ^:private subscriptions
+  "Map of subscription id -> the orchard trace listener registered for it."
+  (atom {}))
+
+(defn- serialize-event
+  "Make a trace EVENT bencode-friendly for transport."
+  [event]
+  (update event :phase name))
+
+(defn trace-subscribe
+  "Stream trace events to the client until `cider/trace-unsubscribe`.
+  Registers an orchard trace listener that forwards each event on this
+  request, and routes trace output to listeners instead of the REPL."
+  [msg]
+  (let [id (str (UUID/randomUUID))
+        listener (fn [event]
+                   (respond-to msg
+                               :cider/trace-event (serialize-event event)
+                               :status :cider/trace-event))]
+    (swap! subscriptions assoc id listener)
+    (trace/add-trace-listener listener)
+    (trace/set-output-mode! :listeners)
+    {:cider/trace-subscribe id}))
+
+(defn trace-unsubscribe
+  "Stop streaming trace events for the given subscription.
+  Restores REPL trace output once the last subscription is gone."
+  [{:keys [subscription]}]
+  (when-let [listener (get @subscriptions subscription)]
+    (trace/remove-trace-listener listener)
+    (swap! subscriptions dissoc subscription))
+  (when (empty? @subscriptions)
+    (trace/set-output-mode! :repl))
+  {:cider/trace-unsubscribe subscription})
+
 (defn handle-trace [handler msg]
   (with-safe-transport handler msg
     "cider/toggle-trace-var" [toggle-trace-var :toggle-trace-error]
@@ -46,4 +84,6 @@
     "cider/toggle-trace-ns" [toggle-trace-ns :toggle-trace-error]
     "toggle-trace-ns" [toggle-trace-ns :toggle-trace-error]
     "cider/list-traced" [list-traced :list-traced-error]
-    "cider/untrace-all" [untrace-all :untrace-all-error]))
+    "cider/untrace-all" [untrace-all :untrace-all-error]
+    "cider/trace-subscribe" [trace-subscribe :trace-subscribe-error]
+    "cider/trace-unsubscribe" [trace-unsubscribe :trace-unsubscribe-error]))

--- a/test/clj/cider/nrepl/middleware/trace_test.clj
+++ b/test/clj/cider/nrepl/middleware/trace_test.clj
@@ -3,9 +3,15 @@
    [cider.nrepl.middleware.trace :refer :all]
    [cider.nrepl.test-session :as session]
    [clojure.test :refer :all]
+   [nrepl.transport :as transport]
    [cider.test-ns.first-test-ns]))
 
 (use-fixtures :each session/session-fixture)
+
+(defn traced-sample
+  "A sample fn to trace; nothing else calls it, so its events are predictable."
+  [x]
+  (inc x))
 
 (deftest toggle-trace-var-test
   (testing "toggling"
@@ -105,6 +111,34 @@
       (is (= (:status listed) #{"done"}))
       (is (empty? (:traced-vars listed)))
       (is (empty? (:traced-nses listed))))))
+
+(deftest trace-subscribe-test
+  (testing "subscribe streams events for traced calls, unsubscribe stops them"
+    (let [sent      (atom [])
+          transport (reify transport/Transport
+                      (send [this msg] (swap! sent conj msg) this)
+                      (recv [_this] nil)
+                      (recv [_this _timeout] nil))
+          {id :cider/trace-subscribe} (trace-subscribe {:transport transport
+                                                        :id "42" :session "s"})]
+      (try
+        (is (string? id))
+        (toggle-trace-var {:ns "cider.nrepl.middleware.trace-test" :sym "traced-sample"})
+        (traced-sample 1)
+        (let [events (keep :cider/trace-event @sent)]
+          (is (= 2 (count events)) "one call event and one return event")
+          (is (= ["call" "return"] (map :phase events)))
+          (is (every? #(= "cider.nrepl.middleware.trace-test/traced-sample" (:name %)) events))
+          (is (= (:id (first events)) (:id (second events))) "call and return share an id"))
+        (finally
+          (toggle-trace-var {:ns "cider.nrepl.middleware.trace-test" :sym "traced-sample"})
+          (trace-unsubscribe {:subscription id})))
+      ;; after unsubscribe the listener is gone, so a further traced call streams nothing
+      (reset! sent [])
+      (toggle-trace-var {:ns "cider.nrepl.middleware.trace-test" :sym "traced-sample"})
+      (with-out-str (traced-sample 1)) ; output mode is back to :repl, swallow its print
+      (is (empty? (keep :cider/trace-event @sent)))
+      (toggle-trace-var {:ns "cider.nrepl.middleware.trace-test" :sym "traced-sample"}))))
 
 (deftest deprecated-ops-test
   (testing "Deprecated 'toggle-trace-var' op still works"


### PR DESCRIPTION
Step 2 of giving CIDER a dedicated trace buffer (Tier 2 of the enlighten/tracing audit).

Trace output only ever went to `*out*` (the REPL). This adds a streaming subscription, mirroring the log middleware's consumer pattern:

- `cider/trace-subscribe` - a held-open request that registers an `orchard.trace` listener forwarding a structured event (`id`, `phase`, `name`, `depth`, `args`/`value`) for each call and return, and routes trace output to listeners instead of the REPL.
- `cider/trace-unsubscribe` - removes the listener and restores REPL output once the last subscriber is gone.

This lets a client (CIDER, next) render trace output in a navigable buffer.

Depends on the new `orchard.trace` listener API (clojure-emacs/orchard#400). Pinned to `0.43.0-alpha1` for now; should be bumped to `0.43.0` once that's released, before cider-nrepl's next release.
