### PR TITLE
Enlighten every sub-expression, not just returns and locals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* [#984](https://github.com/clojure-emacs/cider-nrepl/pull/984): Enlighten now reports the value of every sub-expression as it runs, not just a definition's return value and locals - so the whole computation lights up, much closer to the Light Table feature it was modeled on.
 * [#983](https://github.com/clojure-emacs/cider-nrepl/pull/983): Fix enlighten overlay placement when one evaluation spans several top-level forms (e.g. evaluating a region): each form's values are now reported at that form's own line instead of the line where the evaluation started.
 * [#982](https://github.com/clojure-emacs/cider-nrepl/pull/982): Add the `cider/trace-subscribe` and `cider/trace-unsubscribe` ops, streaming a structured event for every traced call and return so clients can render trace output in a dedicated buffer instead of the REPL (requires `orchard` 0.43.0).
 * [#981](https://github.com/clojure-emacs/cider-nrepl/pull/981): Add the `cider/list-traced` op (listing the currently traced vars and namespaces) and the `cider/untrace-all` op (untracing everything at once).

--- a/src/cider/nrepl/middleware/enlighten.clj
+++ b/src/cider/nrepl/middleware/enlighten.clj
@@ -30,9 +30,10 @@
   "Wrap a form representing a function/macro/special-form call.
   Return an equivalent form, instrumented to work with enlighten.
 
-  Currently this only instruments forms that could run several times
-  in a single evaluation. This is necessary so that the client can
-  clean-up overlays from previous evaluations."
+  `fn*`/`def`/`loop*` get special handling (they can run several times in a
+  single evaluation, so the client must clean up overlays from previous runs).
+  Every other sub-form simply reports its own value, so the whole computation
+  lights up - not just the definition's return value."
   [[head & args :as form] {:keys [coor]}]
   (let [erase `(d/debugger-send (assoc (:msg ~'STATE__)
                                        :coor ~coor
@@ -57,8 +58,14 @@
               form))
       ;; Ensure that any `recur`s remain in the tail position.
       loop* (list* head (first args) erase (rest args))
-      ;; Else.
-      form)))
+      ;; Every other sub-form reports its own value, like the `def` case does.
+      `(let [out# ~form]
+         (->> (assoc (:msg ~'STATE__)
+                     :coor ~coor
+                     :status :enlighten
+                     :debug-value (pr-very-short out#))
+              d/debugger-send)
+         out#))))
 
 (defmacro light-form
   "Return the result of form, and maybe enlighten it."

--- a/test/clj/cider/nrepl/middleware/enlighten_test.clj
+++ b/test/clj/cider/nrepl/middleware/enlighten_test.clj
@@ -6,20 +6,59 @@
    [nrepl.middleware.interruptible-eval :refer [*msg*]]
    [nrepl.transport :as t]))
 
-(deftest eval-with-enlighten-uses-per-form-line
-  ;; The enlighten overlay must be placed by the form's own line, not by the
-  ;; line of the whole evaluation - that is what makes it work form-by-form
-  ;; through `load-file`, where every form shares the same eval-level line.
+(defn- enlighten-run
+  "Eval FORM with enlighten, invoke the resulting var with ARGS, and return the
+  vector of messages sent over the debug channel."
+  [form & args]
   (let [sent (atom [])]
     (with-redefs [d/debugger-message (atom {:transport :fake :id "ID" :session "S"})
                   t/send (fn [_ msg] (swap! sent conj msg))]
       (binding [*msg* {:file "x.clj" :id "ID" :line 1 :column 1}]
-        ;; the eval-level line is 1, but the form claims to live on line 42
-        (let [v (e/eval-with-enlighten
-                 (with-meta '(defn enl-sample [] (+ 1 2)) {:line 42 :column 5}))]
-          (v))) ; running it fires the enlighten return-value message
-      (let [enlighten-msg (->> @sent (filter :debug-value) first)]
-        (is (some? enlighten-msg) "an enlighten value was sent")
-        (is (= #{:enlighten} (:status enlighten-msg)))
-        (is (= 42 (:line enlighten-msg))
-            "positioned by the form's line, not the eval's")))))
+        ;; default a line/column, but let the form's own metadata win
+        (let [v (e/eval-with-enlighten (vary-meta form #(merge {:line 1 :column 1} %)))]
+          (apply v args))))
+    @sent))
+
+(defn- enlighten-values
+  "The set of reported values (as strings) for FORM run with ARGS."
+  [form & args]
+  (->> (apply enlighten-run form args) (keep :debug-value) set))
+
+(defn- survives?
+  "Whether FORM can be enlightened and run with ARGS without throwing."
+  [form & args]
+  (try (apply enlighten-run form args) :ok
+       (catch Throwable e (str (.getMessage e)))))
+
+(deftest eval-with-enlighten-uses-per-form-line
+  ;; Overlays are placed by the form's own line, not the eval's start line, so
+  ;; enlighten works when one evaluation spans several top-level forms.
+  (let [msg (->> (enlighten-run (with-meta '(defn enl-sample [] (+ 1 2))
+                                  {:line 42 :column 5}))
+                 (filter :debug-value) first)]
+    (is (some? msg) "an enlighten value was sent")
+    (is (= #{:enlighten} (:status msg)))
+    (is (= 42 (:line msg)) "positioned by the form's line, not the eval's")))
+
+(deftest reports-every-subexpression-value
+  ;; The whole computation lights up, not just the return value and locals.
+  (let [values (enlighten-values '(defn f [x] (+ (* x 2) 1)) 3)]
+    (is (contains? values "3") "the local x")
+    (is (contains? values "6") "(* x 2)")
+    (is (contains? values "7") "(+ (* x 2) 1) and the return")))
+
+(deftest reports-conditionals-and-bindings
+  (is (contains? (enlighten-values '(defn f [x] (if (pos? x) :pos :neg)) 5) ":pos"))
+  (is (contains? (enlighten-values '(defn f [x] (let [y (* x 3)] (inc y))) 2) "7")))
+
+(deftest survives-tricky-forms
+  ;; Forms in tail/binding/special positions must not be broken by wrapping.
+  (is (= :ok (survives? '(defn f [n] (loop [i 0 acc 0]
+                                       (if (< i n) (recur (inc i) (+ acc i)) acc))) 4))
+      "loop/recur stays in tail position")
+  (is (= :ok (survives? '(defn f [x] (-> x inc (* 2))) 3))
+      "threading macro")
+  (is (= :ok (survives? '(defn f [] (try (/ 1 0) (catch ArithmeticException _ :caught)))))
+      "try/catch")
+  (is (= :ok (survives? '(defn f [xs] (map inc xs)) [1 2 3]))
+      "lazy seq / higher-order"))


### PR DESCRIPTION
Enlighten was modeled on Light Table's "watch every value" feature, but it only ever reported a definition's return value and the values of local symbols - `wrap-function-form` left every other sub-form untouched.

The instrumenter already walks and captures every interesting sub-form's value (that's how the debugger steps through code), so surfacing it is a small change: every other sub-form now emits its own value at its own coordinate. Evaluate a function with enlighten on and the *whole computation* lights up - `(* x 2)`, `(+ … 1)`, the lot - not just the endpoints.

The `fn*`/`def`/`loop*` special cases stay (they handle multiple runs and keep `recur` in tail position). The instrumenter's existing tail-awareness means `recur`, threading macros, `try`/`catch` and lazy seqs all keep working - covered by new tests, and the full debugger suite still passes.

No client change needed: CIDER already places enlighten overlays at sub-form coordinates (same as debugger breakpoints).

Natural follow-ups (separate): a verbosity toggle, multiple-iteration display for loops, and timing.
