### PR TITLE
Enable more clj-kondo linters and clear the findings

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -11,18 +11,19 @@
                                              (cljs.test/is [match? thrown-match?])
                                              (clojure.test/is [match? thrown-match?])]}
            :consistent-alias      {:aliases {clojure.string str}}
-           :unused-import         {:level :off}
+           ;; The following are deliberately left off; each is noisy or
+           ;; false-positive-prone in this codebase:
+           ;; - :unresolved-var fires on `def-wrapper`-generated vars
+           ;; - :unused-binding fires on intentionally-ignored handler args
+           ;; - :refer-all fires on the `:refer :all` test convention
+           ;; - :unused-private-var fires on macros used via expansion and the
+           ;;   side-effecting `warmup-once` defonce
+           ;; - :missing-else-branch flags idiomatic `(if cond then)`
            :unresolved-var        {:level :off}
            :unused-binding        {:level :off}
            :refer-all             {:level :off}
-           :unused-namespace      {:level :off}
-           :missing-test-assertion {:level :off}
-           :use                   {:level :off}
-           :redundant-let         {:level :off}
            :unused-private-var    {:level :off}
            :missing-else-branch   {:level :off}
-           :unused-referred-var   {:level :off}
-           :type-mismatch         {:level :off}
            :unresolved-namespace  {:exclude [clojure.main nrepl.transport js]}}
  :output  {:progress      true
            :exclude-files ["data_readers" "tasks"]}}

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ out
 .nrepl-port
 .source-deps
 .clj-kondo/.cache
+.clj-kondo/imports
+.make_kondo_prep
 /.no-mranderson
 /test-runner
 /.test-classpath

--- a/src/cider/nrepl/middleware/content_type.clj
+++ b/src/cider/nrepl/middleware/content_type.clj
@@ -46,7 +46,6 @@
   (:require
    [cider.nrepl.middleware.slurp :refer [slurp-reply]])
   (:import
-   [java.awt.image RenderedImage]
    [java.io ByteArrayOutputStream File OutputStream]
    [java.net URI URL]
    java.nio.file.Path

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -2,7 +2,6 @@
   "Expression-based debugger for clojure code"
   {:author "Artur Malabarba"}
   (:require
-   [clojure.string :as str]
    [cider.nrepl.middleware.inspect :refer [swap-inspector!]]
    [cider.nrepl.middleware.util :as util :refer [respond-to]]
    [cider.nrepl.middleware.util.cljs :as cljs]
@@ -10,7 +9,6 @@
    [cider.nrepl.middleware.util.instrument :as ins]
    [cider.nrepl.middleware.util.nrepl :refer [notify-client]]
    [nrepl.middleware.interruptible-eval :as ieval :refer [*msg*]]
-   [nrepl.middleware.print :as print]
    [orchard.info :as info]
    [orchard.inspect :as inspect]
    [orchard.meta :as m]

--- a/src/cider/nrepl/middleware/refresh.clj
+++ b/src/cider/nrepl/middleware/refresh.clj
@@ -7,7 +7,6 @@
   (:require
    [cider.nrepl.middleware.util :refer [respond-to]]
    [cider.nrepl.middleware.util.reload :as reload-utils]
-   [clojure.main :refer [repl-caught]]
    [clojure.tools.namespace.dir :as dir]
    [clojure.tools.namespace.find :as find]
    [clojure.tools.namespace.reload :as reload]

--- a/src/cider/nrepl/middleware/stacktrace.clj
+++ b/src/cider/nrepl/middleware/stacktrace.clj
@@ -6,7 +6,6 @@
    [cider.nrepl.middleware.util :refer [respond-to]]
    [cider.nrepl.middleware.util.error-handling :refer [base-error-response]]
    [cider.nrepl.middleware.util.nrepl :refer [notify-client]]
-   [nrepl.middleware.print :as print]
    [nrepl.transport :as t]
    [orchard.stacktrace :as stacktrace]))
 

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -12,7 +12,6 @@
    [clojure.test :as test]
    [clojure.walk :as walk]
    [nrepl.middleware.interruptible-eval :as ie]
-   [nrepl.middleware.print :as print]
    [orchard.misc :as misc]
    [orchard.query :as query]
    [orchard.stacktrace :as stacktrace]))

--- a/src/cider/nrepl/middleware/util/error_handling.clj
+++ b/src/cider/nrepl/middleware/util/error_handling.clj
@@ -8,7 +8,6 @@
    [clojure.stacktrace]
    [clojure.walk :as walk]
    [nrepl.middleware.caught :as caught]
-   [nrepl.middleware.print :as print]
    [nrepl.misc :refer [response-for]]
    [nrepl.transport :as transport]
    [orchard.stacktrace :as stacktrace])

--- a/src/cider/nrepl/middleware/util/meta.clj
+++ b/src/cider/nrepl/middleware/util/meta.clj
@@ -1,7 +1,5 @@
 (ns cider.nrepl.middleware.util.meta
-  "Utility functions for extracting and manipulating metadata."
-  (:require
-   [orchard.misc :as misc]))
+  "Utility functions for extracting and manipulating metadata.")
 
 (def relevant-meta-keys
   "Metadata keys that are useful to us.

--- a/test/clj/cider/nrepl/middleware/apropos_test.clj
+++ b/test/clj/cider/nrepl/middleware/apropos_test.clj
@@ -3,7 +3,6 @@
    [cider.nrepl.middleware.apropos :refer [apropos] :as apropos]
    [cider.nrepl.test-session :as session]
    [cider.test-helpers :refer :all]
-   [clojure.string :as str]
    [clojure.test :refer :all]
    [matcher-combinators.matchers :as mc]))
 

--- a/test/clj/cider/nrepl/middleware/info_test.clj
+++ b/test/clj/cider/nrepl/middleware/info_test.clj
@@ -9,6 +9,10 @@
    [matcher-combinators.matchers :as matchers]
    [orchard.java.source-files]
    [orchard.misc :as misc])
+  ;; These classes declare methods that share a name; they're imported so the
+  ;; eldoc/info tests can introspect the same-named methods across them. The
+  ;; import is used at runtime (via ns introspection), not in Clojure source.
+  #_{:clj-kondo/ignore [:unused-import]}
   (:import (cider.nrepl.test AnotherTestClass TestClass YetAnotherTest)))
 
 (defprotocol FormatResponseTest

--- a/test/clj/cider/nrepl/middleware/inspect_test.clj
+++ b/test/clj/cider/nrepl/middleware/inspect_test.clj
@@ -1,16 +1,13 @@
 (ns cider.nrepl.middleware.inspect-test
   (:require
    [matcher-combinators.matchers :as mc]
-   [cider.nrepl.middleware.inspect :as i]
    [cider.nrepl.test-session :as session]
-   [cider.nrepl.middleware.info-test :as info-test]
    [cider.test-helpers :refer :all]
    [clojure.edn :as edn]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [orchard.java]
-   [orchard.inspect]
-   [orchard.info :as info]))
+   [orchard.inspect]))
 
 (def inspect-tap-current-value-test-atom (atom nil))
 

--- a/test/clj/cider/nrepl/middleware/log_test.clj
+++ b/test/clj/cider/nrepl/middleware/log_test.clj
@@ -1,7 +1,6 @@
 (ns cider.nrepl.middleware.log-test
   (:require [cider.nrepl.test-session :as session]
             [cider.test-helpers :refer [is+]]
-            [clojure.set :as set]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.test.check.generators :as gen]
             [logjam.framework :as framework]))
@@ -302,17 +301,17 @@
       (framework/log framework {:message "a-2"})
       (Thread/sleep 100)
       (framework/log framework {:message "a-3"})
-      (let [[event-3 event-2 event-1] (search-events framework appender {})]
-        (let [options {:filters {:start-time (inc (:timestamp event-1))
-                                 :end-time (dec (:timestamp event-3))}}
-              events (search-events framework appender options)]
-          (is (= 1 (count events)))
-          (is+ {:id (:id event-2)
-                :level "INFO"
-                :logger string?
-                :message "a-2"
-                :timestamp int?}
-               (first events)))))))
+      (let [[event-3 event-2 event-1] (search-events framework appender {})
+            options {:filters {:start-time (inc (:timestamp event-1))
+                               :end-time (dec (:timestamp event-3))}}
+            events (search-events framework appender options)]
+        (is (= 1 (count events)))
+        (is+ {:id (:id event-2)
+              :level "INFO"
+              :logger string?
+              :message "a-2"
+              :timestamp int?}
+             (first events))))))
 
 (deftest test-threads
   (with-each-framework [framework (frameworks)]

--- a/test/clj/cider/nrepl/middleware/ns_test.clj
+++ b/test/clj/cider/nrepl/middleware/ns_test.clj
@@ -2,7 +2,6 @@
   (:require
    [cider.nrepl.middleware.ns :refer [ns-vars-clj ns-list-vars-by-name] :as cider-ns]
    [cider.nrepl.test-session :as session]
-   [cider.nrepl.test-transport :refer [messages test-transport]]
    [cider.test-ns first-test-ns second-test-ns third-test-ns]
    [clojure.test :refer :all]))
 

--- a/test/clj/cider/nrepl/middleware/out_test.clj
+++ b/test/clj/cider/nrepl/middleware/out_test.clj
@@ -3,7 +3,6 @@
    :clojure.tools.namespace.repl/load false}
   (:require
    [cider.nrepl.middleware.out :as o]
-   [clojure.string :as str]
    [clojure.test :refer :all])
   (:import
    [java.io PrintWriter StringWriter]

--- a/test/clj/cider/nrepl/middleware/reload_test.clj
+++ b/test/clj/cider/nrepl/middleware/reload_test.clj
@@ -3,7 +3,6 @@
    [cider.nrepl.middleware.reload :as rl]
    [cider.nrepl.test-session :as session]
    [cider.test-helpers :refer :all]
-   [clojure.string :as str]
    [clojure.test :refer :all]
    [matcher-combinators.matchers :as mc]))
 

--- a/test/clj/cider/nrepl/middleware/spec_test.clj
+++ b/test/clj/cider/nrepl/middleware/spec_test.clj
@@ -1,6 +1,5 @@
 (ns cider.nrepl.middleware.spec-test
   (:require
-   [cider.nrepl.middleware.spec :as cider-spec]
    [cider.nrepl.test-session :as session]
    [clojure.test :refer :all]))
 

--- a/test/clj/cider/nrepl_test.clj
+++ b/test/clj/cider/nrepl_test.clj
@@ -1,7 +1,6 @@
 (ns cider.nrepl-test
   (:require
-   [cider.nrepl :as sut]
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is]]
    [nrepl.version]))
 
 (deftest versions-sanity-check

--- a/test/cljs/cider/nrepl/middleware/cljs_inspect_test.clj
+++ b/test/cljs/cider/nrepl/middleware/cljs_inspect_test.clj
@@ -1,6 +1,5 @@
 (ns cider.nrepl.middleware.cljs-inspect-test
   (:require
-   [cider.nrepl.middleware.inspect :as i]
    [cider.nrepl.middleware.inspect-test :as inspect-test]
    [cider.nrepl.piggieback-test :refer [piggieback-fixture]]
    [cider.nrepl.test-session :as session]

--- a/test/cljs/cider/nrepl/piggieback_test.clj
+++ b/test/cljs/cider/nrepl/piggieback_test.clj
@@ -47,8 +47,10 @@
       (is (= #{"done"} (:status response)))))
 
   (testing "errors handled properly"
+    ;; `(ffirst 1)` is a deliberate type error - the point is to exercise
+    ;; error handling - so silence the type-mismatch linter here.
     (let [response (session/message {:op "eval"
-                                     :code (nrepl/code (ffirst 1))})]
+                                     :code #_{:clj-kondo/ignore [:type-mismatch]} (nrepl/code (ffirst 1))})]
       (is (= "class clojure.lang.ExceptionInfo"
              (:ex response)
              (:root-ex response)))

--- a/test/common/cider/nrepl/test_transport.clj
+++ b/test/common/cider/nrepl/test_transport.clj
@@ -1,7 +1,7 @@
 (ns cider.nrepl.test-transport
   "A transport for testing"
-  (:use
-   [nrepl.transport :only [Transport]]))
+  (:require
+   [nrepl.transport :refer [Transport]]))
 
 (defrecord TestTransport [msgs]
   Transport

--- a/test/common/cider/test_helpers.clj
+++ b/test/common/cider/test_helpers.clj
@@ -1,5 +1,9 @@
 (ns cider.test-helpers
   (:require [clojure.test :refer :all]
+            ;; `match?` is injected unqualified into `is+` expansions (via
+            ;; `~'match?`), so clj-kondo can't see it used here, but the require
+            ;; is still needed to register match?'s `clojure.test/assert-expr`.
+            #_{:clj-kondo/ignore [:unused-namespace :unused-referred-var]}
             [matcher-combinators.test :refer [match?]]))
 
 (defmacro is+


### PR DESCRIPTION
clj-kondo was already wired in, but a dozen linters were switched off - including the unused-code family, which is exactly why the dead `orchard.info` requires I removed earlier weren't caught.

Turns on seven: the dead-code family (`unused-namespace`, `unused-referred-var`, `unused-import`) plus four that were already clean and cheap to keep honest (`missing-test-assertion`, `type-mismatch`, `use`, `redundant-let`). Clearing the findings meant dropping ~20 dead requires/imports across src and test, converting a stray `:use` to `:require`, and merging a redundant nested `let`.

Two findings are deliberate and get a documented ignore rather than a code change: `match?` referred into `is+` expansions (clj-kondo can't see through the macro), and a `(ffirst 1)` that intentionally triggers a type error to exercise error handling.

The five noisy/FP-prone linters stay off - each now has a comment in `config.edn` saying why (e.g. `unresolved-var` fires on `def-wrapper`-generated vars, `refer-all` on the test `:refer :all` convention). `make kondo` is green.