### PR TITLE
Fix op descriptor metadata bugs and a dead test line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* Fix op descriptor metadata: document `cider/get-state`'s return values (previously rendered blank) and correct the `cider/log-remove-consumer` return key.
 * Bump `cljfmt` to 0.16.4 (from 0.9.2).
 * [#955](https://github.com/clojure-emacs/cider-nrepl/issues/955): The `cider/format-code` op now applies the project's `.cljfmt.edn`/`.cljfmt.clj` configuration automatically, with any options passed in the request taking precedence.
 * [clojure-emacs/cider#2099](https://github.com/clojure-emacs/cider/issues/2099): Fix ClojureScript macroexpansion of user-defined macros (e.g. those referred via `:refer-macros`), which previously echoed back unexpanded because the compiler env was passed to the analyzer instead of a proper analysis environment.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## master (unreleased)
 
-* Fix op descriptor metadata: document `cider/get-state`'s return values (previously rendered blank) and correct the `cider/log-remove-consumer` return key.
-* Bump `cljfmt` to 0.16.4 (from 0.9.2).
+* [#993](https://github.com/clojure-emacs/cider-nrepl/pull/993): Fix op descriptor metadata: document `cider/get-state`'s return values (previously rendered blank) and correct the `cider/log-remove-consumer` return key.
+* [#992](https://github.com/clojure-emacs/cider-nrepl/pull/992): Bump `cljfmt` to 0.16.4 (from 0.9.2).
 * [#955](https://github.com/clojure-emacs/cider-nrepl/issues/955): The `cider/format-code` op now applies the project's `.cljfmt.edn`/`.cljfmt.clj` configuration automatically, with any options passed in the request taking precedence.
 * [clojure-emacs/cider#2099](https://github.com/clojure-emacs/cider/issues/2099): Fix ClojureScript macroexpansion of user-defined macros (e.g. those referred via `:refer-macros`), which previously echoed back unexpanded because the compiler env was passed to the analyzer instead of a proper analysis environment.
 * [clojure-emacs/cider#2198](https://github.com/clojure-emacs/cider/issues/2198): Clojure-only ops (apropos, xref, trace, profile, refresh, reload, undef, spec) now reply with a `clojure-only` status when a ClojureScript REPL is active, instead of a confusing failure or a JVM-only result.

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -307,9 +307,9 @@ Depending on the type of the return value of the evaluation this middleware may 
               :optional {"options" "Configuration map for cljfmt, layered on top of the project's cljfmt configuration."}
               :returns {"formatted-code" "The formatted code."}}
              "format-code"
-             {:doc "Deprecated: use `cider/format-code` instead. Reformats the given Clojure code, returning the result as a string."
+             {:doc "Deprecated: use `cider/format-code` instead. Reformats the given Clojure code, returning the result as a string. The project's `.cljfmt.edn`/`.cljfmt.clj` (if any) is applied automatically, with the supplied `options` taking precedence."
               :requires {"code" "The code to format."}
-              :optional {"options" "Configuration map for cljfmt."}
+              :optional {"options" "Configuration map for cljfmt, layered on top of the project's cljfmt configuration."}
               :returns {"formatted-code" "The formatted code."}}
              "cider/format-edn"
              {:doc "Reformats the given EDN data, returning the result as a string."
@@ -702,7 +702,7 @@ if applicable, and re-render the updated value."
                 "appender" "The name of the appender."
                 "consumer" "The name of the consumer."}
      :returns {"status" "done"
-               "cider/log-add-consumer" "The removed consumer."}}
+               "cider/log-remove-consumer" "The removed consumer."}}
 
     "cider/log-update-appender"
     {:doc "Update the appender of a log framework."
@@ -1110,9 +1110,11 @@ stack frame of the most recent exception."
 You can also request to compute the info directly by requesting the \"cider/get-state\" op."
    :requires #{#'session}
    :expects (cljs/maybe-add-piggieback mw/ops-that-can-eval)
-   :handles {"cider/get-state" {}}
-   :returns {"repl-type" "`:clj` or `:cljs`."
-             "changed-namespaces" "A map of namespaces to `{:aliases ,,, :interns ,,,}`"}})
+   :handles {"cider/get-state"
+             {:doc "Return the current REPL state: its type and any namespaces changed since the last notification."
+              :returns {"status" "done"
+                        "repl-type" "`:clj` or `:cljs`."
+                        "changed-namespaces" "A map of namespaces to `{:aliases ,,, :interns ,,,}`"}}}})
 
 (def-wrapper wrap-undef cider.nrepl.middleware.undef/handle-undef
   {:clojure-only? true

--- a/test/clj/cider/nrepl/descriptor_test.clj
+++ b/test/clj/cider/nrepl/descriptor_test.clj
@@ -1,0 +1,26 @@
+(ns cider.nrepl.descriptor-test
+  "Regression tests for the op descriptors declared in `cider.nrepl`."
+  (:require
+   [cider.nrepl]
+   [clojure.test :refer :all]))
+
+(defn- op-descriptor
+  "The descriptor for `op` as declared by the given `wrapper` var."
+  [wrapper op]
+  (-> (meta wrapper)
+      :nrepl.middleware/descriptor
+      (get-in [:handles op])))
+
+(deftest get-state-descriptor-test
+  ;; `cider/get-state` used to carry an empty descriptor with its `:returns`
+  ;; misplaced at the wrapper level, so the op rendered blank in the docs.
+  (let [op (op-descriptor #'cider.nrepl/wrap-tracker "cider/get-state")]
+    (is (seq (:doc op)))
+    (is (contains? (:returns op) "repl-type"))
+    (is (contains? (:returns op) "changed-namespaces"))))
+
+(deftest log-remove-consumer-returns-test
+  ;; The `:returns` key was copy-pasted from the add-consumer op.
+  (let [op (op-descriptor #'cider.nrepl/wrap-log "cider/log-remove-consumer")]
+    (is (contains? (:returns op) "cider/log-remove-consumer"))
+    (is (not (contains? (:returns op) "cider/log-add-consumer")))))

--- a/test/clj/cider/test_helpers.clj
+++ b/test/clj/cider/test_helpers.clj
@@ -1,6 +1,5 @@
 (ns cider.test-helpers
   (:require [clojure.test :refer :all]
-            [matcher-combinators.matchers :as matchers]
             [matcher-combinators.test :refer [match?]]))
 
 (defmacro is+
@@ -12,5 +11,3 @@
 
 (defn mc-includes [expected]
   #(and (string? %) (.contains ^String % expected)))
-
-(matchers/any-of)


### PR DESCRIPTION
A few small, isolated fixes found while reviewing the middleware descriptors:

- `cider/get-state` had an empty `{}` descriptor with its `:returns` misplaced at the wrapper level, so the op showed up blank in the generated `ops.adoc`. Gave it a proper doc + `:returns`.
- `cider/log-remove-consumer` documented its return value under the `cider/log-add-consumer` key (copy-paste). The handler actually returns `:cider/log-remove-consumer`.
- The deprecated `format-code` alias had drifted from its `cider/format-code` primary; brought it back in sync.
- Dropped a dead `(matchers/any-of)` call sitting at the top level of the test-helpers ns.

Adds a small descriptor regression test. First of a few small PRs from a broader middleware consistency/robustness review.