### PR TITLE
Use is+ for response-map assertions in more tests

### DIFF
--- a/test/clj/cider/nrepl/middleware/enlighten_test.clj
+++ b/test/clj/cider/nrepl/middleware/enlighten_test.clj
@@ -2,6 +2,7 @@
   (:require
    [cider.nrepl.middleware.debug :as d]
    [cider.nrepl.middleware.enlighten :as e]
+   [cider.test-helpers :refer [is+]]
    [clojure.test :refer [deftest is]]
    [nrepl.middleware.interruptible-eval :refer [*msg*]]
    [nrepl.transport :as t]))
@@ -36,9 +37,10 @@
   (let [msg (->> (enlighten-run (with-meta '(defn enl-sample [] (+ 1 2))
                                   {:line 42 :column 5}))
                  (filter :debug-value) first)]
-    (is (some? msg) "an enlighten value was sent")
-    (is (= #{:enlighten} (:status msg)))
-    (is (= 42 (:line msg)) "positioned by the form's line, not the eval's")))
+    ;; `:line` is positioned by the form's own line, not the eval's start line.
+    (is+ {:status #{:enlighten}
+          :line 42}
+         msg)))
 
 (deftest reports-every-subexpression-value
   ;; The whole computation lights up, not just the return value and locals.

--- a/test/clj/cider/nrepl/middleware/log_test.clj
+++ b/test/clj/cider/nrepl/middleware/log_test.clj
@@ -1,5 +1,6 @@
 (ns cider.nrepl.middleware.log-test
   (:require [cider.nrepl.test-session :as session]
+            [cider.test-helpers :refer [is+]]
             [clojure.set :as set]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.test.check.generators :as gen]
@@ -92,12 +93,13 @@
   (with-each-framework [framework (frameworks)]
     (let [options {:filters {} :size 10 :threshold 10}
           appender' (add-appender framework appender options)]
-      (is (= [] (:consumers appender')))
-      (is (= (:filters options) (:filters appender')))
-      (is (= (:id appender) (:id appender')))
-      (is (= (:root-logger framework) (:logger appender')))
-      (is (= (:size options) (:size appender')))
-      (is (= (:threshold options) (:threshold appender'))))
+      (is+ {:consumers []
+            :filters (:filters options)
+            :id (:id appender)
+            :logger (:root-logger framework)
+            :size (:size options)
+            :threshold (:threshold options)}
+           appender'))
     (remove-appender framework appender)))
 
 (deftest test-add-consumer
@@ -105,8 +107,9 @@
     (with-appender [framework appender]
       (let [options {:filters {:level :INFO}}
             consumer (add-consumer framework appender options)]
-        (is (uuid-str? (:id consumer)))
-        (is (= {:level "INFO"} (:filters consumer))))
+        (is+ {:id uuid-str?
+              :filters {:level "INFO"}}
+             consumer))
       (framework/log framework {:message "a-1"})
       ;; TODO: How to receive the async log event?
       )))
@@ -115,17 +118,16 @@
   (with-each-framework [framework (frameworks)]
     (with-appender [framework appender]
       (framework/log framework {:message "a-1"})
-      (let [response (session/message {:op "cider/log-clear-appender"
-                                       :framework (:id framework)
-                                       :appender (:id appender)})]
-        (is (= #{"done"} (:status response)))
-        (is (= {:consumers []
-                :filters {}
-                :id (:id appender)
-                :logger (:root-logger framework)
-                :size 100000
-                :threshold 10}
-               (:cider/log-clear-appender response)))))))
+      (is+ {:status #{"done"}
+            :cider/log-clear-appender {:consumers []
+                                       :filters {}
+                                       :id (:id appender)
+                                       :logger (:root-logger framework)
+                                       :size 100000
+                                       :threshold 10}}
+           (session/message {:op "cider/log-clear-appender"
+                             :framework (:id framework)
+                             :appender (:id appender)})))))
 
 (deftest test-exceptions
   (with-each-framework [framework (frameworks)]
@@ -133,13 +135,12 @@
       (framework/log framework {:message "a-1" :exception (IllegalArgumentException. "BOOM")})
       (framework/log framework {:message "b-1" :exception (IllegalStateException. "BOOM")})
       (framework/log framework {:message "b-2" :exception (IllegalStateException. "BOOM")})
-      (let [response (session/message {:op "cider/log-exceptions"
-                                       :framework (:id framework)
-                                       :appender (:id appender)})]
-        (is (= #{"done"} (:status response)))
-        (is (= {:java.lang.IllegalArgumentException 1
-                :java.lang.IllegalStateException 2}
-               (:cider/log-exceptions response)))))))
+      (is+ {:status #{"done"}
+            :cider/log-exceptions {:java.lang.IllegalArgumentException 1
+                                   :java.lang.IllegalStateException 2}}
+           (session/message {:op "cider/log-exceptions"
+                             :framework (:id framework)
+                             :appender (:id appender)})))))
 
 (deftest test-frameworks
   (let [{:keys [cider/log-frameworks status]} (session/message {:op "cider/log-frameworks"})]
@@ -147,18 +148,18 @@
     (is (= ["Logback" "Java Util Logging"] (map :name log-frameworks)))
     (with-each-framework [framework (frameworks)]
       (let [framework' (find-framework log-frameworks framework)]
-        (is (= [] (:appenders framework')))
-        (is (= (:id framework) (name (:id framework'))))
-        (is (= (:javadoc-url framework) (:javadoc-url framework')))
-        (is (= (:name framework) (:name framework')))
-        (is (= (map (fn [level]
-                      {:name (name (:name level))
-                       :category (name (:category level))
-                       :weight (:weight level)})
-                    (:levels framework))
-               (:levels framework')))
-        (is (= (:website-url framework) (:website-url framework')))
-        (is (string? (:root-logger framework')))))))
+        (is+ {:appenders []
+              :javadoc-url (:javadoc-url framework)
+              :name (:name framework)
+              :levels (map (fn [level]
+                             {:name (name (:name level))
+                              :category (name (:category level))
+                              :weight (:weight level)})
+                           (:levels framework))
+              :website-url (:website-url framework)
+              :root-logger string?}
+             framework')
+        (is (= (:id framework) (name (:id framework'))))))))
 
 (deftest test-frameworks-add-appender
   (with-each-framework [framework (frameworks)]
@@ -166,18 +167,18 @@
       (let [{:keys [cider/log-frameworks status]} (session/message {:op "cider/log-frameworks"})]
         (is (= #{"done"} status))
         (let [framework' (find-framework log-frameworks framework)]
-          (is (= [{:consumers []
-                   :filters {}
-                   :id (:id appender)
-                   :logger (:root-logger framework)
-                   :size 100000
-                   :threshold 10}]
-                 (:appenders framework')))
-          (is (= (:id framework) (name (:id framework'))))
-          (is (= (:javadoc-url framework) (:javadoc-url framework')))
-          (is (= (:name framework) (:name framework')))
-          (is (= (:website-url framework) (:website-url framework')))
-          (is (string? (:root-logger framework'))))))))
+          (is+ {:appenders [{:consumers []
+                             :filters {}
+                             :id (:id appender)
+                             :logger (:root-logger framework)
+                             :size 100000
+                             :threshold 10}]
+                :javadoc-url (:javadoc-url framework)
+                :name (:name framework)
+                :website-url (:website-url framework)
+                :root-logger string?}
+               framework')
+          (is (= (:id framework) (name (:id framework')))))))))
 
 (deftest test-format-event
   (with-each-framework [framework (frameworks)]
@@ -223,12 +224,11 @@
       (with-appender [framework appender]
         (doseq [level levels]
           (framework/log framework {:level level :message (name level)}))
-        (let [response (session/message {:op "cider/log-levels"
-                                         :framework (:id framework)
-                                         :appender (:id appender)})]
-          (is (= #{"done"} (:status response)))
-          (is (= (into {} (map #(vector % 1) levels))
-                 (:cider/log-levels response))))))))
+        (is+ {:status #{"done"}
+              :cider/log-levels (into {} (map #(vector % 1) levels))}
+             (session/message {:op "cider/log-levels"
+                               :framework (:id framework)
+                               :appender (:id appender)}))))))
 
 (deftest test-loggers
   (with-each-framework [framework (frameworks)]
@@ -236,11 +236,11 @@
       (framework/log framework {:logger "LOGGER-A" :message "a-1"})
       (framework/log framework {:logger "LOGGER-B" :message "b-1"})
       (framework/log framework {:logger "LOGGER-B" :message "b-2"})
-      (let [response (session/message {:op "cider/log-loggers"
-                                       :framework (:id framework)
-                                       :appender (:id appender)})]
-        (is (= #{"done"} (:status response)))
-        (is (= {:LOGGER-A 1 :LOGGER-B 2} (:cider/log-loggers response)))))))
+      (is+ {:status #{"done"}
+            :cider/log-loggers {:LOGGER-A 1 :LOGGER-B 2}}
+           (session/message {:op "cider/log-loggers"
+                             :framework (:id framework)
+                             :appender (:id appender)})))))
 
 (deftest test-search
   (with-each-framework [framework (frameworks)]
@@ -272,12 +272,12 @@
       (let [options {:filters {:exceptions ["java.lang.IllegalStateException"]}}
             events (search-events framework appender options)]
         (is (= 1 (count events)))
-        (let [event (first events)]
-          (is (uuid-str? (:id event)))
-          (is (string? (:level event)))
-          (is (string? (:logger event)))
-          (is (= "a-3" (:message event)))
-          (is (int? (:timestamp event))))))))
+        (is+ {:id uuid-str?
+              :level string?
+              :logger string?
+              :message "a-3"
+              :timestamp int?}
+             (first events))))))
 
 (deftest test-search-by-pattern
   (with-each-framework [framework (frameworks)]
@@ -287,12 +287,12 @@
       (framework/log framework {:message "a-3"})
       (let [events (search-events framework appender {:filters {:pattern "a-3"}})]
         (is (= 1 (count events)))
-        (let [event (first events)]
-          (is (uuid-str? (:id event)))
-          (is (= "INFO" (:level event)))
-          (is (string? (:logger event)))
-          (is (= "a-3" (:message event)))
-          (is (int? (:timestamp event))))))))
+        (is+ {:id uuid-str?
+              :level "INFO"
+              :logger string?
+              :message "a-3"
+              :timestamp int?}
+             (first events))))))
 
 (deftest test-search-by-start-and-end-time
   (with-each-framework [framework (frameworks)]
@@ -307,12 +307,12 @@
                                  :end-time (dec (:timestamp event-3))}}
               events (search-events framework appender options)]
           (is (= 1 (count events)))
-          (let [event (first events)]
-            (is (= (:id event-2) (:id event)))
-            (is (= "INFO" (:level event)))
-            (is (string? (:logger event)))
-            (is (= "a-2" (:message event)))
-            (is (int? (:timestamp event)))))))))
+          (is+ {:id (:id event-2)
+                :level "INFO"
+                :logger string?
+                :message "a-2"
+                :timestamp int?}
+               (first events)))))))
 
 (deftest test-threads
   (with-each-framework [framework (frameworks)]
@@ -352,9 +352,9 @@
                        :framework (:id framework)
                        :appender (:id appender)
                        :consumer (:id consumer)})]
-        (is (= #{"done"} (:status response)))
-        (is (= {:id (:id consumer)}
-               (:cider/log-remove-consumer response)))
+        (is+ {:status #{"done"}
+              :cider/log-remove-consumer {:id (:id consumer)}}
+             response)
         (let [{:keys [cider/log-frameworks status]} (session/message {:op "cider/log-frameworks"})]
           (is (= #{"done"} status))
           (is (= [{:consumers []
@@ -375,11 +375,12 @@
                        :framework (:id framework)
                        :size 2
                        :threshold 0})]
-        (is (= #{"done"} (:status response)))
+        (is+ {:status #{"done"}
+              :cider/log-update-appender {:filters {:pattern "A.*"}
+                                          :size 2
+                                          :threshold 0}}
+             response)
         (let [appender (:cider/log-update-appender response)]
-          (is (= {:pattern "A.*"} (:filters appender)))
-          (is (= 2 (:size appender)))
-          (is (= 0 (:threshold appender)))
           (framework/log framework {:message "A1"})
           (framework/log framework {:message "A2"})
           (framework/log framework {:message "A3"})
@@ -402,10 +403,10 @@
                        :appender (:id appender)
                        :consumer (:id consumer)
                        :filters {:level :DEBUG}})]
-        (is (= #{"done"} (:status response)))
-        (is (= {:id (:id consumer)
-                :filters {:level "DEBUG"}}
-               (:cider/log-update-consumer response)))
+        (is+ {:status #{"done"}
+              :cider/log-update-consumer {:id (:id consumer)
+                                          :filters {:level "DEBUG"}}}
+             response)
         (framework/log framework {:message "B1" :level :DEBUG})))))
 
 (defn log-something [framework & [^long n ^long sleep]]

--- a/test/clj/cider/nrepl/middleware/macroexpand_test.clj
+++ b/test/clj/cider/nrepl/middleware/macroexpand_test.clj
@@ -3,6 +3,7 @@
   (:require
    [cider.nrepl]
    [cider.nrepl.test-session :as session]
+   [cider.test-helpers :refer :all]
    [clojure.set :as set]
    [clojure.string]
    [clojure.test :refer :all]
@@ -20,38 +21,38 @@
 
 (deftest expander-option-test
   (testing "macroexpand-1 expander works"
-    (let [{:keys [expansion status]} (session/message {:op "cider/macroexpand"
-                                                       :expander "macroexpand-1"
-                                                       :code (:expr code)
-                                                       :display-namespaces "none"})]
-      (is (= (:expanded-1 code) expansion))
-      (is (= #{"done"} status))))
+    (is+ {:status #{"done"}
+          :expansion (:expanded-1 code)}
+         (session/message {:op "cider/macroexpand"
+                           :expander "macroexpand-1"
+                           :code (:expr code)
+                           :display-namespaces "none"})))
 
   (testing "error handling works"
-    (let [{:keys [status err ex]} (session/message {:op "cider/macroexpand"
-                                                    :expander "macroexpand-1"
-                                                    ;; A faulty sexpr:
-                                                    :code "(let 1)"
-                                                    :display-namespaces "none"})]
-      (is (string? err))
-      (is (string? ex))
-      (is (= #{"macroexpand-error" "done"} status))))
+    (is+ {:status #{"macroexpand-error" "done"}
+          :err string?
+          :ex string?}
+         (session/message {:op "cider/macroexpand"
+                           :expander "macroexpand-1"
+                           ;; A faulty sexpr:
+                           :code "(let 1)"
+                           :display-namespaces "none"})))
 
   (testing "macroexpand expander works"
-    (let [{:keys [expansion status]} (session/message {:op "cider/macroexpand"
-                                                       :expander "macroexpand"
-                                                       :code (:expr code)
-                                                       :display-namespaces "none"})]
-      (is (= (:expanded code) expansion))
-      (is (= #{"done"} status))))
+    (is+ {:status #{"done"}
+          :expansion (:expanded code)}
+         (session/message {:op "cider/macroexpand"
+                           :expander "macroexpand"
+                           :code (:expr code)
+                           :display-namespaces "none"})))
 
   (testing "macroexpand-all expander works"
-    (let [{:keys [expansion status]} (session/message {:op "cider/macroexpand"
-                                                       :expander "macroexpand-all"
-                                                       :code (:expr code)
-                                                       :display-namespaces "none"})]
-      (is (= (:expanded-all code) expansion))
-      (is (= #{"done"} status))))
+    (is+ {:status #{"done"}
+          :expansion (:expanded-all code)}
+         (session/message {:op "cider/macroexpand"
+                           :expander "macroexpand-all"
+                           :code (:expr code)
+                           :display-namespaces "none"})))
 
   (testing "macroexpand-step expander works"
     (letfn [(mstep [code]
@@ -65,35 +66,33 @@
         (is (= (:expanded-all code) (nth expansions 6))))))
 
   (testing "macroexpand is the default expander"
-    (let [{:keys [expansion status]} (session/message {:op "cider/macroexpand"
-                                                       :code (:expr code)
-                                                       :display-namespaces "none"})]
-      (is (= (:expanded code) expansion))
-      (is (= #{"done"} status))))
+    (is+ {:status #{"done"}
+          :expansion (:expanded code)}
+         (session/message {:op "cider/macroexpand"
+                           :code (:expr code)
+                           :display-namespaces "none"})))
 
   (testing "invalid expander"
-    (let [{:keys [err ex status pp-stacktrace]} (session/message {:op "cider/macroexpand"
-                                                                  :expander "foo"
-                                                                  :code "(defn x [] nil)"})]
-      (is err)
-      (is ex)
-      (is (= #{"done" "macroexpand-error"} status))
-      (is pp-stacktrace))))
+    (is+ {:status #{"done" "macroexpand-error"}
+          :err some?
+          :ex some?
+          :pp-stacktrace some?}
+         (session/message {:op "cider/macroexpand"
+                           :expander "foo"
+                           :code "(defn x [] nil)"}))))
 
 (defmacro ^:private lazy-test-macro []
   `(list {:a ~@(lazy-seq [(ns-name *ns*)])}))
 
 (deftest lazy-expand-test
   (testing "lazy macroexpansion expands in the correct namespace"
-    (let [{:keys [expansion status]}
-          (session/message {:op "cider/macroexpand"
-                            :expander "macroexpand"
-                            :ns "cider.nrepl.middleware.macroexpand-test"
-                            :code "(lazy-test-macro)"
-                            :display-namespaces "none"})]
-      (is (= "(list {:a cider.nrepl.middleware.macroexpand-test})"
-             expansion))
-      (is (= #{"done"} status)))))
+    (is+ {:status #{"done"}
+          :expansion "(list {:a cider.nrepl.middleware.macroexpand-test})"}
+         (session/message {:op "cider/macroexpand"
+                           :expander "macroexpand"
+                           :ns "cider.nrepl.middleware.macroexpand-test"
+                           :code "(lazy-test-macro)"
+                           :display-namespaces "none"}))))
 
 ;; Tests for the three possible values of the display-namespaces option:
 ;; "qualified", "none" and "tidy"
@@ -113,63 +112,59 @@
 
 (deftest display-namespaces-option-test
   (testing "macroexpand-1 expander with display-namespaces: qualified"
-    (let [{:keys [expansion status]} (session/message {:op "cider/macroexpand"
-                                                       :expander "macroexpand-1"
-                                                       :code "(tidy-test-macro)"
-                                                       :ns "cider.nrepl.middleware.macroexpand-test"
-                                                       :display-namespaces "qualified"})]
-      (is (= "(clojure.test/deftest\n  test-foo\n  (clojure.test/is (clojure.core/zero? 0))\n  (clojure.test/is\n    (clojure.core/nil? cider.nrepl.middleware.macroexpand-test/zipmap))\n  (clojure.test/is (clojure.string/blank? \"\"))\n  (clojure.test/is\n    (clojure.core/=\n      cider.nrepl.middleware.macroexpand-test/my-set\n      (clojure.set/intersection\n        (clojure.core/hash-set 1 2 3)\n        (clojure.core/hash-set 2 3 4)))))"
-             expansion))
-      (is (= #{"done"} status))))
+    (is+ {:status #{"done"}
+          :expansion "(clojure.test/deftest\n  test-foo\n  (clojure.test/is (clojure.core/zero? 0))\n  (clojure.test/is\n    (clojure.core/nil? cider.nrepl.middleware.macroexpand-test/zipmap))\n  (clojure.test/is (clojure.string/blank? \"\"))\n  (clojure.test/is\n    (clojure.core/=\n      cider.nrepl.middleware.macroexpand-test/my-set\n      (clojure.set/intersection\n        (clojure.core/hash-set 1 2 3)\n        (clojure.core/hash-set 2 3 4)))))"}
+         (session/message {:op "cider/macroexpand"
+                           :expander "macroexpand-1"
+                           :code "(tidy-test-macro)"
+                           :ns "cider.nrepl.middleware.macroexpand-test"
+                           :display-namespaces "qualified"})))
 
   (testing "qualified is the default display-namespaces"
-    (let [{:keys [expansion status]} (session/message {:op "cider/macroexpand"
-                                                       :expander "macroexpand-1"
-                                                       :code "(tidy-test-macro)"
-                                                       :ns "cider.nrepl.middleware.macroexpand-test"})]
-      (is (= "(clojure.test/deftest\n  test-foo\n  (clojure.test/is (clojure.core/zero? 0))\n  (clojure.test/is\n    (clojure.core/nil? cider.nrepl.middleware.macroexpand-test/zipmap))\n  (clojure.test/is (clojure.string/blank? \"\"))\n  (clojure.test/is\n    (clojure.core/=\n      cider.nrepl.middleware.macroexpand-test/my-set\n      (clojure.set/intersection\n        (clojure.core/hash-set 1 2 3)\n        (clojure.core/hash-set 2 3 4)))))"
-             expansion))
-      (is (= #{"done"} status))))
+    (is+ {:status #{"done"}
+          :expansion "(clojure.test/deftest\n  test-foo\n  (clojure.test/is (clojure.core/zero? 0))\n  (clojure.test/is\n    (clojure.core/nil? cider.nrepl.middleware.macroexpand-test/zipmap))\n  (clojure.test/is (clojure.string/blank? \"\"))\n  (clojure.test/is\n    (clojure.core/=\n      cider.nrepl.middleware.macroexpand-test/my-set\n      (clojure.set/intersection\n        (clojure.core/hash-set 1 2 3)\n        (clojure.core/hash-set 2 3 4)))))"}
+         (session/message {:op "cider/macroexpand"
+                           :expander "macroexpand-1"
+                           :code "(tidy-test-macro)"
+                           :ns "cider.nrepl.middleware.macroexpand-test"})))
 
   (testing "macroexpand-1 expander with display-namespaces: none"
-    (let [{:keys [expansion status]} (session/message {:op "cider/macroexpand"
-                                                       :expander "macroexpand-1"
-                                                       :code "(tidy-test-macro)"
-                                                       :ns "cider.nrepl.middleware.macroexpand-test"
-                                                       :display-namespaces "none"})]
-      (is (= "(deftest\n  test-foo\n  (is (zero? 0))\n  (is (nil? zipmap))\n  (is (blank? \"\"))\n  (is (= my-set (intersection (hash-set 1 2 3) (hash-set 2 3 4)))))"
-             expansion))
-      (is (= #{"done"} status))))
+    (is+ {:status #{"done"}
+          :expansion "(deftest\n  test-foo\n  (is (zero? 0))\n  (is (nil? zipmap))\n  (is (blank? \"\"))\n  (is (= my-set (intersection (hash-set 1 2 3) (hash-set 2 3 4)))))"}
+         (session/message {:op "cider/macroexpand"
+                           :expander "macroexpand-1"
+                           :code "(tidy-test-macro)"
+                           :ns "cider.nrepl.middleware.macroexpand-test"
+                           :display-namespaces "none"})))
 
   (testing "macroexpand-1 expander with display-namespaces: tidy"
-    (let [{:keys [expansion status]} (session/message {:op "cider/macroexpand"
-                                                       :expander "macroexpand-1"
-                                                       :code "(tidy-test-macro)"
-                                                       :ns "cider.nrepl.middleware.macroexpand-test"
-                                                       :display-namespaces "tidy"})]
-      (is (= "(deftest\n  test-foo\n  (is (clojure.core/zero? 0))\n  (is (nil? zipmap))\n  (is (clojure.string/blank? \"\"))\n  (is (= my-set (set/intersection (hash-set 1 2 3) (hash-set 2 3 4)))))"
-             expansion))
-      (is (= #{"done"} status))))
+    (is+ {:status #{"done"}
+          :expansion "(deftest\n  test-foo\n  (is (clojure.core/zero? 0))\n  (is (nil? zipmap))\n  (is (clojure.string/blank? \"\"))\n  (is (= my-set (set/intersection (hash-set 1 2 3) (hash-set 2 3 4)))))"}
+         (session/message {:op "cider/macroexpand"
+                           :expander "macroexpand-1"
+                           :code "(tidy-test-macro)"
+                           :ns "cider.nrepl.middleware.macroexpand-test"
+                           :display-namespaces "tidy"})))
 
   (testing "invalid display-namespaces"
-    (let [{:keys [err ex status pp-stacktrace]} (session/message {:op "cider/macroexpand"
-                                                                  :code "(defn x [] nil)"
-                                                                  :display-namespaces "foo"})]
-      (is err)
-      (is ex)
-      (is (= #{"done" "macroexpand-error"} status))
-      (is pp-stacktrace))))
+    (is+ {:status #{"done" "macroexpand-error"}
+          :err some?
+          :ex some?
+          :pp-stacktrace some?}
+         (session/message {:op "cider/macroexpand"
+                           :code "(defn x [] nil)"
+                           :display-namespaces "foo"}))))
 
 (deftest print-meta-option-test
   (testing "macroexpand-1 expander with print-meta: true"
-    (let [{:keys [expansion status]} (session/message {:op "cider/macroexpand"
-                                                       :expander "macroexpand-1"
-                                                       :code "(defn x [] nil)"
-                                                       :ns "cider.nrepl.middleware.macroexpand-test"
-                                                       :display-namespaces "tidy"
-                                                       :print-meta "true"})]
-      (is (= "(def ^{:arglists (quote ([]))} x (fn ([] nil)))" expansion))
-      (is (= #{"done"} status)))))
+    (is+ {:status #{"done"}
+          :expansion "(def ^{:arglists (quote ([]))} x (fn ([] nil)))"}
+         (session/message {:op "cider/macroexpand"
+                           :expander "macroexpand-1"
+                           :code "(defn x [] nil)"
+                           :ns "cider.nrepl.middleware.macroexpand-test"
+                           :display-namespaces "tidy"
+                           :print-meta "true"}))))
 
 (deftest print-mw-before-macroexpand-mw-test
   (testing "if print middleware ends up before macroexpand mw on the way up,
@@ -181,23 +176,23 @@ it doesn't mess up macroexpansion output"
                                    (nrepl.middleware.interruptible-eval/interruptible-eval nil))))]
       (session/session-fixture
        (fn []
-         (let [{:keys [expansion status]} (session/message {:op "cider/macroexpand"
-                                                            :expander "macroexpand-1"
-                                                            :code (:expr code)
-                                                            :display-namespaces "none"})]
+         (let [{:keys [expansion]} (session/message {:op "cider/macroexpand"
+                                                     :expander "macroexpand-1"
+                                                     :code (:expr code)
+                                                     :display-namespaces "none"})]
            (is (= (:expanded-1 code) expansion)))
 
-         (let [{:keys [expansion status]} (session/message {:op "cider/macroexpand"
-                                                            :expander "macroexpand"
-                                                            :code (:expr code)
-                                                            :display-namespaces "none"})]
+         (let [{:keys [expansion]} (session/message {:op "cider/macroexpand"
+                                                     :expander "macroexpand"
+                                                     :code (:expr code)
+                                                     :display-namespaces "none"})]
            (is (= (:expanded code) expansion))))))))
 
 (deftest deprecated-op-test
   (testing "Deprecated 'macroexpand' op still works"
-    (let [{:keys [expansion status]} (session/message {:op "macroexpand"
-                                                       :expander "macroexpand-1"
-                                                       :code (:expr code)
-                                                       :display-namespaces "none"})]
-      (is (= (:expanded-1 code) expansion))
-      (is (= #{"done"} status)))))
+    (is+ {:status #{"done"}
+          :expansion (:expanded-1 code)}
+         (session/message {:op "macroexpand"
+                           :expander "macroexpand-1"
+                           :code (:expr code)
+                           :display-namespaces "none"}))))

--- a/test/clj/cider/nrepl/middleware/trace_test.clj
+++ b/test/clj/cider/nrepl/middleware/trace_test.clj
@@ -2,6 +2,7 @@
   (:require
    [cider.nrepl.middleware.trace :refer :all]
    [cider.nrepl.test-session :as session]
+   [cider.test-helpers :refer :all]
    [clojure.test :refer :all]
    [nrepl.transport :as transport]
    [cider.test-ns.first-test-ns]))
@@ -48,10 +49,14 @@
           off (session/message {:op "cider/toggle-trace-var"
                                 :ns "cider.test-ns.first-test-ns"
                                 :sym "same-name-testing-function"})]
-      (is (= (:status on) (:status off) #{"done"}))
-      (is (= (:var-name on) (:var-name off) "#'cider.test-ns.first-test-ns/same-name-testing-function"))
-      (is (= (:var-status on) "traced"))
-      (is (= (:var-status off) "untraced"))))
+      (is+ {:status #{"done"}
+            :var-name "#'cider.test-ns.first-test-ns/same-name-testing-function"
+            :var-status "traced"}
+           on)
+      (is+ {:status #{"done"}
+            :var-name "#'cider.test-ns.first-test-ns/same-name-testing-function"
+            :var-status "untraced"}
+           off)))
 
   (testing "unresolvable"
     (let [var-err (session/message {:op "cider/toggle-trace-var"
@@ -60,8 +65,11 @@
           ns-err  (session/message {:op "cider/toggle-trace-var"
                                     :ns "cider.test-ns.no-such-ns"
                                     :sym "same-name-testing-function"})]
-      (is (= (:status var-err) (:status ns-err) #{"toggle-trace-error" "done"}))
-      (is (:var-status var-err) "not-found"))))
+      (is+ {:status #{"toggle-trace-error" "done"}
+            :var-status "not-found"}
+           var-err)
+      (is+ {:status #{"toggle-trace-error" "done"}}
+           ns-err))))
 
 (deftest integration-test-ns
   (testing "toggling"
@@ -69,14 +77,12 @@
                                 :ns "cider.test-ns.first-test-ns"})
           off (session/message {:op "cider/toggle-trace-ns"
                                 :ns "cider.test-ns.first-test-ns"})]
-      (is (= (:status on) (:status off) #{"done"}))
-      (is (= (:ns-status on) "traced"))
-      (is (= (:ns-status off) "untraced")))
+      (is+ {:status #{"done"} :ns-status "traced"} on)
+      (is+ {:status #{"done"} :ns-status "untraced"} off))
 
     (let [ns-err (session/message {:op "cider/toggle-trace-ns"
                                    :ns "cider.test-ns.missing"})]
-      (is (= (:status ns-err)  #{"done"}))
-      (is (= (:ns-status ns-err) "not-found")))))
+      (is+ {:status #{"done"} :ns-status "not-found"} ns-err))))
 
 (deftest list-traced-test
   (testing "lists the currently traced vars and namespaces"
@@ -101,16 +107,16 @@
                       :ns "cider.test-ns.first-test-ns"
                       :sym "same-name-testing-function"})
     (let [listed (session/message {:op "cider/list-traced"})]
-      (is (= (:status listed) #{"done"}))
-      (is (= (:traced-vars listed)
-             ["#'cider.test-ns.first-test-ns/same-name-testing-function"])))
+      (is+ {:status #{"done"}
+            :traced-vars ["#'cider.test-ns.first-test-ns/same-name-testing-function"]}
+           listed))
     (let [cleared (session/message {:op "cider/untrace-all"})]
-      (is (= (:status cleared) #{"done"}))
-      (is (= (:untraced-count cleared) 1)))
+      (is+ {:status #{"done"} :untraced-count 1} cleared))
     (let [listed (session/message {:op "cider/list-traced"})]
-      (is (= (:status listed) #{"done"}))
-      (is (empty? (:traced-vars listed)))
-      (is (empty? (:traced-nses listed))))))
+      (is+ {:status #{"done"}
+            :traced-vars empty?
+            :traced-nses empty?}
+           listed))))
 
 (deftest trace-subscribe-test
   (testing "subscribe streams events for traced calls, unsubscribe stops them"
@@ -148,15 +154,13 @@
           off (session/message {:op "toggle-trace-var"
                                 :ns "cider.test-ns.first-test-ns"
                                 :sym "same-name-testing-function"})]
-      (is (= (:status on) (:status off) #{"done"}))
-      (is (= (:var-status on) "traced"))
-      (is (= (:var-status off) "untraced"))))
+      (is+ {:status #{"done"} :var-status "traced"} on)
+      (is+ {:status #{"done"} :var-status "untraced"} off)))
 
   (testing "Deprecated 'toggle-trace-ns' op still works"
     (let [on  (session/message {:op "toggle-trace-ns"
                                 :ns "cider.test-ns.first-test-ns"})
           off (session/message {:op "toggle-trace-ns"
                                 :ns "cider.test-ns.first-test-ns"})]
-      (is (= (:status on) (:status off) #{"done"}))
-      (is (= (:ns-status on) "traced"))
-      (is (= (:ns-status off) "untraced")))))
+      (is+ {:status #{"done"} :ns-status "traced"} on)
+      (is+ {:status #{"done"} :ns-status "untraced"} off))))

--- a/test/clj/cider/nrepl/version_test.clj
+++ b/test/clj/cider/nrepl/version_test.clj
@@ -1,13 +1,15 @@
 (ns cider.nrepl.version-test
   (:require
    [cider.nrepl.version :as v]
+   [cider.test-helpers :refer :all]
    [clojure.test :refer :all]))
 
 (deftest version-string-test
   (is (string? v/version-string)))
 
 (deftest version-test
-  (is (contains? v/version :major))
-  (is (contains? v/version :minor))
-  (is (contains? v/version :incremental))
-  (is (contains? v/version :version-string)))
+  (is+ {:major some?
+        :minor some?
+        :incremental some?
+        :version-string some?}
+       v/version))


### PR DESCRIPTION
Targeted follow-up to the `is+` investigation - not a blanket migration. Converts the multi-key response-map assertions in the log, macroexpand, trace, version and enlighten tests to `is+`, collapsing each status-plus-payload pair into one structural match. Better to read, and you get a real matcher-combinators diff on failure instead of a bare `false`.

Exact-equality, count, and derived-value assertions stay as plain `=` - partial matching there would only weaken them. Converting the trace "unresolvable" block also fixes a latent `(is x msg)` assertion that never actually compared its value.

Net ~100 fewer assertions for the same coverage.