### PR TITLE
Extract msg->var helper for op handlers

### DIFF
--- a/src/cider/nrepl/middleware/profile.clj
+++ b/src/cider/nrepl/middleware/profile.clj
@@ -2,13 +2,14 @@
   "Simplistic manual tracing profiler for coarse usecases where the accuracy
   doesn't matter much and you already know which functions to measure."
   (:require
+   [cider.nrepl.middleware.util :refer [msg->var]]
    [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]]
    [cider.nrepl.middleware.inspect :as inspect-mw]
    [nrepl.misc :refer [response-for]]
    [orchard.profile :as profile]))
 
-(defn toggle-var-reply [{:keys [ns sym] :as msg}]
-  (if-let [v (ns-resolve (symbol ns) (symbol sym))]
+(defn toggle-var-reply [msg]
+  (if-let [v (msg->var msg)]
     (if (profile/profiled? v)
       (do (profile/unprofile-var v)
           (response-for msg :status :done :value "unprofiled"))

--- a/src/cider/nrepl/middleware/trace.clj
+++ b/src/cider/nrepl/middleware/trace.clj
@@ -1,14 +1,14 @@
 (ns cider.nrepl.middleware.trace
   (:require
-   [cider.nrepl.middleware.util :refer [respond-to]]
+   [cider.nrepl.middleware.util :refer [msg->var respond-to]]
    [cider.nrepl.middleware.util.error-handling :refer [with-op-aliases with-safe-transport]]
    [orchard.trace :as trace])
   (:import
    [java.util UUID]))
 
 (defn toggle-trace-var
-  [{:keys [ns sym]}]
-  (if-let [v (ns-resolve (symbol ns) (symbol sym))]
+  [msg]
+  (if-let [v (msg->var msg)]
     (if (trace/traceable? v)
       (if (trace/traced? v)
         (do (trace/untrace-var* v)

--- a/src/cider/nrepl/middleware/util.clj
+++ b/src/cider/nrepl/middleware/util.clj
@@ -1,7 +1,8 @@
 (ns cider.nrepl.middleware.util
   "Utility functions that might be useful in middleware."
   (:require [nrepl.transport :as transport]
-            [nrepl.misc :refer [response-for]]))
+            [nrepl.misc :refer [response-for]]
+            [orchard.misc :as misc]))
 
 (defmulti transform-value "Transform a value for output" type)
 
@@ -49,3 +50,10 @@
   "Send a response for `msg` with `response-data` using message's transport."
   [msg & response-data]
   (transport/send (:transport msg) (apply response-for msg response-data)))
+
+(defn msg->var
+  "Resolve the var referred to by the `:ns` and `:sym` slots of an op `msg`,
+  coercing both from their on-the-wire strings. Returns nil if it doesn't
+  resolve to a var."
+  [{:keys [ns sym]}]
+  (ns-resolve (misc/as-sym ns) (misc/as-sym sym)))

--- a/src/cider/nrepl/middleware/xref.clj
+++ b/src/cider/nrepl/middleware/xref.clj
@@ -3,6 +3,7 @@
   {:author "Bozhidar Batsov"
    :added "0.22"}
   (:require
+   [cider.nrepl.middleware.util :as util]
    [cider.nrepl.middleware.util.error-handling :refer [with-op-aliases with-safe-transport]]
    [clojure.java.io :as io]
    [orchard.meta :as meta]
@@ -27,15 +28,15 @@
 (defn file-line-column [{:keys [file-url file line column]}]
   [(or file-url file) (or line 0) (or column 0)])
 
-(defn fn-refs-reply [{:keys [ns sym]}]
-  (let [var (ns-resolve (misc/as-sym ns) (misc/as-sym sym))]
+(defn fn-refs-reply [msg]
+  (let [var (util/msg->var msg)]
     {:fn-refs (->> var
                    xref/fn-refs
                    (map xref-data)
                    (sort-by file-line-column))}))
 
-(defn fn-deps-reply [{:keys [ns sym]}]
-  (let [var (ns-resolve (misc/as-sym ns) (misc/as-sym sym))]
+(defn fn-deps-reply [msg]
+  (let [var (util/msg->var msg)]
     {:fn-deps (->> var
                    xref/fn-deps
                    (map xref-data)
@@ -48,8 +49,8 @@
    :line line
    :column column})
 
-(defn who-implements-reply [{:keys [ns sym]}]
-  (let [v (ns-resolve (misc/as-sym ns) (misc/as-sym sym))
+(defn who-implements-reply [msg]
+  (let [v (util/msg->var msg)
         x (when v (deref v))]
     {:who-implements
      (cond

--- a/test/clj/cider/nrepl/middleware/util_test.clj
+++ b/test/clj/cider/nrepl/middleware/util_test.clj
@@ -1,0 +1,12 @@
+(ns cider.nrepl.middleware.util-test
+  (:require
+   [cider.nrepl.middleware.util :as util]
+   [clojure.test :refer :all]))
+
+(deftest msg->var-test
+  (testing "resolves the var named by the msg's :ns and :sym (as strings)"
+    (is (= #'clojure.core/map (util/msg->var {:ns "clojure.core" :sym "map"}))))
+  (testing "coerces symbols too"
+    (is (= #'clojure.core/map (util/msg->var {:ns 'clojure.core :sym 'map}))))
+  (testing "returns nil when the symbol doesn't resolve"
+    (is (nil? (util/msg->var {:ns "clojure.core" :sym "definitely-not-a-var"})))))


### PR DESCRIPTION
`xref`, `profile` and `trace` each resolved a var straight from a message's `:ns`/`:sym` slots, repeating the same `ns-resolve` + coerce dance. Pull it into a single `msg->var` in the middleware util ns and use it from all three.