### PR TITLE
Make cljs compiler-env resolution pluggable, add shadow provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* [#1003](https://github.com/clojure-emacs/cider-nrepl/pull/1003): Resolve the ClojureScript compiler environment through a provider chain instead of piggieback alone, adding a shadow-cljs provider so the static-analysis ops keep working in a shadow REPL that doesn't load piggieback.
 * [#994](https://github.com/clojure-emacs/cider-nrepl/pull/994): Error handling: catch `Throwable` (not just `Exception`) when handling ops, so an op that hits an `Error` (e.g. `StackOverflowError`, `AssertionError`) returns a proper error response instead of hanging the client without a terminal `done`. The stacktrace ops, which reply outside the shared error machinery, got the same guarantee.
 * [#993](https://github.com/clojure-emacs/cider-nrepl/pull/993): Fix op descriptor metadata: document `cider/get-state`'s return values (previously rendered blank) and correct the `cider/log-remove-consumer` return key.
 * [#992](https://github.com/clojure-emacs/cider-nrepl/pull/992): Bump `cljfmt` to 0.16.4 (from 0.9.2).

--- a/doc/modules/ROOT/pages/internals.adoc
+++ b/doc/modules/ROOT/pages/internals.adoc
@@ -29,16 +29,132 @@ for some operation to be performed for some unresolved symbol in the current nam
 
 == ClojureScript Support
 
-Currently the ClojureScript support relies on inspecting the ClojureScript compiler
-state. `cider-nrepl` would fetch the compiler state from Piggieback and pass it
-to the underlying libraries (e.g. `orchard` and `clj-suitable`) that do something useful with it.
+ClojureScript support hinges on one thing: getting hold of the ClojureScript
+*compiler environment* for the session. `cider-nrepl` runs in a Clojure context,
+so it can't analyze ClojureScript on its own - it hands the compiler env to the
+underlying libraries (`orchard`, `clj-suitable`, the `cljs.analyzer`) that know
+how to read it.
 
-Unfortunately the majority of the middleware don't support ClojureScript
-currently, as they are implemented in terms of Clojure-only libraries. Another
-roadblock is that `cider-nrepl` runs in a Clojure context and you have to jump
-through some hoops to evaluate ClojureScript code from it (e.g. pipe it to
-Piggieback's `eval` or evaluate it against the ClojureScript runtime directly as
-a string). Hopefully this will change down the road.
+=== The compiler-env seam
+
+Every ClojureScript-aware op funnels through a single function,
+`cider.nrepl.middleware.util.cljs/grab-cljs-env`. It resolves the session's
+compiler env through an ordered *provider chain* (`cljs-env-providers`); the
+first provider to return a non-nil value wins:
+
+[horizontal]
+Piggieback:: Reads the compiler-env atom from the session var
+`cider.piggieback/*cljs-compiler-env*`. Tried first, so existing setups behave
+exactly as they always have.
+shadow-cljs:: Reads the build id from shadow's `*repl-state*` and fetches the
+build's compiler env via the public `shadow.cljs.devtools.api/compiler-env`.
+
+New backends (figwheel, weasel, ...) would plug in as additional providers.
+
+=== Two kinds of ops
+
+It helps to split the ClojureScript ops in two:
+
+* *Static-analysis ops* (`info`, `complete`, `eldoc`, `ns-*`, analyzer-based
+  `macroexpand`) only need to *read* the compiler env. These work through
+  `grab-cljs-env` and don't evaluate anything.
+* *Eval-delegating ops* (`test` via `cljs.test`, eval-based `macroexpand`,
+  dynamic completion) need to *run* ClojureScript in the runtime. `cider-nrepl`
+  never evaluates ClojureScript itself - it relies on whatever cljs-eval
+  middleware is in the stack (Piggieback or shadow's own) to do that.
+
+=== A note on shadow-cljs
+
+shadow-cljs is the only major environment with its own nREPL server rather than
+a Piggieback client. Two things are worth knowing:
+
+* It evaluates ClojureScript by forwarding code to the live build worker and its
+  connected JS runtime - it does **not** run a `cljs.repl` loop the way
+  Piggieback does. This is why its eval-delegating ops "just work" once a build
+  is running.
+* It still pulls Piggieback in transitively and populates
+  `cider.piggieback/*cljs-compiler-env*` itself (with a deref handle over the
+  build's live compiler env) specifically so that tools like `cider-nrepl` keep
+  working. In other words, on a default shadow setup the *Piggieback* provider
+  already serves shadow; the dedicated shadow provider is a fallback for setups
+  where that var isn't populated.
+
+A small sample project for exercising shadow support by hand lives under
+`test/shadow-cljs/`.
+
+=== Toward first-class shadow support
+
+A few things stand between the current "works via the Piggieback shim" state and
+genuinely Piggieback-independent shadow support:
+
+* *Discovering the build id.* `api/compiler-env` is public and stable. To learn
+  *which* build a session is on, we read the
+  `:shadow.cljs.devtools.server.nrepl-impl/build-id` key shadow stamps onto every
+  message it forwards - the same seam `clj-suitable` uses, and one shadow keeps
+  stable for tooling (its `set-build-id` notes the key is "kept since cider uses
+  it"). It lives in an internal namespace, though, so getting it officially
+  blessed as a public integration key is a worthwhile upstream ask.
+* *Snapshot vs. live env.* `api/compiler-env` returns a snapshot map, not the
+  live atom Piggieback exposes. That's fine for read-only static analysis (we
+  wrap it so it still derefs and tolerates the analyzer's transient swaps), but
+  it's a sharp edge for anything that expects to mutate compiler state.
+* *Eval-delegating ops.* These ride whatever cljs-eval middleware is in the
+  stack. On shadow that's shadow's own eval, which bypasses cider-nrepl's eval
+  machinery entirely - so things keyed off cider's eval path (e.g. `track-state`)
+  don't run for cljs evals (https://github.com/thheller/shadow-cljs/issues/1138[shadow-cljs#1138]).
+  A shadow-aware path could instead call the public
+  `shadow.cljs.devtools.api/cljs-eval` directly (as `clj-suitable` already does
+  for dynamic completion), but that's a larger change tracked separately.
+* *Testing.* The live shadow path can't run in CI without dragging the whole
+  shadow toolchain onto the test classpath, so it's covered by the manual
+  fixture rather than the automated suite.
+
+Those are the tractable, cider-nrepl-sized items. The deeper limitation is not
+ours to fix alone, and it's worth recording why.
+
+=== The Piggieback debate
+
+The reason shadow-cljs has to *emulate* Piggieback rather than use it goes back
+to a long-running design discussion. shadow's author summed up his position in
+https://github.com/thheller/shadow-cljs/issues/561[thheller/shadow-cljs#561]:
+Piggieback is "too coupled to `cljs.repl` and `cljs.closure`" (which shadow
+doesn't use at all,
+https://github.com/thheller/shadow-cljs/issues/249[#249]), `cljs.repl` exposes
+"no concept of a runtime or session" to hook into, and ultimately "the
+Piggieback approach is fundamentally flawed and cannot be fixed."
+
+The concrete sticking point is in
+https://github.com/nrepl/piggieback/issues/88[nrepl/piggieback#88]: Piggieback
+wraps `cljs.repl/repl`, which binds a *single* `IJavaScriptEnv` per session.
+Shadow's model is many runtimes per build - browser tabs, a node process,
+react-native, all at once - which that abstraction can't express. Both shadow
+(`shadow.remote`) and figwheel solve eval their own way; Piggieback's "make
+ClojureScript transparent by reusing the `eval`/`load-file` ops" design is
+exactly what gets in the way.
+
+Why does cider-nrepl ride the Piggieback shim at all, then? Mostly history: we
+never taught cider-nrepl shadow's own API, and shadow's author kindly offered
+the Piggieback emulation so tools would work unchanged. As discussed in
+https://github.com/clojure-emacs/clj-suitable/issues/34[clj-suitable#34], the
+shim is *basic* compatibility and not everything works through it; in an ideal
+world cider-nrepl would talk to shadow's own nREPL middleware, which exposes the
+full functionality. `suitable` already carries shadow-specific code for exactly
+this reason, rather than going through `grab-cljs-env`.
+
+The takeaway for cider-nrepl: the part we own - *reading* the compiler env for
+static analysis - is well served by the provider chain and is happily backend
+agnostic (the shadow provider here is the first shadow-aware path). The part
+that's genuinely hard - multiplexed runtimes and distinct ClojureScript ops
+instead of hijacked `eval` - lives at the nREPL/backend layer. The realistic
+improvement path is incremental: add shadow-aware code paths (as `suitable`
+does) where the Piggieback compat falls short, while first-class support
+ultimately depends on the broader story (a runtime concept in nREPL, or
+backend-specific ops). That's why this is documented as direction rather than
+promised as a feature.
+
+Beyond the env plumbing, the broader limitation remains: many middleware are
+still Clojure-only because they're implemented in terms of Clojure-only
+libraries. Widening genuine ClojureScript coverage is an ongoing effort.
 
 == Dependency obfuscation
 

--- a/src/cider/nrepl/middleware/complete.clj
+++ b/src/cider/nrepl/middleware/complete.clj
@@ -10,10 +10,6 @@
    [orchard.misc :as misc]
    [suitable.compliment.sources.cljs :as suitable-sources]))
 
-(def shadow-cljs-present?
-  (try (require 'shadow.cljs.devtools.api) true
-       (catch Throwable _ false)))
-
 ;; controls if dynamic cljs code completions are active
 (def suitable-enabled? true)
 

--- a/src/cider/nrepl/middleware/util/cljs.clj
+++ b/src/cider/nrepl/middleware/util/cljs.clj
@@ -28,27 +28,88 @@
     (conj coll pb)
     coll))
 
-(defn- cljs-env-path
-  "Returns the path in the session map for the ClojureScript compiler
-  environment used by piggieback."
-  []
-  [(resolve 'cider.piggieback/*cljs-compiler-env*)])
-
 (defn- maybe-deref
   [x]
   (if (instance? clojure.lang.IDeref x) @x x))
 
+(defn- session-binding
+  "Value bound to the dynamic var named `var-sym` in `msg`'s nREPL session, or
+  nil. Uses plain `resolve`, so a backend whose namespaces aren't loaded simply
+  yields nil instead of forcing a load. nREPL keeps a session's dynamic bindings
+  in the session map keyed by the var object, so the binding is readable outside
+  of an eval - which is exactly what the static-analysis ops need."
+  [msg var-sym]
+  (when-let [v (resolve var-sym)]
+    (some-> msg :session maybe-deref (get v))))
+
+;; --- piggieback (the original behaviour) ---------------------------------
+;; piggieback stores the compiler-env *atom* in the session under
+;; #'cider.piggieback/*cljs-compiler-env*.
+
+(defn- piggieback-cljs-env
+  [msg]
+  (session-binding msg 'cider.piggieback/*cljs-compiler-env*))
+
+;; --- shadow-cljs (without piggieback) ------------------------------------
+;; shadow exposes a build's compiler env via the *public, stable*
+;; (shadow.cljs.devtools.api/compiler-env build-id). To learn *which* build a
+;; session is on, shadow stamps every message it forwards with a
+;; :shadow.cljs.devtools.server.nrepl-impl/build-id key - the integration seam it
+;; keeps stable for tooling (its `set-build-id` notes the key is "kept since
+;; cider uses it"; clj-suitable, bundled here, reads the very same key). We fall
+;; back to shadow's internal *repl-state* session var only if that key is absent.
+;;
+;; Note current shadow-cljs pulls in piggieback transitively and itself
+;; populates piggieback's var (with an equivalent deref handle), so in practice
+;; the piggieback provider already handles shadow. This provider is the fallback
+;; for a shadow setup where that var isn't populated.
+
+(defn- shadow-build-id
+  "The shadow-cljs build id for `msg`'s session, or nil. Prefers the
+  `:shadow.cljs.devtools.server.nrepl-impl/build-id` key shadow stamps onto the
+  message; falls back to shadow's internal `*repl-state*` session var."
+  [msg]
+  (or (:shadow.cljs.devtools.server.nrepl-impl/build-id msg)
+      (some-> (session-binding msg 'shadow.cljs.devtools.server.nrepl-impl/*repl-state*)
+              maybe-deref
+              :build-id)))
+
+(defn- shadow-env-handle
+  "Adapts shadow's compiler env to the deref-able the rest of the code expects.
+  An atom/ref is used as-is; a snapshot map is wrapped in an atom so it both
+  derefs (static analysis) and tolerates the analyzer's transient swaps
+  (macroexpansion). Returns nil for nil."
+  [env]
+  (cond
+    (nil? env) nil
+    (instance? clojure.lang.IDeref env) env
+    :else (atom env)))
+
+(defn- shadow-cljs-env
+  [msg]
+  (when-let [build-id (shadow-build-id msg)]
+    (when-let [compiler-env (resolve 'shadow.cljs.devtools.api/compiler-env)]
+      (shadow-env-handle (compiler-env build-id)))))
+
+;; --- the provider chain --------------------------------------------------
+
+(def cljs-env-providers
+  "Ordered fns of a message that return a deref-able ClojureScript compiler env
+  for the session, or nil. First non-nil wins.
+
+  Piggieback is tried first so existing setups behave exactly as before; the
+  shadow-cljs provider is a fallback for a pure shadow setup that doesn't load
+  piggieback. New backends (figwheel, weasel, ...) plug in here. Rebindable for
+  testing."
+  [#'piggieback-cljs-env #'shadow-cljs-env])
+
 (defn grab-cljs-env*
   [msg]
-  (let [path (cljs-env-path)]
-    (some-> msg
-            :session
-            maybe-deref
-            (get-in path))))
+  (some #(% msg) cljs-env-providers))
 
 (defn grab-cljs-env
-  "If piggieback is active, returns the ClojureScript compiler environment for
-  the running REPL."
+  "Returns the ClojureScript compiler environment for the session's running REPL
+  (piggieback or shadow-cljs), or nil when no ClojureScript REPL is active."
   [msg]
   (maybe-deref (grab-cljs-env* msg)))
 

--- a/test/clj/cider/nrepl/middleware/reload_test.clj
+++ b/test/clj/cider/nrepl/middleware/reload_test.clj
@@ -36,8 +36,8 @@
 
 (deftest reload-all-op-test
   (testing "reload-all op works"
-    (is+ {:progress (mc/all-of #"Reloading 3 namespaces"
-                               #"Reloaded 3 namespaces in \d+ ms")
+    (is+ {:progress (mc/all-of #"Reloading 4 namespaces"
+                               #"Reloaded 4 namespaces in \d+ ms")
           :status #{"done" "ok"}}
          (session/message {:op "cider.clj-reload/reload-all"}))))
 

--- a/test/clj/cider/nrepl/middleware/util/cljs_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/cljs_test.clj
@@ -1,0 +1,86 @@
+(ns cider.nrepl.middleware.util.cljs-test
+  (:require
+   [cider.nrepl.middleware.util.cljs :as cljs]
+   [clojure.test :refer :all]))
+
+;; reach the private provider internals
+(def ^:private shadow-env-handle #'cljs/shadow-env-handle)
+(def ^:private shadow-cljs-env #'cljs/shadow-cljs-env)
+(def ^:private shadow-build-id #'cljs/shadow-build-id)
+
+(deftest provider-chain-test
+  (testing "first non-nil provider wins"
+    (with-redefs [cljs/cljs-env-providers [(constantly nil)
+                                           (constantly :env-b)
+                                           (constantly :env-c)]]
+      (is (= :env-b (cljs/grab-cljs-env* {})))))
+
+  (testing "nil when no provider matches"
+    (with-redefs [cljs/cljs-env-providers [(constantly nil) (constantly nil)]]
+      (is (nil? (cljs/grab-cljs-env* {})))))
+
+  (testing "grab-cljs-env derefs whatever the provider returns"
+    (with-redefs [cljs/cljs-env-providers [(constantly (atom {:a 1}))]]
+      (is (= {:a 1} (cljs/grab-cljs-env {}))))))
+
+(deftest shadow-env-handle-test
+  (testing "nil stays nil"
+    (is (nil? (shadow-env-handle nil))))
+
+  (testing "an existing atom/ref is used as-is"
+    (let [a (atom {:k 1})]
+      (is (identical? a (shadow-env-handle a)))))
+
+  (testing "a snapshot map is wrapped so it derefs and tolerates swaps"
+    (let [env {:cljs.analyzer/namespaces {'cljs.user {}}}
+          handle (shadow-env-handle env)]
+      (is (instance? clojure.lang.IDeref handle))
+      (is (= env @handle))
+      ;; the analyzer transiently swaps the compiler env during macroexpansion;
+      ;; that must not blow up (the write is just ephemeral here)
+      (is (= 1 (:scratch (swap! handle assoc :scratch 1)))))))
+
+(deftest shadow-build-id-test
+  ;; Fake shadow's *repl-state* var so the fallback's `resolve` finds it, without
+  ;; pulling shadow-cljs onto the test classpath.
+  (let [repl-state-var (intern (create-ns 'shadow.cljs.devtools.server.nrepl-impl)
+                               '*repl-state*)]
+    (try
+      (testing "reads the build id shadow stamps onto the message"
+        (is (= :app (shadow-build-id
+                     {:shadow.cljs.devtools.server.nrepl-impl/build-id :app}))))
+
+      (testing "falls back to shadow's *repl-state* session var"
+        (is (= :app (shadow-build-id
+                     {:session (atom {repl-state-var {:build-id :app}})}))))
+
+      (testing "the message key wins over the session var"
+        (is (= :from-msg (shadow-build-id
+                          {:shadow.cljs.devtools.server.nrepl-impl/build-id :from-msg
+                           :session (atom {repl-state-var {:build-id :from-session}})}))))
+
+      (testing "nil when neither is present"
+        (is (nil? (shadow-build-id {:session (atom {})}))))
+      (finally
+        (remove-ns 'shadow.cljs.devtools.server.nrepl-impl)))))
+
+(deftest shadow-cljs-env-test
+  ;; Fake shadow's api/compiler-env so the provider's `resolve` finds it, without
+  ;; pulling shadow-cljs onto the test classpath.
+  (let [env-map {:cljs.analyzer/namespaces {'cljs.user {}}}]
+    (intern (create-ns 'shadow.cljs.devtools.api) 'compiler-env
+            (fn [build-id] (when (= build-id :app) env-map)))
+    (try
+      (testing "no build id anywhere -> nil"
+        (is (nil? (shadow-cljs-env {:session (atom {})}))))
+
+      (testing "build id (from the message) with a live build -> deref-able env"
+        (let [handle (shadow-cljs-env {:shadow.cljs.devtools.server.nrepl-impl/build-id :app})]
+          (is (some? handle))
+          (is (= env-map @handle))))
+
+      (testing "build present but no compiled env yet -> nil"
+        (is (nil? (shadow-cljs-env
+                   {:shadow.cljs.devtools.server.nrepl-impl/build-id :not-built}))))
+      (finally
+        (remove-ns 'shadow.cljs.devtools.api)))))

--- a/test/shadow-cljs/.gitignore
+++ b/test/shadow-cljs/.gitignore
@@ -1,0 +1,6 @@
+/node_modules
+/.shadow-cljs
+/out
+/public/js
+/.cpcache
+package-lock.json

--- a/test/shadow-cljs/README.md
+++ b/test/shadow-cljs/README.md
@@ -1,0 +1,77 @@
+# shadow-cljs sample project
+
+A minimal [shadow-cljs](https://shadow-cljs.github.io/docs/UsersGuide.html)
+project kept around as a fixture for exercising cider-nrepl's ClojureScript
+support against a real shadow setup (completion, info, eldoc, etc.).
+
+It is intentionally tiny and not wired into the main test suite - it needs Node
+and a shadow-cljs toolchain download, so it's meant for manual/exploratory runs.
+
+## Layout
+
+- `shadow-cljs.edn` - two builds:
+  - `:app` - the canonical browser "Hello World" from the UsersGuide.
+  - `:node` - a `:node-script` build that gives a headless cljs REPL (no browser
+    needed), which is what makes this convenient to drive from a script.
+- `src/main/shadow_sample/` - the sample namespaces.
+- `src/dev/cljs_env_probe.clj` - a diagnostic nREPL middleware (see below).
+
+## Setup
+
+```sh
+npm install            # pulls the shadow-cljs npm wrapper
+npx shadow-cljs compile :node   # first run downloads the JVM toolchain
+```
+
+## Headless REPL (the easy way to poke at it)
+
+```sh
+npx shadow-cljs watch :node     # compiles, starts nREPL, writes .shadow-cljs/nrepl.port
+node out/node-main.js           # in another shell: connects a runtime back to shadow
+```
+
+Connect any nREPL client to the port in `.shadow-cljs/nrepl.port`, then enter
+the cljs REPL for the `:node` build by evaluating:
+
+```clojure
+(shadow.cljs.devtools.api/nrepl-select :node)
+```
+
+From there, evals run in ClojureScript (`cljs.user`).
+
+## The cljs-env probe
+
+`src/dev/cljs_env_probe.clj` is wired into `shadow-cljs.edn`'s `:nrepl`
+middleware. For every session-bearing message it appends a diagnostic map to
+`/tmp/cljs-env-probe.log` describing how reachable the session's ClojureScript
+compiler env is - both via shadow's own `*repl-state*` / `api/compiler-env` and
+via the piggieback `*cljs-compiler-env*` var.
+
+It exists to answer one question: when a session is in a shadow cljs REPL, can
+cider-nrepl's static-analysis ops (info/complete/eldoc) reach the compiler env
+*outside of eval*? Tail the log while you drive the REPL:
+
+```sh
+tail -f /tmp/cljs-env-probe.log
+```
+
+### What we found
+
+With shadow-cljs 3.4.11, on non-eval ops (`info`, `eldoc`) while a `:node` cljs
+REPL is active, the probe reports:
+
+```clojure
+{:build-id :node
+ :repl-state-in-session?        true
+ :compiler-env-found?           true   ; via shadow.cljs.devtools.api/compiler-env
+ :compiler-env-has-namespaces?  true
+ :piggieback-var-in-session?    true   ; cider.piggieback/*cljs-compiler-env*
+ :piggieback-env-has-namespaces? true}
+```
+
+The key takeaway: **shadow-cljs depends on `cider/piggieback` transitively** (it
+is not declared anywhere in this project) and its `nrepl-select` populates
+piggieback's `*cljs-compiler-env*` session var. So cider-nrepl's existing,
+piggieback-based `grab-cljs-env` already finds shadow's compiler env - both the
+shadow-native path and the piggieback path resolve the same live env on ordinary
+non-eval messages.

--- a/test/shadow-cljs/package.json
+++ b/test/shadow-cljs/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "cider-nrepl-shadow-sample",
+  "version": "0.1.0",
+  "private": true,
+  "description": "A minimal shadow-cljs project used as a fixture for exercising cider-nrepl's ClojureScript support.",
+  "devDependencies": {
+    "shadow-cljs": "3.4.11"
+  }
+}

--- a/test/shadow-cljs/public/index.html
+++ b/test/shadow-cljs/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>cider-nrepl shadow sample</title>
+  </head>
+  <body>
+    <h1>cider-nrepl shadow sample</h1>
+    <script src="/js/main.js"></script>
+  </body>
+</html>

--- a/test/shadow-cljs/shadow-cljs.edn
+++ b/test/shadow-cljs/shadow-cljs.edn
@@ -1,0 +1,29 @@
+;; Minimal shadow-cljs config used as a cider-nrepl test fixture.
+;;
+;; Two builds:
+;;   :app  - the canonical browser "Hello World" from the shadow-cljs UsersGuide,
+;;           handy for poking at cider-nrepl ops from a real editor session.
+;;   :node - a :node-script build that gives a headless cljs REPL, so the same
+;;           ops can be exercised without a browser (CI-friendly).
+;;
+;; The :nrepl middleware below installs the diagnostic probe (see
+;; src/dev/cljs_env_probe.clj) that reports whether a session's shadow build is
+;; reachable from the nREPL session map - the question that gates native shadow
+;; support in cider-nrepl.
+{:source-paths ["src/main" "src/dev"]
+
+ :dependencies []
+
+ :nrepl {:middleware [cljs-env-probe/wrap-cljs-env-probe]}
+
+ :builds
+ {:app  {:target     :browser
+         :output-dir "public/js"
+         :asset-path "/js"
+         :modules    {:main {:init-fn shadow-sample.app/init}}
+         :devtools   {:http-root "public"
+                      :http-port 8080}}
+
+  :node {:target     :node-script
+         :output-to  "out/node-main.js"
+         :main       shadow-sample.node/main}}}

--- a/test/shadow-cljs/src/dev/cljs_env_probe.clj
+++ b/test/shadow-cljs/src/dev/cljs_env_probe.clj
@@ -1,0 +1,95 @@
+;;; Diagnostic nREPL middleware for cider-nrepl's shadow-cljs support.
+;;;
+;;; The make-or-break question for native shadow-cljs support (no piggieback)
+;;; is: when a session is in a shadow cljs REPL, is the build-id (and therefore
+;;; the compiler env) reachable from the *session map* for ordinary, non-eval
+;;; messages - i.e. the exact context cider-nrepl's info/complete/eldoc ops run
+;;; in?
+;;;
+;;; This middleware, for every message carrying a session, reports what it can
+;;; find and prints it to stderr. It's already wired into shadow-cljs.edn's
+;;; :nrepl middleware, so:
+;;;   1. Start the server:        npx shadow-cljs server   (or `watch :app`)
+;;;   2. Connect & start a REPL:  via your editor, or `node-repl` / `cljs-repl`.
+;;;   3. Evaluate a couple of forms, then idle (let the editor fire its own
+;;;      eldoc/complete ops, or send some yourself).
+;;;   4. Read the shadow server's stderr for the "cljs-env-probe" lines.
+;;;
+;;; WHAT TO LOOK FOR:
+;;;   On messages OTHER than the eval that started the REPL - ideally an
+;;;   editor-driven op like "eldoc"/"complete":
+;;;       :repl-state-in-session?       true
+;;;       :build-id                     <your-build-keyword>
+;;;       :compiler-env-found?          true
+;;;       :compiler-env-has-namespaces? true
+;;;   => native shadow support is straightforward; the provider chain works.
+;;;   If those are only true transiently (only on the eval that set them),
+;;;   shadow tracks the build per-session some other way - the
+;;;   :cljs-related-session-vars dump shows what it parks in the session.
+
+(ns cljs-env-probe
+  (:require
+   [clojure.pprint :as pp]
+   [nrepl.middleware :refer [set-descriptor!]]))
+
+(defn- maybe-deref [x] (if (instance? clojure.lang.IDeref x) @x x))
+
+(defn- safe [f] (try (f) (catch Throwable _ ::error)))
+
+(defn- probe-session [session]
+  (let [m              (maybe-deref session)
+        var-keys       (filter var? (keys m))
+        ;; any session-stored dynamic vars that look cljs-related
+        cljs-vars      (->> var-keys
+                            (filter #(re-find #"shadow|piggieback|cljs"
+                                              (str (.ns ^clojure.lang.Var %))))
+                            (mapv #(symbol (str (.ns ^clojure.lang.Var %))
+                                           (str (.sym ^clojure.lang.Var %)))))
+        repl-state-var (safe #(requiring-resolve
+                               'shadow.cljs.devtools.server.nrepl-impl/*repl-state*))
+        repl-state     (when (var? repl-state-var)
+                         (maybe-deref (get m repl-state-var)))
+        build-id       (when (map? repl-state) (:build-id repl-state))
+        compiler-env   (safe #(requiring-resolve 'shadow.cljs.devtools.api/compiler-env))
+        env            (when (and build-id (ifn? compiler-env))
+                         (safe #(compiler-env build-id)))
+        ;; does the (vendored or real) piggieback var already hold the env?
+        pb-var         (safe #(requiring-resolve 'cider.piggieback/*cljs-compiler-env*))
+        pb-env         (when (var? pb-var) (maybe-deref (get m pb-var)))]
+    {:cljs-related-session-vars cljs-vars
+     :repl-state-in-session?    (and (var? repl-state-var) (contains? m repl-state-var))
+     :repl-state-keys           (when (map? repl-state) (keys repl-state))
+     :build-id                  build-id
+     :compiler-env-found?       (boolean (and env (not= env ::error)))
+     :compiler-env-has-namespaces?
+     (boolean (some-> env maybe-deref :cljs.analyzer/namespaces seq))
+     :piggieback-var-in-session? (and (var? pb-var) (contains? m pb-var))
+     :piggieback-env-has-namespaces?
+     (boolean (some-> pb-env maybe-deref :cljs.analyzer/namespaces seq))}))
+
+;; In an nREPL handler `*out*`/`*err*` are bound to the session's streams (sent
+;; back to the client), so they're an unreliable place to land diagnostics on
+;; the server side. Append to a file instead - tail it while you poke the REPL:
+;;   tail -f /tmp/cljs-env-probe.log
+(def ^:private log-file "/tmp/cljs-env-probe.log")
+
+(defn wrap-cljs-env-probe [handler]
+  (fn [{:keys [op session] :as msg}]
+    (when session
+      (let [info (safe #(probe-session session))]
+        ;; only record when something cljs-ish is in the session, to stay quiet
+        ;; on plain Clojure traffic
+        (when (or (seq (:cljs-related-session-vars info))
+                  (:build-id info))
+          (spit log-file
+                (str "=== cljs-env-probe [op: " op "] ===\n"
+                     (with-out-str (pp/pprint info)))
+                :append true))))
+    (handler msg)))
+
+(set-descriptor! #'wrap-cljs-env-probe
+                 {:requires #{} :expects #{} :handles {}})
+
+;; load-time marker, so we can confirm shadow actually required this ns when it
+;; built the nREPL middleware stack
+(spit log-file "=== cljs-env-probe loaded ===\n" :append true)

--- a/test/shadow-cljs/src/main/shadow_sample/app.cljs
+++ b/test/shadow-cljs/src/main/shadow_sample/app.cljs
@@ -1,0 +1,7 @@
+(ns shadow-sample.app)
+
+(defn init []
+  (js/console.log "Hello from shadow-sample.app"))
+
+(defn ^:dev/after-load reload []
+  (js/console.log "reloaded"))

--- a/test/shadow-cljs/src/main/shadow_sample/node.cljs
+++ b/test/shadow-cljs/src/main/shadow_sample/node.cljs
@@ -1,0 +1,7 @@
+(ns shadow-sample.node)
+
+(defn greet [name]
+  (str "Hello, " name "!"))
+
+(defn main [& _args]
+  (js/console.log (greet "world")))


### PR DESCRIPTION
This comes out of revisiting whether cider-nrepl can support shadow-cljs (and figwheel) any better than it does today through Piggieback. The honest answer, captured in the internals doc, is "partially": the eval/runtime side is a known-hard nREPL/backend design problem (see thheller's [shadow-cljs#561](https://github.com/thheller/shadow-cljs/issues/561) and [clj-suitable#34](https://github.com/clojure-emacs/clj-suitable/issues/34)), but the one piece cider-nrepl actually owns - resolving the ClojureScript compiler env for the static-analysis ops - was needlessly hard-wired to Piggieback's session var.

So `grab-cljs-env` becomes a small provider chain: Piggieback first (unchanged behavior), with a shadow-cljs provider that reads the build's compiler env from shadow's public `api/compiler-env`. The build id comes from the `:shadow.cljs.devtools.server.nrepl-impl/build-id` key shadow stamps onto each message - the same integration seam clj-suitable already uses and that shadow keeps stable for tooling - falling back to shadow's `*repl-state*` var.

Today shadow rides in through Piggieback's compat shim anyway, so the provider is mostly groundwork plus a first shadow-aware path. The bigger deliverable is the writeup of how the two middlewares differ and what genuine first-class shadow support would take (and why it's largely an nREPL/backend-layer question). Also drops a dead `shadow-cljs-present?` def, and adds a small manual `test/shadow-cljs/` fixture for exercising shadow support by hand.

- [x] The commits are consistent with the contribution guidelines
- [x] You've added tests to cover your change(s)
- [x] You've updated the changelog
- [ ] Middleware documentation is up to date - n/a, no op changes
