### PR TITLE
Don't let an Error hang the client on op failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ## master (unreleased)
 
+* [#994](https://github.com/clojure-emacs/cider-nrepl/pull/994): Error handling: catch `Throwable` (not just `Exception`) when handling ops, so an op that hits an `Error` (e.g. `StackOverflowError`, `AssertionError`) returns a proper error response instead of hanging the client without a terminal `done`. The stacktrace ops, which reply outside the shared error machinery, got the same guarantee.
 * [#993](https://github.com/clojure-emacs/cider-nrepl/pull/993): Fix op descriptor metadata: document `cider/get-state`'s return values (previously rendered blank) and correct the `cider/log-remove-consumer` return key.
 * [#992](https://github.com/clojure-emacs/cider-nrepl/pull/992): Bump `cljfmt` to 0.16.4 (from 0.9.2).
-* Error handling: catch `Throwable` (not just `Exception`) when handling ops, so an op that hits an `Error` (e.g. `StackOverflowError`, `AssertionError`) returns a proper error response instead of hanging the client without a terminal `done`. The stacktrace ops, which reply outside the shared error machinery, got the same guarantee.
-* Bump `cljfmt` to 0.16.4 (from 0.9.2).
 * [#955](https://github.com/clojure-emacs/cider-nrepl/issues/955): The `cider/format-code` op now applies the project's `.cljfmt.edn`/`.cljfmt.clj` configuration automatically, with any options passed in the request taking precedence.
 * [clojure-emacs/cider#2099](https://github.com/clojure-emacs/cider/issues/2099): Fix ClojureScript macroexpansion of user-defined macros (e.g. those referred via `:refer-macros`), which previously echoed back unexpanded because the compiler env was passed to the analyzer instead of a proper analysis environment.
 * [clojure-emacs/cider#2198](https://github.com/clojure-emacs/cider/issues/2198): Clojure-only ops (apropos, xref, trace, profile, refresh, reload, undef, spec) now reply with a `clojure-only` status when a ClojureScript REPL is active, instead of a confusing failure or a JVM-only result.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * [#993](https://github.com/clojure-emacs/cider-nrepl/pull/993): Fix op descriptor metadata: document `cider/get-state`'s return values (previously rendered blank) and correct the `cider/log-remove-consumer` return key.
 * [#992](https://github.com/clojure-emacs/cider-nrepl/pull/992): Bump `cljfmt` to 0.16.4 (from 0.9.2).
+* Error handling: catch `Throwable` (not just `Exception`) when handling ops, so an op that hits an `Error` (e.g. `StackOverflowError`, `AssertionError`) returns a proper error response instead of hanging the client without a terminal `done`. The stacktrace ops, which reply outside the shared error machinery, got the same guarantee.
+* Bump `cljfmt` to 0.16.4 (from 0.9.2).
 * [#955](https://github.com/clojure-emacs/cider-nrepl/issues/955): The `cider/format-code` op now applies the project's `.cljfmt.edn`/`.cljfmt.clj` configuration automatically, with any options passed in the request taking precedence.
 * [clojure-emacs/cider#2099](https://github.com/clojure-emacs/cider/issues/2099): Fix ClojureScript macroexpansion of user-defined macros (e.g. those referred via `:refer-macros`), which previously echoed back unexpanded because the compiler env was passed to the analyzer instead of a proper analysis environment.
 * [clojure-emacs/cider#2198](https://github.com/clojure-emacs/cider/issues/2198): Clojure-only ops (apropos, xref, trace, profile, refresh, reload, undef, spec) now reply with a `clojure-only` status when a ClojureScript REPL is active, instead of a confusing failure or a JVM-only result.

--- a/src/cider/nrepl/middleware/stacktrace.clj
+++ b/src/cider/nrepl/middleware/stacktrace.clj
@@ -4,6 +4,7 @@
   (:require
    [cider.nrepl.middleware.inspect :as middleware.inspect]
    [cider.nrepl.middleware.util :refer [respond-to]]
+   [cider.nrepl.middleware.util.error-handling :refer [base-error-response]]
    [cider.nrepl.middleware.util.nrepl :refer [notify-client]]
    [nrepl.middleware.print :as print]
    [nrepl.transport :as t]
@@ -62,9 +63,17 @@
     (respond-to msg :status :done)))
 
 (defn handle-stacktrace
-  "Handle stacktrace ops."
-  [_ {:keys [op] :as msg}]
-  (case op
-    ("cider/analyze-last-stacktrace" "analyze-last-stacktrace") (handle-analyze-last-stacktrace-op msg)
-    ("cider/inspect-last-exception" "inspect-last-exception")   (handle-inspect-last-exception-op msg)
-    ("cider/stacktrace" "stacktrace")                           (handle-stacktrace-op msg)))
+  "Handle stacktrace ops.
+
+  Unlike most middleware these ops stream their replies directly rather than
+  going through `with-safe-transport`, so guard them here: any error still has
+  to produce a terminal `:done`, otherwise the client hangs."
+  [handler {:keys [op transport] :as msg}]
+  (try
+    (case op
+      ("cider/analyze-last-stacktrace" "analyze-last-stacktrace") (handle-analyze-last-stacktrace-op msg)
+      ("cider/inspect-last-exception" "inspect-last-exception")   (handle-inspect-last-exception-op msg)
+      ("cider/stacktrace" "stacktrace")                           (handle-stacktrace-op msg)
+      (handler msg))
+    (catch Throwable e
+      (t/send transport (base-error-response msg e :done :stacktrace-error)))))

--- a/src/cider/nrepl/middleware/util/error_handling.clj
+++ b/src/cider/nrepl/middleware/util/error_handling.clj
@@ -167,8 +167,11 @@
   `(let [{op# :op transport# :transport :as msg#} ~msg]
      (if-let [action# (get (hash-map ~@pairings) op#)]
        (let [[op-action# err-action#]  (if (vector? action#) action# [action# ::default])]
+         ;; Catch `Throwable`, not just `Exception`: an `Error` (e.g.
+         ;; `AssertionError`, `StackOverflowError`) escaping here would leave the
+         ;; op without a terminal `:done`, hanging the client until it times out.
          (try (transport/send transport# (op-handler op-action# msg#))
-              (catch Exception e# (transport/send transport# (error-handler err-action# msg# e#)))))
+              (catch Throwable e# (transport/send transport# (error-handler err-action# msg# e#)))))
        (~handler msg#))))
 
 (defn eval-interceptor-transport

--- a/test/clj/cider/nrepl/middleware/stacktrace_test.clj
+++ b/test/clj/cider/nrepl/middleware/stacktrace_test.clj
@@ -64,6 +64,17 @@
       (testing "returns done and no-error status"
         (is (= #{"done" "no-error"} (:status response)))))))
 
+(deftest analyze-last-stacktrace-error-test
+  ;; These ops stream their replies directly, so an error during analysis must
+  ;; still terminate the op with `:done` instead of hanging the client.
+  (testing "an error during analysis still terminates with done"
+    (session/message {:op "eval" :code "(first 1)"})
+    (with-redefs [sut/analyze-last-stacktrace (fn [_] (throw (AssertionError. "boom")))]
+      (let [response (session/message {:op "cider/analyze-last-stacktrace"})]
+        (is (contains? (:status response) "done"))
+        (is (contains? (:status response) "stacktrace-error"))
+        (is (= "class java.lang.AssertionError" (:ex response)))))))
+
 (deftest deprecated-ops-test
   (testing "Deprecated 'stacktrace' op still works"
     (session/message {:op "eval" :code "(first 1)"})

--- a/test/clj/cider/nrepl/middleware/util/error_handling_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/error_handling_test.clj
@@ -59,6 +59,20 @@
           "Should pass since *ns* is inside a quoted list and doesn't get evaluated")
       (is (thrown? IllegalArgumentException (deep-bencodable? [:a :vector 1 {:a :map} 2 [:sub :vec :bad *ns*] '(:a :list) 3]))))))
 
+(deftest with-safe-transport-catches-throwable-test
+  ;; An `Error` (not just an `Exception`) escaping an op-action must still
+  ;; produce a terminal `:done`, otherwise the client hangs waiting for it.
+  (let [transport (tt/test-transport)
+        msg {:op "cider/boom" :transport transport :id 1}]
+    (err/with-safe-transport (fn [_] :unhandled)
+      msg
+      "cider/boom" (fn [_] (throw (AssertionError. "boom"))))
+    (let [resp (first (tt/messages transport))]
+      (is (some? resp) "an error response is sent rather than the Error propagating")
+      (is (contains? (:status resp) :done))
+      (is (contains? (:status resp) :cider/boom-error))
+      (is (= "class java.lang.AssertionError" (:ex resp))))))
+
 (deftest error-handler-root-ex
   (let [e (Exception. "testing" (Throwable. "root-cause"))
         e2 (Exception. "testing2")]


### PR DESCRIPTION
Second PR from the middleware robustness review.

`with-safe-transport` (the shared op error machinery used by ~19 middleware) only caught `Exception`. An `Error` escaping an op-action - `StackOverflowError`, `AssertionError`, `NoClassDefFoundError`, etc. - skipped the catch, so no terminal `done` was sent and the CIDER client hung until it timed out. Several handlers already catch `Throwable` by hand precisely because these happen in practice. Now the shared catch is `Throwable` too, routing it through the normal error response.

The stacktrace ops (`analyze-last-stacktrace`, `inspect-last-exception`, `stacktrace`) reply directly rather than through `with-safe-transport` and had no error guard at all - so they get the same guarantee here, plus the previously-missing default fallthrough to the next handler.

Tests: a unit test proving an `Error` now yields a terminal error response, and a stacktrace op test proving a failure during analysis still terminates with `done`.

Follow-up worth its own PR: the same guaranteed-`done` audit for the remaining roll-your-own handlers (test/retest, inspect print-current-value, reload clear).