### PR TITLE
Degrade gracefully when ClojureScript can't load on an older JDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* [#1007](https://github.com/clojure-emacs/cider-nrepl/pull/1007): Don't crash at startup on an older JDK when a Java-21 ClojureScript (recent closure-compiler) is on the classpath: the ClojureScript load probes now catch `Throwable`, so cider-nrepl falls back to a Clojure-only setup instead of failing to load.
 * Bump `compliment` to [0.8.0](https://github.com/alexander-yakushev/compliment/blob/0.8.0/CHANGELOG.md) (adds Babashka compatibility).
 * [#1003](https://github.com/clojure-emacs/cider-nrepl/pull/1003): Resolve the ClojureScript compiler environment through a provider chain instead of piggieback alone, adding a shadow-cljs provider so the static-analysis ops keep working in a shadow REPL that doesn't load piggieback.
 * [#994](https://github.com/clojure-emacs/cider-nrepl/pull/994): Error handling: catch `Throwable` (not just `Exception`) when handling ops, so an op that hits an `Error` (e.g. `StackOverflowError`, `AssertionError`) returns a proper error response instead of hanging the client without a terminal `done`. The stacktrace ops, which reply outside the shared error machinery, got the same guarantee.

--- a/src/cider/nrepl/middleware/macroexpand.clj
+++ b/src/cider/nrepl/middleware/macroexpand.clj
@@ -165,17 +165,21 @@
 
 ;; ClojureScript impl
 
+;; Throwable, not Exception: loading ClojureScript can fail with an
+;; `UnsupportedClassVersionError` on an older JDK (recent closure-compiler is
+;; Java-21 bytecode), and these run at namespace load. Degrade to nil so the
+;; Clojure macroexpansion path keeps working instead of failing to load.
 (def ^:private macroexpand-1-cljs
   (try
     (require 'cljs.analyzer)
     @(resolve 'cljs.analyzer/macroexpand-1)
-    (catch Exception _)))
+    (catch Throwable _)))
 
 (def ^:private empty-env-cljs
   (try
     (require 'cljs.analyzer)
     @(resolve 'cljs.analyzer/empty-env)
-    (catch Exception _)))
+    (catch Throwable _)))
 
 (defn- resolve-expander-cljs
   "Returns the macroexpansion fn for macroexpanding ClojureScript code,

--- a/src/cider/nrepl/middleware/util/cljs.clj
+++ b/src/cider/nrepl/middleware/util/cljs.clj
@@ -6,8 +6,12 @@
   "If piggieback is loaded, return `#'cider.piggieback/wrap-cljs-repl`, nil
   otherwise."
   []
+  ;; Catch Throwable, not just Exception: loading piggieback pulls in
+  ;; ClojureScript, whose recent closure-compiler is Java-21 bytecode, so on an
+  ;; older JDK the require fails with an `UnsupportedClassVersionError` (an
+  ;; Error). We want to degrade to a Clojure-only setup, not crash at startup.
   (try (requiring-resolve 'cider.piggieback/wrap-cljs-repl)
-       (catch Exception _)))
+       (catch Throwable _)))
 
 (defn expects-piggieback
   "Deprecated: returns the descriptor unchanged."
@@ -136,14 +140,16 @@
     (require 'cljs.env)
     `(binding [cljs.env/*compiler* (grab-cljs-env* ~msg)]
        ~@body)
-    (catch Exception _)))
+    ;; Throwable, not Exception: loading ClojureScript can fail with an
+    ;; `UnsupportedClassVersionError` on an older JDK (see `try-resolve-piggieback`).
+    (catch Throwable _)))
 
 (defmacro with-cljs-ns [ns-sym & body]
   (try
     (require 'cljs.analyzer)
     `(binding [cljs.analyzer/*cljs-ns* ~ns-sym]
        ~@body)
-    (catch Exception _)))
+    (catch Throwable _)))
 
 (defn respond-clojure-only
   "Replies to `msg` signaling that its op is Clojure-only and isn't available

--- a/test/clj/cider/nrepl/middleware/util/cljs_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/cljs_test.clj
@@ -23,6 +23,18 @@
     (with-redefs [cljs/cljs-env-providers [(constantly (atom {:a 1}))]]
       (is (= {:a 1} (cljs/grab-cljs-env {}))))))
 
+(deftest try-resolve-piggieback-degrades-on-error-test
+  (testing "a class-version error while loading ClojureScript degrades to nil, not a crash"
+    ;; Recent ClojureScript ships a Java-21 closure-compiler, so on an older JDK
+    ;; the piggieback require surfaces an `UnsupportedClassVersionError` - an
+    ;; Error, not an Exception. The startup probe must swallow it and fall back
+    ;; to a Clojure-only setup rather than take the whole middleware stack down.
+    (with-redefs [requiring-resolve
+                  (fn [_] (throw (UnsupportedClassVersionError.
+                                  "closure-compiler has been compiled by a more recent JDK")))]
+      (is (nil? (cljs/try-resolve-piggieback)))
+      (is (= #{:session} (cljs/maybe-add-piggieback #{:session}))))))
+
 (deftest shadow-env-handle-test
   (testing "nil stays nil"
     (is (nil? (shadow-env-handle nil))))


### PR DESCRIPTION
Recent ClojureScript bundles a Java-21 closure-compiler, so on JDK 8/11/17 loading piggieback (or `cljs.analyzer`/`cljs.env`) can throw an `UnsupportedClassVersionError`. That's an `Error`, not an `Exception`, so it slipped past the existing `catch Exception` guards and took the whole middleware stack down at startup instead of degrading to a Clojure-only setup.

Catch `Throwable` around the ClojureScript load probes - `try-resolve-piggieback` (runs at descriptor-build time) plus the `cljs.analyzer`/`cljs.env` requires in macroexpand and the `with-cljs-*` macros. Added a test that simulates the class-version error and asserts the probe falls back to nil.

- [x] The commits are consistent with the contribution guidelines
- [x] You've added tests to cover your change(s)
- [x] You've updated the changelog
- [ ] Middleware documentation is up to date - n/a