### PR TITLE
Bump ClojureScript to 1.12.145; run cljs tests only on JDK 21+

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,15 @@
+;; ClojureScript's bundled closure-compiler ships Java-21 bytecode as of
+;; 1.12.42+, so the cljs test suite can only load on JDK 21+. Gate the cljs
+;; test path (and, transitively, the whole cljs suite) on the running JDK;
+;; JDK 8/11/17 run the Clojure-only tests. cider-nrepl itself stays JDK 8
+;; compatible because it loads ClojureScript lazily and only when present.
+(def jdk-major
+  (Integer/parseInt (re-find #"\d+$" (System/getProperty "java.specification.version"))))
+
+(def cljs-test? (>= jdk-major 21))
+
 (def dev-test-common-profile
-  {:dependencies '[[org.clojure/clojurescript "1.11.60" :scope "provided"]
+  {:dependencies '[[org.clojure/clojurescript "1.12.145" :scope "provided"]
                    ;; 1.3.7 and 1.4.7 are working, but we need 1.3.7 for JDK8
                    [ch.qos.logback/logback-classic "1.3.7"]
                    [mvxcvi/puget "1.3.4" :exclusions [org.clojure/clojure]]
@@ -61,7 +71,8 @@
   :source-paths ["src"]
   :java-source-paths ["src"]
   :resource-paths ["resources"]
-  :test-paths ["test/clj" "test/cljs" "test/common"]
+  :test-paths ~(cond-> ["test/clj" "test/common"]
+                 cljs-test? (conj "test/cljs"))
 
   :test-selectors {:default (fn [test-meta]
                               (let [parse-version (fn [v] (mapv #(Integer/parseInt (re-find #"\d+" %)) (clojure.string/split v #"\.")))
@@ -88,12 +99,12 @@
   :profiles {:provided {:dependencies [[org.clojure/clojure "1.12.5"]
                                        [nrepl/nrepl "1.7.0"]]}
 
-             :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]
-                                   [org.clojure/clojurescript "1.10.520" :scope "provided"]]}
-             :1.11 {:dependencies [[org.clojure/clojure "1.11.4"]
-                                   [org.clojure/clojurescript "1.11.60" :scope "provided"]]}
-             :1.12 {:dependencies [[org.clojure/clojure "1.12.5"]
-                                   [org.clojure/clojurescript "1.12.42" :scope "provided"]]}
+             ;; These profiles only set the Clojure version; the ClojureScript
+             ;; version is controlled solely by dev-test-common-profile, since a
+             ;; cljs entry here would lose the profile merge to it anyway.
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
+             :1.11 {:dependencies [[org.clojure/clojure "1.11.4"]]}
+             :1.12 {:dependencies [[org.clojure/clojure "1.12.5"]]}
 
              :nrepl-1.0 {:dependencies [[nrepl/nrepl "1.0.0"]]}
              :nrepl-1.3 {:dependencies [[nrepl/nrepl "1.3.0"]]}

--- a/test/clj/cider/nrepl/middleware/macroexpand_test.clj
+++ b/test/clj/cider/nrepl/middleware/macroexpand_test.clj
@@ -29,7 +29,13 @@
                            :display-namespaces "none"})))
 
   (testing "error handling works"
-    (is+ {:status #{"macroexpand-error" "done"}
+    ;; The op tags the error as `macroexpand-error` only when piggieback is
+    ;; loaded (the retag needs the `::caught/throwable` that piggieback's eval
+    ;; path attaches). Without it - e.g. a plain Clojure setup, or an older JDK
+    ;; where ClojureScript's Java-21 closure-compiler can't load piggieback - it
+    ;; degrades to a plain `eval-error`. Either way the error is fully reported.
+    (is+ {:status #(and (contains? % "done")
+                        (some #{"macroexpand-error" "eval-error"} %))
           :err string?
           :ex string?}
          (session/message {:op "cider/macroexpand"

--- a/test/cljs/cider/nrepl/middleware/cljs_complete_test.clj
+++ b/test/cljs/cider/nrepl/middleware/cljs_complete_test.clj
@@ -75,7 +75,12 @@
                                      :context "(defn foo [bar] (let [baz :baz, quux :quux] (str __prefix__)))"
                                      :enhanced-cljs-completion? "t"})
           candidates (:completions response)]
-      (is (= [{:candidate "bar", :type "local"}, {:candidate "baz", :type "local"}] candidates)))))
+      ;; Assert on the local candidates specifically: the prefix `ba` may also
+      ;; match core vars that differ across ClojureScript versions (e.g.
+      ;; `cljs.core/bases` was added in 1.12), but the locals must be exactly
+      ;; `bar`/`baz` - `quux` is excluded, proving the prefix is respected.
+      (is (= [{:candidate "bar", :type "local"} {:candidate "baz", :type "local"}]
+             (filter (comp #{"local"} :type) candidates))))))
 
 (deftest cljs-complete-doc-test
   (testing "no suitable documentation can be found"


### PR DESCRIPTION
Bumps ClojureScript to 1.12.145. Its bundled closure-compiler is Java-21 bytecode (as of 1.12.42), so the cljs test suite can no longer load on JDK 8/11/17. I gate the `test/cljs` path on the running JDK: those JDKs run the Clojure-only suite, while cljs is exercised on JDK 21/25. cider-nrepl itself stays JDK 8 compatible since it loads ClojureScript lazily and only when present.

Builds on #1007 - with a Java-21 cljs on the classpath, an older JDK can't load piggieback, so #1007's `Throwable` guards are what let those jobs degrade to a Clojure-only setup instead of hanging. One consequence: without piggieback loaded, `cider/macroexpand` on faulty code reports a plain `eval-error` rather than `macroexpand-error` (the retag needs the throwable piggieback's eval path attaches), so I relaxed that assertion to accept either - the error is fully reported either way.

While digging in I also found the `:1.10`/`:1.11`/`:1.12` cljs overrides never took effect - the `dev-test-common` default always wins the profile merge - so I dropped them; the cljs version now lives in one place.

cljs is `:scope provided`, so none of this affects the shipped artifact. Full suite green locally on JDK 21.

- [x] The commits are consistent with the contribution guidelines
- [x] You've added/adjusted tests to cover your change(s)
- [x] You've updated the changelog - n/a, test-only (provided-scope) dependency
- [ ] Middleware documentation is up to date - n/a