### PR TITLE
Support ClojureScript in the tap middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* [#1010](https://github.com/clojure-emacs/cider-nrepl/pull/1010): The `tap` middleware now works in ClojureScript: a runtime helper buffers values sent to `tap>` and the JVM side polls and streams them (the same approach the cljs test middleware uses for async tests). Streaming only - cljs tapped values aren't inspectable, since the value lives in the JS runtime.
 * [#1007](https://github.com/clojure-emacs/cider-nrepl/pull/1007): Don't crash at startup on an older JDK when a Java-21 ClojureScript (recent closure-compiler) is on the classpath: the ClojureScript load probes now catch `Throwable`, so cider-nrepl falls back to a Clojure-only setup instead of failing to load.
 * [#1006](https://github.com/clojure-emacs/cider-nrepl/pull/1006): Add a `tap` middleware: `cider/tap-subscribe` streams a summary of every value sent to `tap>` (retaining recent ones, bounded), `cider/tap-inspect` opens an inspector session on a retained value by index, and `cider/tap-unsubscribe` stops the stream. Clojure-only for now.
 * Bump `compliment` to [0.8.0](https://github.com/alexander-yakushev/compliment/blob/0.8.0/CHANGELOG.md) (adds Babashka compatibility).

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -895,12 +895,11 @@ stack frame of the most recent exception."
                :returns  {"cider/trace-unsubscribe" "The id of the removed subscription"}}})})
 
 (def-wrapper wrap-tap cider.nrepl.middleware.tap/handle-tap
-  {:clojure-only? true
-   :doc     "Stream values sent to `tap>` to the client and inspect them."
+  {:doc     "Stream values sent to `tap>` to the client and inspect them."
    :handles {"cider/tap-subscribe"
-             {:doc     "Open a streaming subscription that delivers a summary of each value sent to `tap>` until `cider/tap-unsubscribe`."
+             {:doc     "Open a streaming subscription that delivers a summary of each value sent to `tap>` until `cider/tap-unsubscribe`. Works in ClojureScript too (by polling the runtime), but cljs tapped values aren't inspectable."
               :returns {"cider/tap-subscribe" "The id of the subscription, to be passed to `cider/tap-unsubscribe`"
-                        "cider/tap-value" "A tapped value summary, with `idx` (for `cider/tap-inspect`), `summary`, `type` and, when counted, `count`"}}
+                        "cider/tap-value" "A tapped value summary, with `summary`, `type`, when counted `count`, and (Clojure only) an `idx` for `cider/tap-inspect`"}}
              "cider/tap-unsubscribe"
              {:doc      "Stop streaming tapped values for the given subscription."
               :requires {"subscription" "The id of the subscription to remove"}

--- a/src/cider/nrepl/cljs/tap.cljs
+++ b/src/cider/nrepl/cljs/tap.cljs
@@ -1,0 +1,68 @@
+(ns cider.nrepl.cljs.tap
+  "ClojureScript-runtime helper for the tap middleware.
+
+  Loaded into the user's ClojureScript runtime on demand (via `require`) by
+  `cider.nrepl.middleware.tap`.  A JS runtime can't push to nREPL on its own, so
+  this registers an `add-tap' handler that accumulates an EDN-safe summary of
+  each tapped value into an atom; the JVM side drains it by polling.")
+
+(defonce ^:private buffer (atom []))
+
+(defonce ^:private tap-fn (atom nil))
+
+(defn- type-name
+  "A short, readable type label for VALUE."
+  [value]
+  (cond
+    (nil? value) "nil"
+    (map? value) "map"
+    (vector? value) "vector"
+    (set? value) "set"
+    (seq? value) "seq"
+    (list? value) "list"
+    (string? value) "string"
+    (keyword? value) "keyword"
+    (symbol? value) "symbol"
+    (number? value) "number"
+    (boolean? value) "boolean"
+    :else (let [t (type value)]
+            (or (some-> t .-name) (str t)))))
+
+(defn- summarize
+  "Return an EDN-safe summary of a tapped VALUE."
+  [value]
+  (let [s (binding [*print-length* 8 *print-level* 4] (pr-str value))
+        max-len 200]
+    (cond-> {:summary (if (> (count s) max-len)
+                        (str (subs s 0 max-len) " …")
+                        s)
+             :type (type-name value)}
+      (counted? value) (assoc :count (count value)))))
+
+(defn drain
+  "Return the summaries accumulated since the last call, clearing the buffer.
+  Runs synchronously on the single JS thread, so the read and clear can't
+  interleave with a tap delivery."
+  []
+  (let [old @buffer]
+    (when (seq old)
+      (swap! buffer subvec (count old)))
+    old))
+
+(defn start!
+  "Register the tap handler (idempotent)."
+  []
+  (when-not @tap-fn
+    (let [f (fn [value] (swap! buffer conj (summarize value)))]
+      (reset! tap-fn f)
+      (add-tap f)))
+  nil)
+
+(defn stop!
+  "Remove the tap handler and clear the buffer."
+  []
+  (when-let [f @tap-fn]
+    (remove-tap f)
+    (reset! tap-fn nil))
+  (reset! buffer [])
+  nil)

--- a/src/cider/nrepl/middleware/tap.clj
+++ b/src/cider/nrepl/middleware/tap.clj
@@ -8,7 +8,9 @@
   value by its index, so the client reuses the existing inspector UI."
   (:require
    [cider.nrepl.middleware.inspect :as inspect]
+   [cider.nrepl.middleware.tap.cljs :as tap-cljs]
    [cider.nrepl.middleware.util :refer [respond-to]]
+   [cider.nrepl.middleware.util.cljs :as cljs]
    [cider.nrepl.middleware.util.error-handling :refer [with-safe-transport]])
   (:import
    [java.util UUID]))
@@ -87,7 +89,14 @@
       {:status #{:tap-value-not-retained}})))
 
 (defn handle-tap [handler msg]
-  (with-safe-transport handler msg
-    {"cider/tap-subscribe"   [tap-subscribe :tap-subscribe-error]
-     "cider/tap-unsubscribe" [tap-unsubscribe :tap-unsubscribe-error]
-     "cider/tap-inspect"     [tap-inspect :tap-inspect-error]}))
+  ;; In a ClojureScript REPL the JVM `add-tap' can't see taps in the JS runtime,
+  ;; so subscribe/unsubscribe are handled by polling the runtime (it streams and
+  ;; replies on its own).  `tap-inspect' stays on the Clojure path - cljs taps
+  ;; carry no `idx' and aren't inspectable yet.
+  (if (and (cljs/grab-cljs-env msg)
+           (#{"cider/tap-subscribe" "cider/tap-unsubscribe"} (:op msg)))
+    (tap-cljs/handle handler msg)
+    (with-safe-transport handler msg
+      {"cider/tap-subscribe"   [tap-subscribe :tap-subscribe-error]
+       "cider/tap-unsubscribe" [tap-unsubscribe :tap-unsubscribe-error]
+       "cider/tap-inspect"     [tap-inspect :tap-inspect-error]})))

--- a/src/cider/nrepl/middleware/tap/cljs.clj
+++ b/src/cider/nrepl/middleware/tap/cljs.clj
@@ -1,0 +1,126 @@
+(ns cider.nrepl.middleware.tap.cljs
+  "ClojureScript support for the tap middleware.
+
+  The JVM `add-tap' can't see `tap>' in a JS runtime, so for a ClojureScript
+  REPL we load a runtime helper (`cider.nrepl.cljs.tap') that buffers tapped
+  values, and poll it via `eval' - the same approach the cljs test middleware
+  uses to await async tests.
+
+  Streaming only: a tapped ClojureScript value lives in the JS runtime, so it
+  can't be handed to the JVM inspector.  So cljs tap entries carry no `idx' and
+  aren't inspectable (a later phase could inspect them in the runtime)."
+  (:require
+   [cider.nrepl.middleware.util :refer [respond-to]]
+   [cider.nrepl.middleware.util.cljs :as cljs])
+  (:import
+   (java.util UUID)
+   (java.util.concurrent Executors ScheduledExecutorService ThreadFactory TimeUnit)
+   (nrepl.transport Transport)))
+
+(def ^:private poll-interval-ms 300)
+
+(defonce ^:private ^ScheduledExecutorService poll-executor
+  (Executors/newSingleThreadScheduledExecutor
+   (reify ThreadFactory
+     (newThread [_ r] (doto (Thread. ^Runnable r "cider-cljs-tap-poll")
+                        (.setDaemon true))))))
+
+(def ^:private subscriptions
+  "Map of subscription id -> a `running?' atom controlling its poll loop."
+  (atom {}))
+
+(defn- eval-cljs
+  "Send `code' to be evaluated in the ClojureScript runtime, using `transport' to
+  intercept the result."
+  [handler msg code transport]
+  (handler (assoc msg
+                  :op "eval"
+                  :code code
+                  :transport transport
+                  :nrepl.middleware.print/keys [])))
+
+(defn- swallowing-transport
+  "A transport that discards an eval's responses and calls `on-done' once it
+  completes (used for the helper-loading evals)."
+  [{:keys [^Transport transport] :as _msg} on-done]
+  (reify Transport
+    (recv [_this] (.recv transport))
+    (recv [_this timeout] (.recv transport timeout))
+    (send [this response]
+      (when (contains? (:status response) :done)
+        (on-done))
+      this)))
+
+(defn- value-transport
+  "A transport that forwards `:out'/`:err', hands the evaluated value to
+  `on-value', and calls `on-error' on an eval error or a value-less completion."
+  [{:keys [^Transport transport] :as msg} on-value on-error]
+  (let [value-seen? (volatile! false)]
+    (reify Transport
+      (recv [_this] (.recv transport))
+      (recv [_this timeout] (.recv transport timeout))
+      (send [this response]
+        (cond
+          (contains? response :value)
+          (do (vreset! value-seen? true)
+              (on-value (cljs/response-value msg response)))
+
+          (or (contains? response :out) (contains? response :err))
+          (.send transport response)
+
+          (contains? (:status response) :done)
+          (when-not @value-seen? (on-error)))
+        this))))
+
+(defn- poll!
+  "Drain the runtime's tap buffer once, stream the entries, and reschedule."
+  [handler msg running?]
+  (when @running?
+    (eval-cljs
+     handler msg "(cider.nrepl.cljs.tap/drain)"
+     (value-transport
+      msg
+      (fn [entries]
+        (when @running?
+          (doseq [e entries]
+            (respond-to msg :cider/tap-value e :status :cider/tap-value))
+          (.schedule poll-executor
+                     ^Runnable (fn [] (poll! handler msg running?))
+                     (long poll-interval-ms) TimeUnit/MILLISECONDS)))
+      ;; Stop polling if the runtime eval errors (e.g. the REPL went away).
+      (fn [] (reset! running? false))))))
+
+(defn- subscribe [handler msg]
+  (let [id (str (UUID/randomUUID))
+        running? (atom true)]
+    (swap! subscriptions assoc id running?)
+    ;; cljs needs the `require' in its own eval before the namespace's vars can
+    ;; be used, so load the helper, register the tap, then start polling.
+    (eval-cljs
+     handler msg "(require 'cider.nrepl.cljs.tap)"
+     (swallowing-transport
+      msg
+      (fn []
+        (eval-cljs
+         handler msg "(cider.nrepl.cljs.tap/start!)"
+         (swallowing-transport
+          msg
+          (fn [] (poll! handler msg running?)))))))
+    (respond-to msg :cider/tap-subscribe id :status #{:done})))
+
+(defn- unsubscribe [handler {:keys [subscription] :as msg}]
+  (when-let [running? (get @subscriptions subscription)]
+    (reset! running? false)
+    (swap! subscriptions dissoc subscription)
+    (eval-cljs handler msg "(cider.nrepl.cljs.tap/stop!)"
+               (swallowing-transport msg (fn []))))
+  (respond-to msg :cider/tap-unsubscribe subscription :status #{:done}))
+
+(defn handle
+  "Handle a tap subscribe/unsubscribe op against a ClojureScript REPL.
+  Replies on its own (the stream and the terminal `:done' are sent here, not via
+  `with-safe-transport')."
+  [handler msg]
+  (case (:op msg)
+    "cider/tap-subscribe" (subscribe handler msg)
+    "cider/tap-unsubscribe" (unsubscribe handler msg)))

--- a/test/cljs/cider/nrepl/middleware/cljs_tap_test.clj
+++ b/test/cljs/cider/nrepl/middleware/cljs_tap_test.clj
@@ -1,0 +1,38 @@
+(ns cider.nrepl.middleware.cljs-tap-test
+  (:require
+   [cider.nrepl.piggieback-test :refer [piggieback-fixture]]
+   [cider.nrepl.test-session :as session]
+   [clojure.test :refer :all]))
+
+(use-fixtures :once piggieback-fixture)
+
+;; The runtime helper (`cider.nrepl.cljs.tap') is loaded into and run inside the
+;; ClojureScript runtime, so it's referenced via string `:code' rather than as a
+;; required (JVM) namespace.
+
+(deftest cljs-tap-runtime-helper-test
+  ;; The JVM side can't see cljs taps, so it polls this runtime helper.  Exercise
+  ;; the helper end-to-end in the node runtime: register the tap, `tap>` a value,
+  ;; and drain an EDN-safe summary.
+  (session/message {:op "eval" :code "(require 'cider.nrepl.cljs.tap)"})
+  (session/message {:op "eval" :code "(cider.nrepl.cljs.tap/start!)"})
+  (session/message {:op "eval" :code "(tap> {:hello 42})"})
+  ;; `tap>` dispatches on the next event-loop tick (setTimeout 0); a further
+  ;; round-trip to the runtime lets that fire before we drain.
+  (session/message {:op "eval" :code ":flush"})
+  (testing "a tapped value is buffered and drained as a summary"
+    (let [value (first (:value (session/message
+                                {:op "eval" :code "(cider.nrepl.cljs.tap/drain)"})))]
+      (is (re-find #":hello 42" value))
+      (is (re-find #"\"map\"" value))))
+  (testing "drain clears the buffer"
+    (let [value (first (:value (session/message
+                                {:op "eval" :code "(cider.nrepl.cljs.tap/drain)"})))]
+      (is (= "[]" value))))
+  (testing "stop! removes the handler so further taps aren't buffered"
+    (session/message {:op "eval" :code "(cider.nrepl.cljs.tap/stop!)"})
+    (session/message {:op "eval" :code "(tap> :ignored)"})
+    (session/message {:op "eval" :code ":flush"})
+    (let [value (first (:value (session/message
+                                {:op "eval" :code "(cider.nrepl.cljs.tap/drain)"})))]
+      (is (= "[]" value)))))


### PR DESCRIPTION
Phase 2 of the tap viewer: make `tap>` streaming work for ClojureScript REPLs.

The JVM `add-tap` can't see `tap>` in a JS runtime, so this loads a runtime helper (`cider.nrepl.cljs.tap`) that registers an `add-tap` buffering an EDN-safe summary of each tapped value, and the JVM side **polls** it via `eval` (`(drain)`) and streams the summaries - the same proven approach the cljs **test** middleware uses to await async tests.

- `handle-tap` branches to the cljs path (poll loop) for subscribe/unsubscribe when a cljs compiler env is active; `wrap-tap` is no longer `:clojure-only?`.
- **Streaming only.** A tapped cljs value lives in the JS runtime, so it can't be handed to the JVM inspector (orchard is JVM-only). cljs tap entries carry no `idx` and aren't `RET`-inspectable; real cljs inspection would be a separate effort (cljs-side inspector, or shadow.remote `obj-*` ops).
- Trade-off (first cut, per discussion): a subscription background-polls the runtime (300ms) while open, stopping cleanly on unsubscribe or eval error.

Tested end-to-end against a node runtime (`cljs_tap_test.clj`): the helper buffers a `tap>`'d value and drains an EDN summary, and `stop!` unregisters cleanly. The Clojure path (#1006) is unchanged. Companion CIDER client tweak handles the non-inspectable cljs entries.

Polling helpers (`eval-cljs`/`value-transport`) are replicated from `test/cljs.clj` for now - a future refactor could share them.