### PR TITLE
Add the cider/who-implements op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* [#985](https://github.com/clojure-emacs/cider-nrepl/pull/985): Add the `cider/who-implements` op, returning the implementations of a protocol (both `extend`-style and inline `defrecord`/`deftype`, with source locations) or the dispatch values of a multimethod (requires `orchard` 0.43.0-alpha2).
 * [#984](https://github.com/clojure-emacs/cider-nrepl/pull/984): Enlighten now reports the value of every sub-expression as it runs, not just a definition's return value and locals - so the whole computation lights up, much closer to the Light Table feature it was modeled on.
 * [#983](https://github.com/clojure-emacs/cider-nrepl/pull/983): Fix enlighten overlay placement when one evaluation spans several top-level forms (e.g. evaluating a region): each form's values are now reported at that form's own line instead of the line where the evaluation started.
 * [#982](https://github.com/clojure-emacs/cider-nrepl/pull/982): Add the `cider/trace-subscribe` and `cider/trace-unsubscribe` ops, streaming a structured event for every traced call and return so clients can render trace output in a dedicated buffer instead of the REPL (requires `orchard` 0.43.0).

--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/clojure-emacs/cider-nrepl"}
   :dependencies
-  ~(cond-> '[[cider/orchard "0.43.0-alpha1" :exclusions [org.clojure/clojure]]
+  ~(cond-> '[[cider/orchard "0.43.0-alpha2" :exclusions [org.clojure/clojure]]
              [compliment "0.7.1"]
              [io.github.tonsky/clj-reload "1.0.0" :exclusions [org.clojure/clojure]]
              [mx.cider/logjam "0.3.0" :exclusions [org.clojure/clojure]]

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -1148,6 +1148,12 @@ You can also request to compute the info directly by requesting the \"cider/get-
               :requires {"sym" "The symbol to lookup"
                          "ns" "The current namespace"}
               :returns {"fn-deps" "A list of function deps, with a `:name :doc :file :file-url :line :column` structure."
+                        "status" "done"}}
+             "cider/who-implements"
+             {:doc "Look up the implementations of a protocol or the dispatch values of a multimethod."
+              :requires {"sym" "The symbol to lookup"
+                         "ns" "The current namespace"}
+              :returns {"who-implements" "A map with `:kind` (\"protocol\", \"multimethod\" or \"other\"); for a protocol an `:impls` list of `:name :file :file-url :line :column` maps, for a multimethod a `:dispatch-values` list."
                         "status" "done"}}}})
 
 (def-wrapper wrap-clojuredocs cider.nrepl.middleware.clojuredocs/handle-clojuredocs

--- a/src/cider/nrepl/middleware/xref.clj
+++ b/src/cider/nrepl/middleware/xref.clj
@@ -41,9 +41,33 @@
                    (map xref-data)
                    (sort-by file-line-column))}))
 
+(defn- impl-data [{:keys [name file line column]}]
+  {:name name
+   :file file
+   :file-url (some-> file filename-as-url)
+   :line line
+   :column column})
+
+(defn who-implements-reply [{:keys [ns sym]}]
+  (let [v (ns-resolve (misc/as-sym ns) (misc/as-sym sym))
+        x (when v (deref v))]
+    {:who-implements
+     (cond
+       (instance? clojure.lang.MultiFn x)
+       {:kind "multimethod"
+        :dispatch-values (xref/multimethod-dispatch-values v)}
+
+       (and (map? x) (:on-interface x))
+       {:kind "protocol"
+        :impls (mapv impl-data (xref/protocol-impls v))}
+
+       :else
+       {:kind "other"})}))
+
 (defn handle-xref [handler msg]
   (with-safe-transport handler msg
     "cider/fn-refs" fn-refs-reply
     "fn-refs" fn-refs-reply
     "cider/fn-deps" fn-deps-reply
-    "fn-deps" fn-deps-reply))
+    "fn-deps" fn-deps-reply
+    "cider/who-implements" who-implements-reply))

--- a/test/clj/cider/nrepl/middleware/xref_test.clj
+++ b/test/clj/cider/nrepl/middleware/xref_test.clj
@@ -62,3 +62,43 @@
           fn-deps (:fn-deps response)]
       (is (= (:status response) #{"done"}))
       (is (= (count fn-deps) 3)))))
+
+;;; who-implements
+
+(defprotocol TestProto
+  (test-m [_]))
+
+(defrecord TestImpl [x]
+  TestProto
+  (test-m [_] x))
+
+(deftest who-implements-protocol-test
+  (let [response (session/message {:op "cider/who-implements"
+                                   :ns "cider.nrepl.middleware.xref-test"
+                                   :sym "TestProto"})
+        result (:who-implements response)]
+    (testing (pr-str response)
+      (is (= (:status response) #{"done"}))
+      (is (= "protocol" (:kind result)))
+      (is (some #(= "cider.nrepl.middleware.xref_test.TestImpl" (:name %))
+                (:impls result))
+          "includes the inline defrecord implementer"))))
+
+(deftest who-implements-multimethod-test
+  (let [response (session/message {:op "cider/who-implements"
+                                   :ns "clojure.core"
+                                   :sym "print-method"})
+        result (:who-implements response)]
+    (testing (pr-str response)
+      (is (= (:status response) #{"done"}))
+      (is (= "multimethod" (:kind result)))
+      (is (seq (:dispatch-values result))))))
+
+(deftest who-implements-other-test
+  (let [response (session/message {:op "cider/who-implements"
+                                   :ns "clojure.core"
+                                   :sym "map"})
+        result (:who-implements response)]
+    (testing (pr-str response)
+      (is (= (:status response) #{"done"}))
+      (is (= "other" (:kind result))))))


### PR DESCRIPTION
Builds on orchard#401 to back CIDER's `cider-who-implements` with real introspection (clojure-emacs/cider#1969).

`cider/who-implements` resolves a symbol and:
- for a **protocol**, returns its implementations - both `extend`/`extend-type`/`extend-protocol` targets and inline `defrecord`/`deftype` implementers, each with `:name`/`:file`/`:file-url`/`:line`/`:column` where a source location is resolvable;
- for a **multimethod**, returns its `:dispatch-values`;
- otherwise `{:kind "other"}`.

Validated end-to-end against orchard master (installed locally): the new tests pass and the existing xref tests are unaffected (6 tests, 31 assertions).

**Draft / staged:** this needs `orchard` 0.43.0, which contains `orchard.xref/protocol-impls` and `multimethod-dispatch-values` but isn't released yet (same release the trace op in #982 is already waiting on). The `project.clj` dep is bumped to `0.43.0` in anticipation; CI will stay red until that release is cut, at which point this can come out of draft and merge. Adjust the version if the actual release differs.