### PR TITLE
Place enlighten overlays by each form's own line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* [#983](https://github.com/clojure-emacs/cider-nrepl/pull/983): Fix enlighten overlay placement when one evaluation spans several top-level forms (e.g. evaluating a region): each form's values are now reported at that form's own line instead of the line where the evaluation started.
 * [#982](https://github.com/clojure-emacs/cider-nrepl/pull/982): Add the `cider/trace-subscribe` and `cider/trace-unsubscribe` ops, streaming a structured event for every traced call and return so clients can render trace output in a dedicated buffer instead of the REPL (requires `orchard` 0.43.0).
 * [#981](https://github.com/clojure-emacs/cider-nrepl/pull/981): Add the `cider/list-traced` op (listing the currently traced vars and namespaces) and the `cider/untrace-all` op (untracing everything at once).
 * [#979](https://github.com/clojure-emacs/cider-nrepl/pull/979): Bump `orchard` to 0.42.0 and adapt to its removal of the inspector analytics hint (the `:display-analytics-hint` inspect option is gone; use the `cider/inspect-display-analytics` op to show analytics on demand).

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -474,7 +474,14 @@ this map (identified by a key), and will `dissoc` it afterwards."}
 #_:clj-kondo/ignore
 (def ^:dynamic ^:private *found-debugger-tag*)
 #_:clj-kondo/ignore
-(def ^:dynamic ^:private *top-level-form-meta*)
+(def ^{:dynamic true
+       :doc "Per-form metadata (line/column and `::form-info`) of the top-level
+  form being instrumented.  When bound, `with-initial-debug-bindings` uses it for
+  accurate per-form coordinates; otherwise it falls back to the whole-eval
+  `*msg*`.  Bound by the debugger's instrumenting eval and by
+  `enlighten/eval-with-enlighten`.  Must stay unbound by default - giving it a
+  root value would make `(bound? ...)` always true and break the fallback."}
+  *top-level-form-meta*)
 
 (defmacro with-initial-debug-bindings
   "Let-wrap `body` with STATE__ map containing code, file, line, column etc.

--- a/src/cider/nrepl/middleware/enlighten.clj
+++ b/src/cider/nrepl/middleware/enlighten.clj
@@ -6,7 +6,8 @@
   {:author "Artur Malabarba"}
   (:require
    [cider.nrepl.middleware.debug :as d]
-   [cider.nrepl.middleware.util.instrument :as ins]))
+   [cider.nrepl.middleware.util.instrument :as ins]
+   [nrepl.middleware.interruptible-eval :refer [*msg*]]))
 
 (defn pr-very-short [val]
   (binding [*print-length* 3, *print-level* 2]
@@ -76,12 +77,19 @@
 
 ;;; Middleware
 (defn eval-with-enlighten
-  "Like `eval`, but also enlighten code."
+  "Like `eval`, but also enlighten code.
+  Called once per top-level form.  Binds `d/*top-level-form-meta*` to the form's
+  own metadata so each overlay is placed by that form's line/column rather than
+  by the start of the whole evaluation - which matters when one evaluation spans
+  several top-level forms (e.g. evaluating a region)."
   [form]
   (let [form1 `(d/with-initial-debug-bindings
                  ~(ins/instrument-tagged-code (light-reader form)))]
-    ;; (ins/print-form form1 true)
-    (eval form1)))
+    (binding [d/*top-level-form-meta*
+              (assoc (meta form)
+                     :cider.nrepl.middleware.debug/form-info
+                     {:file (:file *msg*) :original-id (:id *msg*)})]
+      (eval form1))))
 
 (defn handle-enlighten
   [h {:keys [op enlighten] :as msg}]

--- a/test/clj/cider/nrepl/middleware/enlighten_test.clj
+++ b/test/clj/cider/nrepl/middleware/enlighten_test.clj
@@ -1,0 +1,25 @@
+(ns ^:debugger cider.nrepl.middleware.enlighten-test
+  (:require
+   [cider.nrepl.middleware.debug :as d]
+   [cider.nrepl.middleware.enlighten :as e]
+   [clojure.test :refer [deftest is]]
+   [nrepl.middleware.interruptible-eval :refer [*msg*]]
+   [nrepl.transport :as t]))
+
+(deftest eval-with-enlighten-uses-per-form-line
+  ;; The enlighten overlay must be placed by the form's own line, not by the
+  ;; line of the whole evaluation - that is what makes it work form-by-form
+  ;; through `load-file`, where every form shares the same eval-level line.
+  (let [sent (atom [])]
+    (with-redefs [d/debugger-message (atom {:transport :fake :id "ID" :session "S"})
+                  t/send (fn [_ msg] (swap! sent conj msg))]
+      (binding [*msg* {:file "x.clj" :id "ID" :line 1 :column 1}]
+        ;; the eval-level line is 1, but the form claims to live on line 42
+        (let [v (e/eval-with-enlighten
+                 (with-meta '(defn enl-sample [] (+ 1 2)) {:line 42 :column 5}))]
+          (v))) ; running it fires the enlighten return-value message
+      (let [enlighten-msg (->> @sent (filter :debug-value) first)]
+        (is (some? enlighten-msg) "an enlighten value was sent")
+        (is (= #{:enlighten} (:status enlighten-msg)))
+        (is (= 42 (:line enlighten-msg))
+            "positioned by the form's line, not the eval's")))))


### PR DESCRIPTION
A focused fix that fell out of investigating enlighten on `load-file`.

`eval-with-enlighten` built the debugger's `STATE__` from the whole eval message's `:line`. When a single evaluation spans several top-level forms (e.g. evaluating a region with `cider-eval-region`), every form's enlighten values were reported at the line where evaluation *started*, so overlays for all but the first form landed in the wrong place. Bind `*top-level-form-meta*` to the form's own metadata - the same mechanism the debugger uses for accurate per-form coordinates - so each form's values are reported at its own line.

(Groundwork toward enlighten on `C-c C-k`, which needs a deeper change to the debugger's read-fn; that's being evaluated separately.)
