### PR TITLE
Drop dead eager requires from cider.nrepl

### DIFF
--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -16,10 +16,8 @@
    [nrepl.middleware.caught :refer [wrap-caught]]
    [nrepl.middleware.print :refer [wrap-print wrap-print-optional-arguments]]
    [nrepl.middleware.session :refer [session]]
-   [nrepl.misc :as misc :refer [with-session-classloader]]
+   [nrepl.misc :refer [with-session-classloader]]
    [nrepl.server :as nrepl-server]
-   [orchard.info]
-   [orchard.namespace]
    [orchard.java]))
 
 (def min-clojure-version


### PR DESCRIPTION
`orchard.info` and `orchard.namespace` were required eagerly for an Orchard cache warmup that got removed a while back, so they're now dead. They're especially worth dropping here, since `cider.nrepl` exists to *defer* loading heavy middleware deps - eagerly pulling in Orchard at startup for nothing works against that. Also drops the unused `misc` alias.