### PR TITLE
Await asynchronous ClojureScript tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [clojure-emacs/cider#2099](https://github.com/clojure-emacs/cider/issues/2099): Fix ClojureScript macroexpansion of user-defined macros (e.g. those referred via `:refer-macros`), which previously echoed back unexpanded because the compiler env was passed to the analyzer instead of a proper analysis environment.
 * [clojure-emacs/cider#2198](https://github.com/clojure-emacs/cider/issues/2198): Clojure-only ops (apropos, xref, trace, profile, refresh, reload, undef, spec) now reply with a `clojure-only` status when a ClojureScript REPL is active, instead of a confusing failure or a JVM-only result.
-* [#555](https://github.com/clojure-emacs/cider-nrepl/issues/555): The `test` ops (`cider/test`, `cider/test-var-query`, `cider/test-all`, `cider/retest`) now run ClojureScript tests via `cljs.test` when a ClojureScript REPL is active, returning the same report shape as for Clojure. Asynchronous (`cljs.test/async`) tests aren't awaited yet.
+* [#555](https://github.com/clojure-emacs/cider-nrepl/issues/555): The `test` ops (`cider/test`, `cider/test-var-query`, `cider/test-all`, `cider/retest`) now run ClojureScript tests via `cljs.test` when a ClojureScript REPL is active, returning the same report shape as for Clojure. Asynchronous (`cljs.test/async`) tests are awaited, bounded by an optional `:timeout` (default 30s).
 
 ## 0.60.0 (2026-06-24)
 

--- a/src/cider/nrepl/cljs/test.cljs
+++ b/src/cider/nrepl/cljs/test.cljs
@@ -14,13 +14,24 @@
 (defn clear!
   "Reset the captured test state. Call before a run."
   []
-  (reset! state {:results []
+  (reset! state {:done? false
+                 :results []
                  :summary {:ns 0 :var 0 :test 0 :pass 0 :fail 0 :error 0}}))
 
 (defn collect
   "Return the captured test state as EDN-safe data."
   []
   @state)
+
+(defn poll
+  "Return the full captured state once the run has completed (`:end-run-tests`
+  fired), or a lightweight `{:done? false}` while it's still running. Used by the
+  JVM side to await asynchronous (`cljs.test/async`) tests without blocking the
+  runtime's event loop."
+  []
+  (if (:done? @state)
+    @state
+    {:done? false}))
 
 (defn- current-var []
   (first (:testing-vars (t/get-current-env))))
@@ -71,5 +82,9 @@
   (swap! state update-in [:summary :var] inc))
 
 (defmethod t/report [::reporter :end-test-var] [_m])
-(defmethod t/report [::reporter :end-run-tests] [_m])
+
+(defmethod t/report [::reporter :end-run-tests] [_m]
+  ;; Fires once the whole run (including async tests) has finished.
+  (swap! state assoc :done? true))
+
 (defmethod t/report [::reporter :default] [_m])

--- a/src/cider/nrepl/middleware/test/cljs.clj
+++ b/src/cider/nrepl/middleware/test/cljs.clj
@@ -8,18 +8,22 @@
   (see `cider.nrepl.cljs.test`), then reshape that data into the very same report
   the Clojure path produces. See clojure-emacs/cider#555.
 
-  Current limitations: only synchronous tests are supported (`cljs.test/async`
-  tests aren't awaited); `fail-fast` is ignored (`cljs.test` has no equivalent);
-  and running specific vars runs (but only reports) their whole namespace, since
-  fixtures are namespace-scoped."
+  Asynchronous (`cljs.test/async`) tests are awaited by polling the runtime for
+  the `:end-run-tests` event (a single eval can't block the JS event loop), up to
+  an optional `:timeout`. Other limitations: `fail-fast` is ignored (`cljs.test`
+  has no equivalent); running specific vars runs (but only reports) their whole
+  namespace, since fixtures are namespace-scoped; and concurrent test runs
+  sharing one ClojureScript runtime aren't isolated (the reporter state and the
+  JVM-side results store are global)."
   (:require
    [cider.nrepl.middleware.util :as util :refer [respond-to]]
    [cider.nrepl.middleware.util.cljs :as cljs]
-   [cider.nrepl.middleware.util.error-handling :refer [base-error-response eval-interceptor-transport]]
+   [cider.nrepl.middleware.util.error-handling :refer [base-error-response]]
    [clojure.string :as str]
    [nrepl.middleware.caught :as caught]
    [orchard.misc :as misc])
   (:import
+   (java.util.concurrent Executors ScheduledExecutorService ThreadFactory TimeUnit)
    (nrepl.transport Transport)))
 
 (def ^:private reporter
@@ -108,12 +112,6 @@
                  :error (get by-type :error 0)}
                 summary)}))
 
-(defn- reply [msg vars response]
-  (let [data (cljs/response-value msg response)
-        report (reshape data vars)]
-    (reset! results (:results report))
-    (respond-to msg (util/transform-value report))))
-
 (defn- eval-cljs
   "Send `code` to be evaluated in the ClojureScript runtime, using `transport` to
   intercept the result."
@@ -145,6 +143,37 @@
             (on-done)))
         this))))
 
+(defn- value-transport
+  "Transport for the run/poll evals. Forwards `:out`/`:err` so test output still
+  reaches the client, hands the evaluated value to `on-value`, and forwards eval
+  errors. The eval's own `:done` is swallowed (the op sends a single terminal
+  `:done` itself) - except when the eval completes without ever producing a value
+  (e.g. an interrupt), in which case `terminate!` ends the op so it can't hang."
+  [{:keys [^Transport transport] :as msg} on-value terminate!]
+  (let [value-seen? (volatile! false)]
+    (reify Transport
+      (recv [_this] (.recv transport))
+      (recv [_this timeout] (.recv transport timeout))
+      (send [this response]
+        (cond
+          (contains? response :value)
+          (do (vreset! value-seen? true)
+              (on-value (cljs/response-value msg response)))
+
+          (and (contains? (:status response) :eval-error)
+               (contains? response ::caught/throwable))
+          (do (.send transport (base-error-response msg (::caught/throwable response) :test-error))
+              (terminate! #{:done}))
+
+          (or (contains? response :out) (contains? response :err))
+          (.send transport response)
+
+          (contains? (:status response) :done)
+          (when-not @value-seen?
+            (terminate! (cond-> #{:done}
+                          (contains? (:status response) :interrupted) (conj :interrupted)))))
+        this))))
+
 (defn- missing-namespaces
   "Of `nss`, the ones not present in the running ClojureScript compiler env (so
   they can't be tested). Returns nil when the env can't be inspected."
@@ -155,15 +184,56 @@
                            set)]
     (seq (remove known nss))))
 
-(defn- run-tests [handler msg {:keys [all? nss] :as target}]
+(def ^:private poll-interval-ms 100)
+(def ^:private default-timeout-ms 30000)
+
+(defonce ^:private ^ScheduledExecutorService poll-executor
+  (Executors/newSingleThreadScheduledExecutor
+   (reify ThreadFactory
+     (newThread [_ r] (doto (Thread. ^Runnable r "cider-cljs-test-poll")
+                        (.setDaemon true))))))
+
+(defn- timeout-ms [{:keys [timeout]}]
+  (let [n (when timeout (try (Integer/parseInt (str timeout)) (catch Exception _ nil)))]
+    (if (and n (pos? n)) n default-timeout-ms)))
+
+(defn- run-tests [handler msg {:keys [all? nss vars] :as target}]
   (if (and (not all?) (missing-namespaces msg nss))
     (respond-to msg :status #{:namespace-not-found :done})
-    (let [run (fn []
+    (let [done? (atom false)
+          deadline (+ (System/currentTimeMillis) (timeout-ms msg))
+          ;; `finish!`/`terminate!` both guard on `done?` so the op replies with
+          ;; exactly one terminal `:done`, even under interrupt/poll races.
+          finish! (fn [data extra-status]
+                    (when (compare-and-set! done? false true)
+                      (let [report (reshape data vars)]
+                        (reset! results (:results report))
+                        (respond-to msg (util/transform-value report))
+                        (respond-to msg :status (cond-> #{:done} extra-status (conj extra-status))))))
+          terminate! (fn [status] (when (compare-and-set! done? false true)
+                                    (respond-to msg :status status)))]
+      (letfn [(poll-eval [on-value]
+                (eval-cljs handler msg "(cider.nrepl.cljs.test/poll)"
+                           (value-transport msg on-value terminate!)))
+              (on-value [data]
+                (cond
+                  ;; The op already ended (e.g. interrupted): stop polling.
+                  @done? nil
+                  ;; The run (incl. async tests) finished.
+                  (:done? data) (finish! data nil)
+                  ;; Still running: poll again after a short delay.
+                  (< (System/currentTimeMillis) deadline)
+                  (.schedule poll-executor ^Runnable #(poll-eval on-value)
+                             (long poll-interval-ms) TimeUnit/MILLISECONDS)
+                  ;; Timed out: report whatever has been captured so far.
+                  :else
+                  (eval-cljs handler msg "(cider.nrepl.cljs.test/collect)"
+                             (value-transport msg #(finish! % :test-timeout) terminate!))))
+              (run []
                 (eval-cljs handler msg (run-code target)
-                           (eval-interceptor-transport
-                            msg (fn [m response] (reply m (:vars target) response)) :test-error)))]
-      ;; Load the runtime helper first (separate message), then run the tests.
-      (eval-cljs handler msg require-code (swallowing-transport msg run)))))
+                           (value-transport msg on-value terminate!)))]
+        ;; Load the runtime helper first (separate message), then run the tests.
+        (eval-cljs handler msg require-code (swallowing-transport msg run))))))
 
 ;;; ## Op handlers
 

--- a/test/cljs/cider/nrepl/middleware/cljs_test_test.clj
+++ b/test/cljs/cider/nrepl/middleware/cljs_test_test.clj
@@ -70,6 +70,33 @@
     (is (= #{"done"} status))
     (is (= 0 (:test summary)))))
 
+(deftest cljs-async-test
+  ;; cljs.test/async tests finish after run-tests returns; the middleware must
+  ;; poll the runtime until they complete rather than reporting empty results.
+  (session/message {:op "eval"
+                    :code (nrepl/code (require 'cider.nrepl.sample-cljs-async-test-ns))})
+  (let [{:keys [summary results status]}
+        (session/message {:op "cider/test-var-query"
+                          :var-query {:ns-query {:exactly ["cider.nrepl.sample-cljs-async-test-ns"]}}})]
+    (is (= #{"done"} status))
+    (testing "async assertions are awaited and captured"
+      (is (= 2 (:test summary)))
+      (is (= 1 (:pass summary)))
+      (is (= 1 (:fail summary)))
+      (is (= #{:async-passing-test :async-failing-test}
+             (set (keys (:cider.nrepl.sample-cljs-async-test-ns results))))))))
+
+(deftest cljs-async-timeout-test
+  (session/message {:op "eval"
+                    :code (nrepl/code (require 'cider.nrepl.sample-cljs-timeout-test-ns))})
+  (let [{:keys [status]}
+        (session/message {:op "cider/test-var-query"
+                          :var-query {:ns-query {:exactly ["cider.nrepl.sample-cljs-timeout-test-ns"]}}
+                          :timeout "800"})]
+    (testing "an async test that never completes times out instead of hanging"
+      (is (contains? status "test-timeout"))
+      (is (contains? status "done")))))
+
 (deftest cljs-namespace-not-found-test
   (require-sample!)
   (let [{:keys [status]} (session/message {:op "cider/test-var-query"

--- a/test/cljs/cider/nrepl/sample_cljs_async_test_ns.cljs
+++ b/test/cljs/cider/nrepl/sample_cljs_async_test_ns.cljs
@@ -1,0 +1,13 @@
+(ns cider.nrepl.sample-cljs-async-test-ns
+  "ClojureScript test namespace with `cljs.test/async` tests, used to exercise
+  the test middleware's awaiting of asynchronous tests. See clojure-emacs/cider#555."
+  (:require
+   [cljs.test :refer-macros [deftest is async]]))
+
+(deftest async-passing-test
+  (async done
+         (js/setTimeout (fn [] (is (= 1 1)) (done)) 20)))
+
+(deftest async-failing-test
+  (async done
+         (js/setTimeout (fn [] (is (= 1 2)) (done)) 20)))

--- a/test/cljs/cider/nrepl/sample_cljs_timeout_test_ns.cljs
+++ b/test/cljs/cider/nrepl/sample_cljs_timeout_test_ns.cljs
@@ -1,0 +1,11 @@
+(ns cider.nrepl.sample-cljs-timeout-test-ns
+  "A ClojureScript test namespace whose async test never calls `done`, used to
+  exercise the test middleware's await timeout. See clojure-emacs/cider#555."
+  (:require
+   [cljs.test :refer-macros [deftest is async]]))
+
+(deftest never-completes-test
+  (async _done
+    ;; The assertion runs, but `_done` is never called, so the run never
+    ;; finishes and the middleware must time out rather than hang.
+         (is (= 1 1))))


### PR DESCRIPTION
Follow-up to #555. `cljs.test/async` tests finish *after* `run-tests` returns, so the synchronous path captured empty/partial results for them. A single eval can't wait for them either - blocking Node's event loop would deadlock the very callbacks it's waiting on.

So the runtime helper now flags `:done?` on `:end-run-tests`, and the JVM side polls the runtime (scheduled `(poll)` evals) until the run completes or an optional `:timeout` (default 30s) elapses, then replies with the same report. Synchronous runs are unaffected - they're already done by the time the run eval returns, so they reply immediately with no polling.

A single `done?` guard ensures exactly one terminal `:done` across the run/poll/timeout/interrupt paths, the poll loop stops once the op ends, and `:out`/`:err` from tests is forwarded to the client.

Tests cover sync, async (awaited), timeout, and the existing retest/namespace-not-found cases.