### PR TITLE
Apply the project's cljfmt config when formatting code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 * Bump `cljfmt` to 0.16.4 (from 0.9.2).
+* [#955](https://github.com/clojure-emacs/cider-nrepl/issues/955): The `cider/format-code` op now applies the project's `.cljfmt.edn`/`.cljfmt.clj` configuration automatically, with any options passed in the request taking precedence.
 * [clojure-emacs/cider#2099](https://github.com/clojure-emacs/cider/issues/2099): Fix ClojureScript macroexpansion of user-defined macros (e.g. those referred via `:refer-macros`), which previously echoed back unexpanded because the compiler env was passed to the analyzer instead of a proper analysis environment.
 * [clojure-emacs/cider#2198](https://github.com/clojure-emacs/cider/issues/2198): Clojure-only ops (apropos, xref, trace, profile, refresh, reload, undef, spec) now reply with a `clojure-only` status when a ClojureScript REPL is active, instead of a confusing failure or a JVM-only result.
 * [#555](https://github.com/clojure-emacs/cider-nrepl/issues/555): The `test` ops (`cider/test`, `cider/test-var-query`, `cider/test-all`, `cider/retest`) now run ClojureScript tests via `cljs.test` when a ClojureScript REPL is active, returning the same report shape as for Clojure. Asynchronous (`cljs.test/async`) tests are awaited, bounded by an optional `:timeout` (default 30s).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* Bump `cljfmt` to 0.16.4 (from 0.9.2).
 * [clojure-emacs/cider#2099](https://github.com/clojure-emacs/cider/issues/2099): Fix ClojureScript macroexpansion of user-defined macros (e.g. those referred via `:refer-macros`), which previously echoed back unexpanded because the compiler env was passed to the analyzer instead of a proper analysis environment.
 * [clojure-emacs/cider#2198](https://github.com/clojure-emacs/cider/issues/2198): Clojure-only ops (apropos, xref, trace, profile, refresh, reload, undef, spec) now reply with a `clojure-only` status when a ClojureScript REPL is active, instead of a confusing failure or a JVM-only result.
 * [#555](https://github.com/clojure-emacs/cider-nrepl/issues/555): The `test` ops (`cider/test`, `cider/test-var-query`, `cider/test-all`, `cider/retest`) now run ClojureScript tests via `cljs.test` when a ClojureScript REPL is active, returning the same report shape as for Clojure. Asynchronous (`cljs.test/async`) tests are awaited, bounded by an optional `:timeout` (default 30s).

--- a/project.clj
+++ b/project.clj
@@ -28,8 +28,9 @@
              [org.rksm/suitable "0.6.2" :exclusions [org.clojure/clojure
                                                      org.clojure/clojurescript
                                                      compliment]]
-             ^:inline-dep [cljfmt "0.9.2" :exclusions [org.clojure/clojurescript
-                                                       org.clojure/tools.cli]]
+             ^:inline-dep [dev.weavejester/cljfmt "0.16.4" :exclusions [org.clojure/clojure
+                                                                        org.clojure/clojurescript
+                                                                        org.clojure/tools.cli]]
              ^:inline-dep [org.clojure/tools.namespace "1.5.1" :exclusions [org.clojure/clojure
                                                                             org.clojure/clojurescript
                                                                             org.clojure/tools.cli]]

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -302,9 +302,9 @@ Depending on the type of the return value of the evaluation this middleware may 
   {:doc "Middleware providing support for formatting Clojure code and EDN data."
    :requires #{#'wrap-print}
    :handles {"cider/format-code"
-             {:doc "Reformats the given Clojure code, returning the result as a string."
+             {:doc "Reformats the given Clojure code, returning the result as a string. The project's `.cljfmt.edn`/`.cljfmt.clj` (if any) is applied automatically, with the supplied `options` taking precedence."
               :requires {"code" "The code to format."}
-              :optional {"options" "Configuration map for cljfmt."}
+              :optional {"options" "Configuration map for cljfmt, layered on top of the project's cljfmt configuration."}
               :returns {"formatted-code" "The formatted code."}}
              "format-code"
              {:doc "Deprecated: use `cider/format-code` instead. Reformats the given Clojure code, returning the result as a string."

--- a/src/cider/nrepl/middleware/format.clj
+++ b/src/cider/nrepl/middleware/format.clj
@@ -3,9 +3,10 @@
   (:refer-clojure :exclude [read-string])
   (:require
    [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
+   [cljfmt.config :as fmt-config]
    [cljfmt.core :as fmt]
-   [clojure.string :as str]
    [clojure.edn :as edn]
+   [clojure.string :as str]
    [clojure.walk :as walk]
    [nrepl.middleware.print :as print])
   (:import
@@ -15,21 +16,56 @@
 (defn- keyword->symbol [kw]
   (.sym ^clojure.lang.Keyword kw))
 
-(defn- generate-user-indents [indents]
-  (reduce-kv
-   (fn [acc kw rule]
-     (assoc acc
-            (keyword->symbol kw)
-            (walk/postwalk #(cond-> % (string? %) keyword) rule)))
-   fmt/default-indents
-   indents))
+;;; Project cljfmt configuration (.cljfmt.edn)
+(defn- config-file
+  "The project's cljfmt configuration file, found by walking up from the working
+  directory just as cljfmt's own tooling does, or nil when there is none."
+  []
+  (fmt-config/find-config-file "" {:read-clj-config-files? true}))
+
+(defn- project-config
+  "The cljfmt options from the project's configuration file, or nil when none
+  exists. Discovery and reading are delegated to cljfmt; the data is already in
+  cljfmt's native shape, so it needs no translation."
+  []
+  (when-let [file (config-file)]
+    (try
+      ;; `.cljfmt.clj` files are read with `read-string`; disable read-eval so
+      ;; formatting a file can never execute code embedded in the config.
+      (binding [*read-eval* false]
+        (fmt-config/read-config file))
+      (catch Exception e
+        (throw (ex-info (str "Failed to read cljfmt config " file ": " (.getMessage e))
+                        {:file (str file)} e))))))
+
+(defn- request-overrides
+  "Translate the editor-supplied `options` into cljfmt's native shape. Indent
+  rules arrive with string elements (e.g. `[[\"inner\" 0]]`) and keyword keys,
+  and alias keys arrive as keywords, so both are converted."
+  [options]
+  (cond-> {}
+    (:indents options)
+    (assoc :indents (reduce-kv
+                     (fn [acc kw rule]
+                       (assoc acc (keyword->symbol kw)
+                              (walk/postwalk #(cond-> % (string? %) keyword) rule)))
+                     {}
+                     (:indents options)))
+
+    (:alias-map options)
+    (assoc :alias-map (reduce-kv (fn [m k v] (assoc m (name k) v)) {} (:alias-map options)))))
 
 (defn format-code-reply
   [{:keys [code options]}]
-  (let [opts (some-> options
-                     (select-keys [:indents :alias-map])
-                     (update :indents generate-user-indents)
-                     (update :alias-map #(reduce-kv (fn [m k v] (assoc m (name k) v)) {} %)))]
+  (let [config (or (project-config) {})
+        request (request-overrides options)
+        ;; The project's config applies first; the request options layer on top.
+        ;; Editor-supplied indent rules are additive, so they go through
+        ;; `:extra-indents` to avoid discarding cljfmt's (or the project's) own
+        ;; `:indents`.
+        opts (cond-> config
+               (:indents request)   (update :extra-indents merge (:indents request))
+               (:alias-map request) (update :alias-map merge (:alias-map request)))]
     {:formatted-code (fmt/reformat-string code opts)}))
 
 ;;; EDN formatting

--- a/test/clj/cider/nrepl/middleware/format_test.clj
+++ b/test/clj/cider/nrepl/middleware/format_test.clj
@@ -1,10 +1,13 @@
 (ns cider.nrepl.middleware.format-test
   (:require
+   [cider.nrepl.middleware.format :as format]
    [cider.nrepl.test-session :as session]
    [cider.test-helpers :refer :all]
    [clojure.test :refer :all]
    [matcher-combinators.matchers :as mc]
-   [nrepl.middleware.print :as print]))
+   [nrepl.middleware.print :as print])
+  (:import
+   (java.io File)))
 
 (def ugly-code-sample
   "( let [x 3
@@ -102,6 +105,75 @@
          (session/message {:op "cider/format-code"
                            :code "(+ 1 2 3)"
                            :options {"alias-map" "INVALID"}}))))
+
+(defn- with-temp-config*
+  "Write CONTENTS to a temp cljfmt config file, make cljfmt's config lookup
+  return it for the duration of THUNK, then clean up."
+  [contents thunk]
+  (let [tmp (File/createTempFile "cljfmt" ".edn")]
+    (try
+      (spit tmp contents)
+      (with-redefs [format/config-file (constantly tmp)]
+        (thunk))
+      (finally
+        (.delete tmp)))))
+
+(defn- format-with-config [contents msg]
+  (with-temp-config* contents #(:formatted-code (format/format-code-reply msg))))
+
+(deftest cljfmt-config-test
+  ;; See: https://github.com/clojure-emacs/cider-nrepl/issues/955
+  (let [alias-sample "(foo/bar 1\n2)"]
+    (testing "indent rules from the project config are applied"
+      (is (= "(let [x 3\n      y 4]\n     (+ (* x x) (* y y)))"
+             (format-with-config "{:extra-indents {let [[:block 2]]}}"
+                                 {:code ugly-code-sample}))))
+
+    (testing ":extra-indents and :alias-map from the project config are applied"
+      (is (= "(foo/bar 1\n  2)"
+             (format-with-config "{:extra-indents {foo.core/bar [[:inner 0]]}
+                                   :alias-map {\"foo\" \"foo.core\"}}"
+                                 {:code alias-sample}))))
+
+    (testing "boolean toggles from the project config are respected"
+      (is (= "(+ 1 2)   "
+             (format-with-config "{:remove-trailing-whitespace? false}"
+                                 {:code "(+ 1 2)   "}))))
+
+    (testing "explicit request options take precedence over the project config"
+      ;; The config's bogus alias for `foo` would stop the indent rule (keyed on
+      ;; `foo.core/bar`) from matching; the request's correct alias makes it apply.
+      (is (= "(foo/bar 1\n  2)"
+             (format-with-config "{:alias-map {\"foo\" \"wrong.ns\"}
+                                   :extra-indents {foo.core/bar [[:inner 0]]}}"
+                                 {:code alias-sample
+                                  :options {:alias-map {:foo "foo.core"}}}))))
+
+    (testing "formatting works unchanged when there is no project config"
+      (is (= formatted-code-sample
+             (with-redefs [format/config-file (constantly nil)]
+               (:formatted-code (format/format-code-reply {:code ugly-code-sample}))))))
+
+    (testing "a malformed project config surfaces a clear error"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"Failed to read cljfmt config"
+           (format-with-config "{:indents " {:code "(+ 1 2)"}))))
+
+    (testing "a .clj config is honored but read with eval disabled"
+      (let [tmp (File/createTempFile "cljfmt" ".clj")]
+        (try
+          (with-redefs [format/config-file (constantly tmp)]
+            (testing "a plain-data config is applied"
+              (spit tmp "{:remove-trailing-whitespace? false}")
+              (is (= "(+ 1 2)   "
+                     (:formatted-code (format/format-code-reply {:code "(+ 1 2)   "})))))
+            (testing "an embedded eval form is rejected, not executed"
+              (spit tmp "{:x #=(+ 1 1)}")
+              (is (thrown-with-msg?
+                   clojure.lang.ExceptionInfo #"Failed to read cljfmt config"
+                   (format/format-code-reply {:code "(+ 1 2)"})))))
+          (finally
+            (.delete tmp)))))))
 
 (deftest format-edn-op-test
   (testing "format-edn works"


### PR DESCRIPTION
The `format-code` op used to only honor the indents/alias-map passed in the request and ignored the project's own `.cljfmt.edn`, so server-side formatting could diverge from what the project expects. It now loads the project config through cljfmt's own config loader and layers the request options on top.

To get a real config loader (and the modern formatting options), this also bumps cljfmt from the ancient 0.9.2 to 0.16.4. That moves to the `dev.weavejester` group and pulls in rewrite-clj; mranderson shades it cleanly, and only `cljfmt.main` still needs stripping for tools.cli (which the Makefile already does). The existing format tests pass unchanged against the new version.

Two commits: the cljfmt bump, then the feature.

Addresses the main half of #955. The other suggestion there - auto-deriving `alias-map` from a supplied `ns` - is now largely handled by cljfmt itself (0.16.x reads aliases from the form's own `ns`), so a buffer that includes its `ns` form gets it for free.