### PR TITLE
Fix ClojureScript macroexpansion of user-defined macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [clojure-emacs/cider#2099](https://github.com/clojure-emacs/cider/issues/2099): Fix ClojureScript macroexpansion of user-defined macros (e.g. those referred via `:refer-macros`), which previously echoed back unexpanded because the compiler env was passed to the analyzer instead of a proper analysis environment.
+
 ## 0.60.0 (2026-06-24)
 
 * [#986](https://github.com/clojure-emacs/cider-nrepl/pull/986): Add the `cider/type-protocols` op (the protocols a type implements) and the `cider/protocols-with-method` op (the protocols declaring a method of a given name), each returning `:name :file :file-url :line :column` maps (requires `orchard` 0.43.0).

--- a/src/cider/nrepl/middleware/macroexpand.clj
+++ b/src/cider/nrepl/middleware/macroexpand.clj
@@ -171,12 +171,27 @@
     @(resolve 'cljs.analyzer/macroexpand-1)
     (catch Exception _)))
 
+(def ^:private empty-env-cljs
+  (try
+    (require 'cljs.analyzer)
+    @(resolve 'cljs.analyzer/empty-env)
+    (catch Exception _)))
+
 (defn- resolve-expander-cljs
   "Returns the macroexpansion fn for macroexpanding ClojureScript code,
-  corresponding to the given value of the :expander option."
+  corresponding to the given value of the :expander option.
+
+  Must be called with `cljs.env/*compiler*` and `cljs.analyzer/*cljs-ns*` bound
+  (i.e. inside `with-cljs-env`/`with-cljs-ns`), since `empty-env` derives the
+  analysis environment's `:ns` from those. Passing the compiler env returned by
+  `cljs/grab-cljs-env` straight to `macroexpand-1` (as the code used to) is *not*
+  a valid analysis environment: it leaves `:ns` empty, so macros referred into
+  the namespace (e.g. via `:refer-macros`) don't resolve and only cljs.core
+  macros expand. See clojure-emacs/cider#2099."
   [{:keys [expander] :as msg}]
-  (let [macroexpand-1 (fn [form]
-                        (macroexpand-1-cljs (cljs/grab-cljs-env msg) form))
+  (let [env (empty-env-cljs)
+        macroexpand-1 (fn [form]
+                        (macroexpand-1-cljs env form))
 
         macroexpand (fn [form]
                       (let [mform (macroexpand-1 form)]
@@ -245,12 +260,11 @@
   in the context of the given :ns, using the provided :expander.
   and :display-namespaces options."
   [{:keys [code ns] :as msg}]
-  (let [expander-fn (resolve-expander-cljs msg)
-        code (read-string code)]
+  (let [code (read-string code)]
     (walk/prewalk (post-expansion-walker-cljs msg)
                   (cljs/with-cljs-env msg
                     (cljs/with-cljs-ns ns
-                      (expander-fn code))))))
+                      ((resolve-expander-cljs msg) code))))))
 
 (defn macroexpansion-reply-cljs [msg]
   (let [msg (update msg :ns #(or (misc/as-sym %) 'cljs.user))]

--- a/test/cljs/cider/nrepl/middleware/cljs_macroexpand_test.clj
+++ b/test/cljs/cider/nrepl/middleware/cljs_macroexpand_test.clj
@@ -2,7 +2,8 @@
   (:require
    [cider.nrepl.piggieback-test :refer [piggieback-fixture]]
    [cider.nrepl.test-session :as session]
-   [clojure.test :refer :all]))
+   [clojure.test :refer :all]
+   [nrepl.core :as nrepl]))
 
 (use-fixtures :once piggieback-fixture)
 
@@ -133,4 +134,18 @@
                                                        :print-meta "true"})]
       (is (= "(def ^{:private true, :arglists (quote ([]))} x\n (clojure.core/fn ([] nil)))"
              expansion))
+      (is (= #{"done"} status))))
+
+  (testing "user-defined macros expand (see clojure-emacs/cider#2099)"
+    (let [{:keys [status]}
+          (session/message
+           {:op "eval"
+            :code (nrepl/code (require '[cider.nrepl.middleware.cljs-macroexpand-test-macros
+                                         :refer-macros [my-when]]))})]
+      (is (= #{"done"} status) "requiring the test macro namespace should succeed"))
+    (let [{:keys [expansion status]} (session/message {:op "cider/macroexpand"
+                                                       :expander "macroexpand-1"
+                                                       :code "(my-when true 1)"
+                                                       :ns "cljs.user"})]
+      (is (= "(if true (do 1))" expansion))
       (is (= #{"done"} status)))))

--- a/test/cljs/cider/nrepl/middleware/cljs_macroexpand_test_macros.cljc
+++ b/test/cljs/cider/nrepl/middleware/cljs_macroexpand_test_macros.cljc
@@ -1,0 +1,9 @@
+(ns cider.nrepl.middleware.cljs-macroexpand-test-macros)
+
+;; A user-defined macro used to verify that ClojureScript macroexpansion works
+;; for macros that aren't part of cljs.core (see
+;; https://github.com/clojure-emacs/cider/issues/2099).
+
+(defmacro my-when
+  [test & body]
+  `(if ~test (do ~@body)))


### PR DESCRIPTION
Macroexpansion of user-defined ClojureScript macros (e.g. anything referred via `:refer-macros`) silently echoed the form back unexpanded. The cljs path was handing the piggieback *compiler* env to `cljs.analyzer/macroexpand-1`, but that's not a valid analysis environment - its `:ns` is empty, so the analyzer could only resolve `cljs.core` macros. We now build a proper env via `cljs.analyzer/empty-env`, which picks up `:ns` from the `*cljs-ns*` binding the call site already establishes.

Added a cljs test that requires a user macro via `:refer-macros` and asserts it expands.

Fixes clojure-emacs/cider#2099