### PR TITLE
Run ClojureScript tests via the test ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## master (unreleased)
 
 * [clojure-emacs/cider#2099](https://github.com/clojure-emacs/cider/issues/2099): Fix ClojureScript macroexpansion of user-defined macros (e.g. those referred via `:refer-macros`), which previously echoed back unexpanded because the compiler env was passed to the analyzer instead of a proper analysis environment.
-* [clojure-emacs/cider#2198](https://github.com/clojure-emacs/cider/issues/2198): Clojure-only ops (apropos, xref, trace, profile, test, refresh, reload, undef, spec) now reply with a `clojure-only` status when a ClojureScript REPL is active, instead of a confusing failure or a JVM-only result.
+* [clojure-emacs/cider#2198](https://github.com/clojure-emacs/cider/issues/2198): Clojure-only ops (apropos, xref, trace, profile, refresh, reload, undef, spec) now reply with a `clojure-only` status when a ClojureScript REPL is active, instead of a confusing failure or a JVM-only result.
+* [#555](https://github.com/clojure-emacs/cider-nrepl/issues/555): The `test` ops (`cider/test`, `cider/test-var-query`, `cider/test-all`, `cider/retest`) now run ClojureScript tests via `cljs.test` when a ClojureScript REPL is active, returning the same report shape as for Clojure. Asynchronous (`cljs.test/async`) tests aren't awaited yet.
 
 ## 0.60.0 (2026-06-24)
 

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -1019,8 +1019,10 @@ stack frame of the most recent exception."
 (def fail-fast-doc {"fail-fast" "If equals to the string \"true\", the tests will be considered complete after the first test has failed or errored."})
 
 (def-wrapper wrap-test cider.nrepl.middleware.test/handle-test
-  {:clojure-only? true
-   :doc "Middleware that handles testing requests."
+  {:doc "Middleware that handles testing requests."
+   ;; Expect piggieback so that, for ClojureScript, the `eval` op we synthesize
+   ;; to run the tests flows down into the piggieback middleware.
+   :expects (cljs/maybe-add-piggieback #{})
    :requires #{#'session #'wrap-print}
    :handles {"cider/test-var-query"
              {:doc "Run tests specified by the `var-query` and return results. Results are cached for exception retrieval and to enable re-running of failed/erring tests."

--- a/src/cider/nrepl/cljs/test.cljs
+++ b/src/cider/nrepl/cljs/test.cljs
@@ -1,0 +1,75 @@
+(ns cider.nrepl.cljs.test
+  "ClojureScript-runtime helper for the test middleware.
+
+  This namespace is compiled into the user's ClojureScript runtime on demand
+  (via `require`) by `cider.nrepl.middleware.test`. It installs a custom
+  `cljs.test/report` reporter that captures each assertion as plain, EDN-safe
+  data, so the JVM side can read the results back and reshape them into the same
+  report the Clojure test middleware produces. See clojure-emacs/cider#555."
+  (:require
+   [cljs.test :as t]))
+
+(defonce ^:private state (atom nil))
+
+(defn clear!
+  "Reset the captured test state. Call before a run."
+  []
+  (reset! state {:results []
+                 :summary {:ns 0 :var 0 :test 0 :pass 0 :fail 0 :error 0}}))
+
+(defn collect
+  "Return the captured test state as EDN-safe data."
+  []
+  @state)
+
+(defn- current-var []
+  (first (:testing-vars (t/get-current-env))))
+
+(defn- error-data [e]
+  (if (instance? js/Error e)
+    {:message (.-message e) :stack (.-stack e)}
+    {:message (pr-str e)}))
+
+(defn- record! [result-type m]
+  (let [vm (meta (current-var))
+        env (t/get-current-env)]
+    (swap! state
+           (fn [s]
+             (-> s
+                 (update-in [:summary :test] inc)
+                 (update-in [:summary result-type] inc)
+                 (update :results conj
+                         (cond-> {:type result-type
+                                  :ns (str (:ns vm))
+                                  :var (str (:name vm))}
+                           (:message m)
+                           (assoc :message (:message m))
+
+                           (seq (:testing-contexts env))
+                           (assoc :context (t/testing-contexts-str))
+
+                           (contains? m :expected)
+                           (assoc :expected (pr-str (:expected m)))
+
+                           (#{:fail :error} result-type)
+                           (assoc :actual (pr-str (:actual m)))
+
+                           (:line m)
+                           (assoc :line (:line m))
+
+                           (= :error result-type)
+                           (assoc :error (error-data (:actual m))))))))))
+
+(defmethod t/report [::reporter :pass] [m] (record! :pass m))
+(defmethod t/report [::reporter :fail] [m] (record! :fail m))
+(defmethod t/report [::reporter :error] [m] (record! :error m))
+
+(defmethod t/report [::reporter :begin-test-ns] [_m]
+  (swap! state update-in [:summary :ns] inc))
+
+(defmethod t/report [::reporter :begin-test-var] [_m]
+  (swap! state update-in [:summary :var] inc))
+
+(defmethod t/report [::reporter :end-test-var] [_m])
+(defmethod t/report [::reporter :end-run-tests] [_m])
+(defmethod t/report [::reporter :default] [_m])

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -2,8 +2,10 @@
   "Test execution, reporting, and inspection"
   {:author "Jeff Valk"}
   (:require
+   [cider.nrepl.middleware.test.cljs :as test-cljs]
    [cider.nrepl.middleware.test.extensions :as extensions]
    [cider.nrepl.middleware.util :as util :refer [respond-to]]
+   [cider.nrepl.middleware.util.cljs :as cljs]
    [cider.nrepl.middleware.util.coerce :as util.coerce]
    [clojure.pprint :as pp]
    [clojure.string :as str]
@@ -512,13 +514,17 @@
             (respond-to msg :status :done)))))
 
 (defn handle-test [handler msg & _configuration]
-  (case (:op msg)
-    ;; (NOTE: deprecated)
-    ("cider/test" "test")         (handle-test-op msg)
-    ;; (NOTE: deprecated)
-    ("cider/test-all" "test-all") (handle-test-all-op msg)
+  (if (and (cljs/grab-cljs-env msg)
+           (test-cljs/handle-test-cljs handler msg))
+    ;; Handled by the ClojureScript path.
+    nil
+    (case (:op msg)
+      ;; (NOTE: deprecated)
+      ("cider/test" "test")         (handle-test-op msg)
+      ;; (NOTE: deprecated)
+      ("cider/test-all" "test-all") (handle-test-all-op msg)
 
-    ("cider/test-var-query" "test-var-query")   (handle-test-var-query-op msg)
-    ("cider/test-stacktrace" "test-stacktrace") (handle-stacktrace-op msg)
-    ("cider/retest" "retest")                   (handle-retest-op msg)
-    (handler msg)))
+      ("cider/test-var-query" "test-var-query")   (handle-test-var-query-op msg)
+      ("cider/test-stacktrace" "test-stacktrace") (handle-stacktrace-op msg)
+      ("cider/retest" "retest")                   (handle-retest-op msg)
+      (handler msg))))

--- a/src/cider/nrepl/middleware/test/cljs.clj
+++ b/src/cider/nrepl/middleware/test/cljs.clj
@@ -1,0 +1,211 @@
+(ns cider.nrepl.middleware.test.cljs
+  "ClojureScript support for the test middleware.
+
+  ClojureScript tests can only run in the JS runtime, and `eval` is the only way
+  to reach it. So, much like the Clojure path drives execution through `eval` for
+  interruptibility, here we rewrite the test op into an `eval` op that runs the
+  tests via `cljs.test` in the runtime, capturing each assertion as EDN-safe data
+  (see `cider.nrepl.cljs.test`), then reshape that data into the very same report
+  the Clojure path produces. See clojure-emacs/cider#555.
+
+  Current limitations: only synchronous tests are supported (`cljs.test/async`
+  tests aren't awaited); `fail-fast` is ignored (`cljs.test` has no equivalent);
+  and running specific vars runs (but only reports) their whole namespace, since
+  fixtures are namespace-scoped."
+  (:require
+   [cider.nrepl.middleware.util :as util :refer [respond-to]]
+   [cider.nrepl.middleware.util.cljs :as cljs]
+   [cider.nrepl.middleware.util.error-handling :refer [base-error-response eval-interceptor-transport]]
+   [clojure.string :as str]
+   [nrepl.middleware.caught :as caught]
+   [orchard.misc :as misc])
+  (:import
+   (nrepl.transport Transport)))
+
+(def ^:private reporter
+  "The `cljs.test` reporter keyword installed by `cider.nrepl.cljs.test`."
+  :cider.nrepl.cljs.test/reporter)
+
+(def results
+  "An atom holding the most recent ClojureScript test results, keyed by namespace
+  and var, mirroring the Clojure path's store so `retest` can re-run failures."
+  (atom {}))
+
+;;; ## Determining what to run
+
+(defn- targets
+  "Derive the run targets from a test message. Returns a map with `:all?` (run
+  every loaded test namespace), `:nss` (namespace symbols to run), and `:vars`
+  (a set of fully-qualified var symbols to filter the report to, or nil for all)."
+  [{:keys [op ns tests var-query]}]
+  (case op
+    ("cider/test-all" "test-all")
+    {:all? true}
+
+    ("cider/test" "test")
+    {:nss (when ns [(misc/as-sym ns)])
+     :vars (when (seq tests)
+             (set (map #(misc/as-sym (str ns "/" %)) tests)))}
+
+    ;; cider/test-var-query
+    (let [{:keys [ns-query exactly]} var-query]
+      (if (:project? ns-query)
+        {:all? true}
+        (let [vars (when (seq exactly) (set (map misc/as-sym exactly)))]
+          {:nss (or (seq (map misc/as-sym (:exactly ns-query)))
+                    ;; Fall back to the namespaces of the requested vars.
+                    (distinct (map (comp symbol namespace) vars)))
+           :vars vars})))))
+
+;;; ## Running the tests
+
+(def ^:private require-code
+  "ClojureScript that loads the runtime helper. It must be evaluated as its own
+  message before the run code: cljs can't use a namespace's vars in the same
+  compilation unit that requires it."
+  "(require 'cljs.test 'cider.nrepl.cljs.test)")
+
+(defn- run-code
+  "Build the ClojureScript program (as a string) that runs the requested tests
+  with our capturing reporter and returns the collected data."
+  [{:keys [all? nss]}]
+  (let [run (if all?
+              (format "(cljs.test/run-all-tests nil (cljs.test/empty-env %s))" reporter)
+              (format "(cljs.test/run-tests (cljs.test/empty-env %s) %s)"
+                      reporter
+                      (str/join " " (map #(str "'" %) nss))))]
+    (format "(do (cider.nrepl.cljs.test/clear!) %s (cider.nrepl.cljs.test/collect))"
+            run)))
+
+;;; ## Reshaping the results
+
+(defn- reshape
+  "Turn the EDN data captured in the runtime into the report shape the Clojure
+  path produces: `{:summary {...} :results {ns {var [assertion-maps]}}}`. When
+  `vars` is non-nil, keep only assertions for those vars and recompute the
+  summary so it matches what's reported; otherwise use the runtime's own summary,
+  which also counts vars/namespaces that produced no assertions."
+  [{captured :results, summary :summary} vars]
+  (let [keep? (fn [{:keys [ns var]}]
+                (or (nil? vars)
+                    (contains? vars (symbol (str ns "/" var)))))
+        kept (filterv keep? captured)
+        nested (reduce (fn [acc {:keys [ns var] :as m}]
+                         (let [ns (symbol ns), var (symbol var)
+                               idx (count (get-in acc [ns var]))]
+                           (update-in acc [ns var] (fnil conj [])
+                                      (assoc m :ns ns :var var :index idx))))
+                       {}
+                       kept)
+        by-type (frequencies (map :type kept))]
+    {:results nested
+     :summary (if vars
+                {:ns (count nested)
+                 :var (reduce + (map count (vals nested)))
+                 :test (count kept)
+                 :pass (get by-type :pass 0)
+                 :fail (get by-type :fail 0)
+                 :error (get by-type :error 0)}
+                summary)}))
+
+(defn- reply [msg vars response]
+  (let [data (cljs/response-value msg response)
+        report (reshape data vars)]
+    (reset! results (:results report))
+    (respond-to msg (util/transform-value report))))
+
+(defn- eval-cljs
+  "Send `code` to be evaluated in the ClojureScript runtime, using `transport` to
+  intercept the result."
+  [handler msg code transport]
+  (handler (assoc msg
+                  :op "eval"
+                  :code code
+                  :transport transport
+                  :nrepl.middleware.print/keys [])))
+
+(defn- swallowing-transport
+  "A transport that discards the (irrelevant) responses of the helper-loading
+  eval and invokes `on-done` once it completes. If the eval itself errored, the
+  error is forwarded to the client and `on-done` is not invoked."
+  [{:keys [^Transport transport] :as msg} on-done]
+  (let [error (atom nil)]
+    (reify Transport
+      (recv [_this] (.recv transport))
+      (recv [_this timeout] (.recv transport timeout))
+      (send [this response]
+        (cond
+          (and (contains? (:status response) :eval-error)
+               (contains? response ::caught/throwable))
+          (reset! error (::caught/throwable response))
+
+          (contains? (:status response) :done)
+          (if-let [e @error]
+            (.send transport (base-error-response msg e :done :test-error))
+            (on-done)))
+        this))))
+
+(defn- missing-namespaces
+  "Of `nss`, the ones not present in the running ClojureScript compiler env (so
+  they can't be tested). Returns nil when the env can't be inspected."
+  [msg nss]
+  (when-let [known (some-> (cljs/grab-cljs-env msg)
+                           (get :cljs.analyzer/namespaces)
+                           keys
+                           set)]
+    (seq (remove known nss))))
+
+(defn- run-tests [handler msg {:keys [all? nss] :as target}]
+  (if (and (not all?) (missing-namespaces msg nss))
+    (respond-to msg :status #{:namespace-not-found :done})
+    (let [run (fn []
+                (eval-cljs handler msg (run-code target)
+                           (eval-interceptor-transport
+                            msg (fn [m response] (reply m (:vars target) response)) :test-error)))]
+      ;; Load the runtime helper first (separate message), then run the tests.
+      (eval-cljs handler msg require-code (swallowing-transport msg run)))))
+
+;;; ## Op handlers
+
+(defn- handle-retest [handler msg]
+  (let [failed (for [[ns vars] @results
+                     [var assertions] vars
+                     :when (some (comp #{:fail :error} :type) assertions)]
+                 (symbol (str ns "/" var)))]
+    (if (seq failed)
+      (run-tests handler msg {:nss (distinct (map (comp symbol namespace) failed))
+                              :vars (set failed)})
+      (do (reset! results {})
+          (respond-to msg (util/transform-value {:summary {:ns 0 :var 0 :test 0 :pass 0 :fail 0 :error 0}
+                                                 :results {}}))
+          (respond-to msg :status :done)))))
+
+(defn- handle-stacktrace [msg]
+  (let [[ns var] (map misc/as-sym [(:ns msg) (:var msg)])
+        {:keys [message stack]} (get-in @results [ns var (:index msg) :error])]
+    (if message
+      (respond-to msg
+                  :class "js/Error"
+                  ;; CIDER renders JVM stack frames; a JS stack is just text, so
+                  ;; surface it as part of the message for now.
+                  :message (cond-> message stack (str "\n" stack))
+                  :status :done)
+      (respond-to msg :status #{:no-error :done}))))
+
+(defn handle-test-cljs
+  "Handle a test op against an active ClojureScript REPL. Returns true when the
+  op was handled here, nil otherwise (so the caller can fall through)."
+  [handler {:keys [op] :as msg}]
+  (case op
+    ("cider/test" "test"
+                  "cider/test-all" "test-all"
+                  "cider/test-var-query" "test-var-query")
+    (do (run-tests handler msg (targets msg)) true)
+
+    ("cider/retest" "retest")
+    (do (handle-retest handler msg) true)
+
+    ("cider/test-stacktrace" "test-stacktrace")
+    (do (handle-stacktrace msg) true)
+
+    nil))

--- a/test/cljs/cider/nrepl/middleware/cljs_test_test.clj
+++ b/test/cljs/cider/nrepl/middleware/cljs_test_test.clj
@@ -1,0 +1,78 @@
+(ns cider.nrepl.middleware.cljs-test-test
+  (:require
+   [cider.nrepl.piggieback-test :refer [piggieback-fixture]]
+   [cider.nrepl.test-session :as session]
+   [clojure.test :refer :all]
+   [nrepl.core :as nrepl]))
+
+(use-fixtures :once piggieback-fixture)
+
+(def ^:private sample-ns "cider.nrepl.sample-cljs-test-ns")
+
+(defn- require-sample! []
+  (session/message {:op "eval"
+                    :code (nrepl/code (require 'cider.nrepl.sample-cljs-test-ns))}))
+
+(deftest cljs-test-var-query-test
+  (require-sample!)
+  (let [{:keys [summary results status]}
+        (session/message {:op "cider/test-var-query"
+                          :var-query {:ns-query {:exactly [sample-ns]}}})
+        ns-results (:cider.nrepl.sample-cljs-test-ns results)]
+    (is (= #{"done"} status))
+    (testing "summary counts"
+      (is (= 1 (:ns summary)))
+      (is (= 3 (:var summary)))
+      (is (= 3 (:test summary)))
+      (is (= 1 (:pass summary)))
+      (is (= 1 (:fail summary)))
+      (is (= 1 (:error summary))))
+    (testing "per-var results"
+      (is (= #{:passing-test :failing-test :erroring-test}
+             (set (keys ns-results))))
+      (is (= "pass" (:type (first (:passing-test ns-results)))))
+      (is (= "fail" (:type (first (:failing-test ns-results)))))
+      (is (= "error" (:type (first (:erroring-test ns-results))))))
+    (testing "testing context is captured"
+      (is (= "a passing assertion" (:context (first (:passing-test ns-results))))))))
+
+(deftest cljs-test-at-point-test
+  (require-sample!)
+  (let [{:keys [summary results]}
+        (session/message {:op "cider/test"
+                          :ns sample-ns
+                          :tests ["passing-test"]})]
+    (testing "only the requested var is reported"
+      (is (= 1 (:test summary)))
+      (is (= 1 (:pass summary)))
+      (is (= #{:passing-test}
+             (set (keys (:cider.nrepl.sample-cljs-test-ns results))))))))
+
+(deftest cljs-retest-test
+  (require-sample!)
+  (session/message {:op "cider/test-var-query"
+                    :var-query {:ns-query {:exactly [sample-ns]}}})
+  (let [{:keys [summary results]} (session/message {:op "cider/retest"})]
+    (testing "only previously-failing vars are re-run"
+      (is (= 2 (:test summary)))
+      (is (= 0 (:pass summary)))
+      (is (= 1 (:fail summary)))
+      (is (= 1 (:error summary)))
+      (is (= #{:failing-test :erroring-test}
+             (set (keys (:cider.nrepl.sample-cljs-test-ns results))))))))
+
+(deftest cljs-retest-no-failures-test
+  (require-sample!)
+  ;; A run with no failures, then retest: must complete (send `done`) rather
+  ;; than hang, and report nothing to re-run.
+  (session/message {:op "cider/test" :ns sample-ns :tests ["passing-test"]})
+  (let [{:keys [summary status]} (session/message {:op "cider/retest"})]
+    (is (= #{"done"} status))
+    (is (= 0 (:test summary)))))
+
+(deftest cljs-namespace-not-found-test
+  (require-sample!)
+  (let [{:keys [status]} (session/message {:op "cider/test-var-query"
+                                           :var-query {:ns-query {:exactly ["no.such.ns"]}}})]
+    (is (contains? status "namespace-not-found"))
+    (is (contains? status "done"))))

--- a/test/cljs/cider/nrepl/middleware/cljs_unsupported_test.clj
+++ b/test/cljs/cider/nrepl/middleware/cljs_unsupported_test.clj
@@ -18,7 +18,6 @@
                {:op "cider/refresh"}
                {:op "cider.clj-reload/reload"}
                {:op "cider/spec-list"}
-               {:op "cider/test-var-query" :ns-query {:exactly ["cljs.user"]}}
                {:op "cider/undef" :ns "cljs.user" :symbol "x"}]]
     (testing (:op msg)
       (let [{:keys [status err]} (session/message msg)]

--- a/test/cljs/cider/nrepl/sample_cljs_test_ns.cljs
+++ b/test/cljs/cider/nrepl/sample_cljs_test_ns.cljs
@@ -1,0 +1,15 @@
+(ns cider.nrepl.sample-cljs-test-ns
+  "A small ClojureScript test namespace exercised by the cljs test middleware
+  tests. See clojure-emacs/cider#555."
+  (:require
+   [cljs.test :refer-macros [deftest is testing]]))
+
+(deftest passing-test
+  (testing "a passing assertion"
+    (is (= 1 1))))
+
+(deftest failing-test
+  (is (= 1 2)))
+
+(deftest erroring-test
+  (is (= :never (throw (js/Error. "boom")))))


### PR DESCRIPTION
The `test` ops (`cider/test`, `cider/test-var-query`, `cider/test-all`, `cider/retest`) only ever worked for Clojure. With this change, when a ClojureScript REPL is active they run the tests via `cljs.test` in the JS runtime and return the exact same report shape as the Clojure path, so editors pick up cljs test support through the existing ops with no client-side changes.

Since `eval` is the only way to reach the runtime (as discussed in the issue), the test op is rewritten into an `eval` that installs a capturing `cljs.test` reporter - a small runtime helper, `cider.nrepl.cljs.test`, compiled into the user's runtime on demand - runs the tests, and returns the results as EDN. The JVM side reshapes that into the standard report. `wrap-test` now expects piggieback so the synthesized eval reaches it.

Scope: synchronous tests only for now. `cljs.test/async` tests aren't awaited yet, and `fail-fast` is ignored (no `cljs.test` equivalent). Both are noted as follow-ups.

Closes #555