### PR TITLE
Add cider/type-protocols and cider/protocols-with-method ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* [#986](https://github.com/clojure-emacs/cider-nrepl/pull/986): Add the `cider/type-protocols` op (the protocols a type implements) and the `cider/protocols-with-method` op (the protocols declaring a method of a given name), each returning `:name :file :file-url :line :column` maps (requires `orchard` 0.43.0).
 * [#985](https://github.com/clojure-emacs/cider-nrepl/pull/985): Add the `cider/who-implements` op, returning the implementations of a protocol (both `extend`-style and inline `defrecord`/`deftype`, with source locations) or the dispatch values of a multimethod (requires `orchard` 0.43.0-alpha2).
 * [#984](https://github.com/clojure-emacs/cider-nrepl/pull/984): Enlighten now reports the value of every sub-expression as it runs, not just a definition's return value and locals - so the whole computation lights up, much closer to the Light Table feature it was modeled on.
 * [#983](https://github.com/clojure-emacs/cider-nrepl/pull/983): Fix enlighten overlay placement when one evaluation spans several top-level forms (e.g. evaluating a region): each form's values are now reported at that form's own line instead of the line where the evaluation started.

--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:name "git" :url "https://github.com/clojure-emacs/cider-nrepl"}
   :dependencies
-  ~(cond-> '[[cider/orchard "0.43.0-alpha2" :exclusions [org.clojure/clojure]]
+  ~(cond-> '[[cider/orchard "0.43.0" :exclusions [org.clojure/clojure]]
              [compliment "0.7.1"]
              [io.github.tonsky/clj-reload "1.0.0" :exclusions [org.clojure/clojure]]
              [mx.cider/logjam "0.3.0" :exclusions [org.clojure/clojure]]

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -1154,6 +1154,17 @@ You can also request to compute the info directly by requesting the \"cider/get-
               :requires {"sym" "The symbol to lookup"
                          "ns" "The current namespace"}
               :returns {"who-implements" "A map with `:kind` (\"protocol\", \"multimethod\" or \"other\"); for a protocol an `:impls` list of `:name :file :file-url :line :column` maps, for a multimethod a `:dispatch-values` list."
+                        "status" "done"}}
+             "cider/type-protocols"
+             {:doc "Look up the protocols a type implements."
+              :requires {"sym" "The type to lookup"
+                         "ns" "The current namespace"}
+              :returns {"type-protocols" "A list of protocols, with a `:name :doc :file :file-url :line :column` structure."
+                        "status" "done"}}
+             "cider/protocols-with-method"
+             {:doc "Look up the protocols that declare a method of a given name."
+              :requires {"method" "The method name to lookup"}
+              :returns {"protocols-with-method" "A list of protocols, with a `:name :doc :file :file-url :line :column` structure."
                         "status" "done"}}}})
 
 (def-wrapper wrap-clojuredocs cider.nrepl.middleware.clojuredocs/handle-clojuredocs

--- a/src/cider/nrepl/middleware/xref.clj
+++ b/src/cider/nrepl/middleware/xref.clj
@@ -64,10 +64,31 @@
        :else
        {:kind "other"})}))
 
+(defn- resolve-class
+  "Resolve `sym` (in namespace `ns`) to a class, or nil.
+  Handles a bare/imported type name, a value-holding var, and a dotted class name
+  - a slash-qualified record symbol won't resolve, since records are classes."
+  [ns sym]
+  (let [s (misc/as-sym sym)
+        r (try (ns-resolve (misc/as-sym ns) s) (catch Throwable _ nil))]
+    (cond
+      (class? r) r
+      (and (var? r) (class? (deref r))) (deref r)
+      (var? r) (class (deref r))
+      :else (try (Class/forName (str s)) (catch Throwable _ nil)))))
+
+(defn type-protocols-reply [{:keys [ns sym]}]
+  {:type-protocols (mapv xref-data (xref/type-protocols (resolve-class ns sym)))})
+
+(defn protocols-with-method-reply [{:keys [method]}]
+  {:protocols-with-method (mapv xref-data (xref/protocols-with-method method))})
+
 (defn handle-xref [handler msg]
   (with-safe-transport handler msg
     "cider/fn-refs" fn-refs-reply
     "fn-refs" fn-refs-reply
     "cider/fn-deps" fn-deps-reply
     "fn-deps" fn-deps-reply
-    "cider/who-implements" who-implements-reply))
+    "cider/who-implements" who-implements-reply
+    "cider/type-protocols" type-protocols-reply
+    "cider/protocols-with-method" protocols-with-method-reply))

--- a/test/clj/cider/nrepl/middleware/xref_test.clj
+++ b/test/clj/cider/nrepl/middleware/xref_test.clj
@@ -102,3 +102,22 @@
     (testing (pr-str response)
       (is (= (:status response) #{"done"}))
       (is (= "other" (:kind result))))))
+
+(deftest type-protocols-integration-test
+  (let [response (session/message {:op "cider/type-protocols"
+                                   :ns "cider.nrepl.middleware.xref-test"
+                                   :sym "TestImpl"})
+        names (set (map :name (:type-protocols response)))]
+    (testing (pr-str response)
+      (is (= (:status response) #{"done"}))
+      (is (some #(str/includes? % "TestProto") names)
+          "lists the protocol the record implements"))))
+
+(deftest protocols-with-method-integration-test
+  (let [response (session/message {:op "cider/protocols-with-method"
+                                   :method "test-m"})
+        names (set (map :name (:protocols-with-method response)))]
+    (testing (pr-str response)
+      (is (= (:status response) #{"done"}))
+      (is (some #(str/includes? % "TestProto") names)
+          "lists the protocol declaring the method"))))


### PR DESCRIPTION
Backs the server-side path of CIDER's `cider-type-protocols` / `cider-protocols-with-method` commands, on top of orchard#402.

- `cider/type-protocols` resolves the given symbol to a class and returns the protocols it implements (both `extend`-style and inline).
- `cider/protocols-with-method` returns the protocols whose `:sigs` declare a method of the given name.

Each returns the usual `:name :file :file-url :line :column` maps. Validated end-to-end against orchard master installed locally (8 tests, 35 assertions).

**Draft / staged:** needs `orchard` 0.43.0, which contains `orchard.xref/type-protocols` and `protocols-with-method` but isn't released yet (same release #985 already targets). The `project.clj` dep is bumped to `0.43.0` in anticipation; CI stays red until that release is cut, then this comes out of draft and merges.