### PR TITLE
Add a tap middleware for streaming and inspecting tap> values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 * [#1007](https://github.com/clojure-emacs/cider-nrepl/pull/1007): Don't crash at startup on an older JDK when a Java-21 ClojureScript (recent closure-compiler) is on the classpath: the ClojureScript load probes now catch `Throwable`, so cider-nrepl falls back to a Clojure-only setup instead of failing to load.
+* [#1006](https://github.com/clojure-emacs/cider-nrepl/pull/1006): Add a `tap` middleware: `cider/tap-subscribe` streams a summary of every value sent to `tap>` (retaining recent ones, bounded), `cider/tap-inspect` opens an inspector session on a retained value by index, and `cider/tap-unsubscribe` stops the stream. Clojure-only for now.
 * Bump `compliment` to [0.8.0](https://github.com/alexander-yakushev/compliment/blob/0.8.0/CHANGELOG.md) (adds Babashka compatibility).
 * [#1003](https://github.com/clojure-emacs/cider-nrepl/pull/1003): Resolve the ClojureScript compiler environment through a provider chain instead of piggieback alone, adding a shadow-cljs provider so the static-analysis ops keep working in a shadow REPL that doesn't load piggieback.
 * [#994](https://github.com/clojure-emacs/cider-nrepl/pull/994): Error handling: catch `Throwable` (not just `Exception`) when handling ops, so an op that hits an `Error` (e.g. `StackOverflowError`, `AssertionError`) returns a proper error response instead of hanging the client without a terminal `done`. The stacktrace ops, which reply outside the shared error machinery, got the same guarantee.

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -894,6 +894,22 @@ stack frame of the most recent exception."
                :requires {"subscription" "The id of the subscription to remove"}
                :returns  {"cider/trace-unsubscribe" "The id of the removed subscription"}}})})
 
+(def-wrapper wrap-tap cider.nrepl.middleware.tap/handle-tap
+  {:clojure-only? true
+   :doc     "Stream values sent to `tap>` to the client and inspect them."
+   :handles {"cider/tap-subscribe"
+             {:doc     "Open a streaming subscription that delivers a summary of each value sent to `tap>` until `cider/tap-unsubscribe`."
+              :returns {"cider/tap-subscribe" "The id of the subscription, to be passed to `cider/tap-unsubscribe`"
+                        "cider/tap-value" "A tapped value summary, with `idx` (for `cider/tap-inspect`), `summary`, `type` and, when counted, `count`"}}
+             "cider/tap-unsubscribe"
+             {:doc      "Stop streaming tapped values for the given subscription."
+              :requires {"subscription" "The id of the subscription to remove"}
+              :returns  {"cider/tap-unsubscribe" "The id of the removed subscription"}}
+             "cider/tap-inspect"
+             {:doc      "Start an inspector session on a retained tapped value."
+              :requires {"idx" "The index of the tapped value to inspect"}
+              :returns  {"value" "The inspector rendering of the tapped value"}}}})
+
 (def-wrapper wrap-tracker cider.nrepl.middleware.track-state/handle-tracker
   mw/ops-that-can-eval
   {:doc "Under its normal operation mode, enhances the `eval` op by notifying the client of the current REPL state.

--- a/src/cider/nrepl/middleware.clj
+++ b/src/cider/nrepl/middleware.clj
@@ -28,6 +28,7 @@
     cider.nrepl/wrap-spec
     cider.nrepl/wrap-stacktrace
     cider.nrepl/wrap-test
+    cider.nrepl/wrap-tap
     cider.nrepl/wrap-trace
     cider.nrepl/wrap-tracker
     cider.nrepl/wrap-undef

--- a/src/cider/nrepl/middleware/tap.clj
+++ b/src/cider/nrepl/middleware/tap.clj
@@ -1,0 +1,93 @@
+(ns cider.nrepl.middleware.tap
+  "Stream values sent to `tap>' to the client, and let it inspect them.
+
+  A subscription registers an `add-tap' handler that, for each tapped value,
+  retains it (bounded, for later inspection) and forwards a short summary to the
+  client on the subscribing request - mirroring how the trace middleware streams
+  events.  `cider/tap-inspect' starts a normal inspector session on a retained
+  value by its index, so the client reuses the existing inspector UI."
+  (:require
+   [cider.nrepl.middleware.inspect :as inspect]
+   [cider.nrepl.middleware.util :refer [respond-to]]
+   [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]])
+  (:import
+   [java.util UUID]))
+
+(def ^:private max-retained-values
+  "How many recently tapped values to keep available for `cider/tap-inspect'."
+  100)
+
+(def ^:private retained
+  "Recently tapped values available for inspection.
+  `:vals' maps an integer index to a value; `:order' is the FIFO of indices used
+  to evict the oldest once `max-retained-values' is exceeded."
+  (atom {:next 0, :vals {}, :order clojure.lang.PersistentQueue/EMPTY}))
+
+(defn- retain!
+  "Store VALUE for later inspection and return the index assigned to it."
+  [value]
+  (-> (swap! retained
+             (fn [{:keys [next vals order]}]
+               (let [vals  (assoc vals next value)
+                     order (conj order next)
+                     over? (> (count vals) max-retained-values)]
+                 {:next  (inc next)
+                  :vals  (if over? (dissoc vals (peek order)) vals)
+                  :order (if over? (pop order) order)})))
+      :next
+      dec))
+
+(defn- summarize
+  "Return a short, bencode-friendly description of a tapped VALUE."
+  [value]
+  (let [s   (binding [*print-length* 8, *print-level* 4] (pr-str value))
+        max 200]
+    (cond-> {:summary (if (> (count s) max)
+                        (str (subs s 0 max) " …")
+                        s)
+             :type    (if (nil? value) "nil" (.getName (class value)))}
+      (counted? value) (assoc :count (count value)))))
+
+(def ^:private subscriptions
+  "Map of subscription id -> the `add-tap' handler registered for it."
+  (atom {}))
+
+(defn tap-subscribe
+  "Stream a summary of every tapped value to the client until
+  `cider/tap-unsubscribe'.  Registers an `add-tap' handler that forwards each
+  value on this request and retains it for `cider/tap-inspect'."
+  [msg]
+  (let [id     (str (UUID/randomUUID))
+        tap-fn (fn [value]
+                 (let [idx (retain! value)]
+                   (respond-to msg
+                               :cider/tap-value (assoc (summarize value) :idx idx)
+                               :status :cider/tap-value)))]
+    (swap! subscriptions assoc id tap-fn)
+    (add-tap tap-fn)
+    {:cider/tap-subscribe id}))
+
+(defn tap-unsubscribe
+  "Stop streaming tapped values for the given subscription."
+  [{:keys [subscription]}]
+  (when-let [tap-fn (get @subscriptions subscription)]
+    (remove-tap tap-fn)
+    (swap! subscriptions dissoc subscription))
+  {:cider/tap-unsubscribe subscription})
+
+(defn tap-inspect
+  "Start an inspector session on the retained tapped value at index `idx'."
+  [{:keys [idx] :as msg}]
+  (let [idx  (some-> idx Long/parseLong)
+        vals (:vals @retained)]
+    (if (and idx (contains? vals idx))
+      ;; Reuse the inspector: this sets the session inspector and returns the
+      ;; standard inspector response, so all later inspect ops keep working.
+      (inspect/inspect-reply* msg (get vals idx))
+      {:status #{:tap-value-not-retained}})))
+
+(defn handle-tap [handler msg]
+  (with-safe-transport handler msg
+    {"cider/tap-subscribe"   [tap-subscribe :tap-subscribe-error]
+     "cider/tap-unsubscribe" [tap-unsubscribe :tap-unsubscribe-error]
+     "cider/tap-inspect"     [tap-inspect :tap-inspect-error]}))

--- a/test/clj/cider/nrepl/middleware/tap_test.clj
+++ b/test/clj/cider/nrepl/middleware/tap_test.clj
@@ -1,0 +1,55 @@
+(ns cider.nrepl.middleware.tap-test
+  (:require
+   [cider.nrepl.middleware.tap :refer :all]
+   [clojure.test :refer :all]
+   [nrepl.transport :as transport]))
+
+(defn- wait-for
+  "Poll PRED (for up to ~1s) until it returns truthy; return that or nil.
+  `tap>' delivers values asynchronously on a dedicated thread, so tests have
+  to wait for the streamed message rather than assert immediately."
+  [pred]
+  (loop [n 0]
+    (or (pred)
+        (when (< n 100)
+          (Thread/sleep 10)
+          (recur (inc n))))))
+
+(defn- capturing-transport [sent]
+  (reify transport/Transport
+    (send [this msg] (swap! sent conj msg) this)
+    (recv [_this] nil)
+    (recv [_this _timeout] nil)))
+
+(deftest tap-subscribe-test
+  (testing "subscribe streams tapped values; unsubscribe stops them"
+    (let [sent (atom [])
+          {id :cider/tap-subscribe} (tap-subscribe {:transport (capturing-transport sent)
+                                                    :id "1" :session "s"})]
+      (try
+        (is (string? id))
+        (tap> {:hello 42})
+        (is (wait-for #(seq (keep :cider/tap-value @sent)))
+            "the tapped value was streamed")
+        (let [event (first (keep :cider/tap-value @sent))]
+          (is (string? (:summary event)))
+          (is (re-find #":hello" (:summary event)))
+          (is (= "clojure.lang.PersistentArrayMap" (:type event)))
+          (is (= 1 (:count event)))
+          (is (integer? (:idx event)))
+
+          (testing "tap-inspect renders a retained value by its idx"
+            (let [resp (tap-inspect {:idx (str (:idx event)) :session (atom {}) :id "2"})]
+              (is (string? (:value resp)))
+              (is (re-find #"42" (:value resp)))))
+
+          (testing "tap-inspect on an unknown idx reports it isn't retained"
+            (is (= #{:tap-value-not-retained}
+                   (:status (tap-inspect {:idx "999999" :session (atom {}) :id "3"}))))))
+        (finally
+          (tap-unsubscribe {:subscription id})))
+
+      (testing "after unsubscribe no further values are streamed"
+        (reset! sent [])
+        (tap> {:ignored true})
+        (is (nil? (wait-for #(seq (keep :cider/tap-value @sent)))))))))


### PR DESCRIPTION
Server half of a native `tap>` viewer for CIDER (the consumer side - CIDER can already *send* to taps, but has nowhere to receive them). Mirrors the trace middleware's streaming model.

Ops:
- `cider/tap-subscribe` - registers an `add-tap` handler that forwards a short summary (`idx`, `summary`, `type`, and `count` when counted) of each tapped value on the subscribing request, and retains the value in a bounded registry (cap 100) for inspection. Returns the subscription id.
- `cider/tap-inspect` - starts a normal inspector session on a retained value by `idx`, reusing `inspect/inspect-reply*` so the client gets the standard inspector response and all later inspect ops keep working.
- `cider/tap-unsubscribe` - removes the handler.

Clojure-only for now (`:clojure-only? true`): the JVM `add-tap` doesn't see `tap>` calls in a ClojureScript runtime, so cljs gets a clean `clojure-only` reply until a cljs path is added.

Has a test (`tap_test.clj`) covering subscribe→stream→inspect→unsubscribe (with a small wait loop since `tap>` delivers asynchronously). The CIDER client side (`cider-tap.el`) is a companion PR.

First cut of a prototype - happy to tune the retention cap, summary format, etc.