### PR TITLE
Bump piggieback to 0.6.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
                    [mvxcvi/puget "1.3.4" :exclusions [org.clojure/clojure]]
                    [fipp "0.6.29" :exclusions [org.clojure/clojure]]
                    [org.clojure/test.check "1.1.3" :exclusions [org.clojure/clojure]]
-                   [cider/piggieback "0.6.1"]
+                   [cider/piggieback "0.6.2"]
                    [nubank/matcher-combinators "3.10.0"]]
    :source-paths ["test/src"]
    :global-vars {'*assert* true}

--- a/test/cljs/cider/nrepl/piggieback_test.clj
+++ b/test/cljs/cider/nrepl/piggieback_test.clj
@@ -36,7 +36,9 @@
     (let [response (session/message {:op "eval"
                                      :code (nrepl/code (js/Object.))})]
       (is (= "cljs.user" (:ns response)))
-      (is (= ["#js{}"] (:value response)))
+      ;; piggieback 0.6.2 fixed tagged-literal printing to emit the space after
+      ;; the reader tag (nrepl/piggieback#120), so this is now "#js {}".
+      (is (= ["#js {}"] (:value response)))
       (is (= #{"done"} (:status response)))))
 
   (testing "eval works"


### PR DESCRIPTION
Routine bump of our test-only piggieback dependency. 0.6.2 is bug fixes only (nrepl/piggieback#124, #120, #62, #111), no breaking changes. cljs test suite green locally on JDK 21.

- [x] The commits are consistent with the contribution guidelines
- [x] You've added tests to cover your change(s) - n/a, dependency bump
- [x] You've updated the changelog - n/a, test-only (provided-scope) dependency
- [ ] Middleware documentation is up to date - n/a