### PR TITLE
Bump mranderson to 0.7.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -61,7 +61,7 @@
   ;; so we conditionally disable it, because otherwise clj-kondo cannot run.
   :plugins ~(if (System/getenv "CIDER_NO_MRANDERSON")
               []
-              '[[thomasa/mranderson "0.5.4-SNAPSHOT"]])
+              '[[thomasa/mranderson "0.7.0"]])
 
   :mranderson {:project-prefix "cider.nrepl.inlined.deps"
                :unresolved-tree false}


### PR DESCRIPTION
Moves our inlining plugin off the unreleased `0.5.4-SNAPSHOT` to the latest stable `0.7.0`, which rolls up all the 0.6.x Java-import rewriting fixes, a ~2x inlining speedup, and finalizes the public API. Build-tool only - it inlines deps into the published jar and isn't a shipped dependency, so no changelog entry.

Validated locally with `make test` against the inlined deps, plus `make smoketest`, which builds the real install jar via mranderson, uberjars it and runs it.

- [x] The commits are consistent with the contribution guidelines
- [x] You've added tests to cover your change(s) - n/a, build plugin bump
- [x] You've updated the changelog - n/a, build-tool (not a shipped dependency)
- [ ] Middleware documentation is up to date - n/a
