### PR TITLE
[Fix #680] Honor test-ns-hook in the test ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 * [#1010](https://github.com/clojure-emacs/cider-nrepl/pull/1010): The `tap` middleware now works in ClojureScript: a runtime helper buffers values sent to `tap>` and the JVM side polls and streams them (the same approach the cljs test middleware uses for async tests). Streaming only - cljs tapped values aren't inspectable, since the value lives in the JS runtime.
+* [#680](https://github.com/clojure-emacs/cider-nrepl/issues/680): The test ops now honor a namespace's `test-ns-hook`, so a namespace whose tests run only through the hook (with no standalone `deftest` vars) is no longer silently skipped.
 * [#1007](https://github.com/clojure-emacs/cider-nrepl/pull/1007): Don't crash at startup on an older JDK when a Java-21 ClojureScript (recent closure-compiler) is on the classpath: the ClojureScript load probes now catch `Throwable`, so cider-nrepl falls back to a Clojure-only setup instead of failing to load.
 * [#1006](https://github.com/clojure-emacs/cider-nrepl/pull/1006): Add a `tap` middleware: `cider/tap-subscribe` streams a summary of every value sent to `tap>` (retaining recent ones, bounded), `cider/tap-inspect` opens an inspector session on a retained value by index, and `cider/tap-unsubscribe` stops the stream. Clojure-only for now.
 * Bump `compliment` to [0.8.0](https://github.com/alexander-yakushev/compliment/blob/0.8.0/CHANGELOG.md) (adds Babashka compatibility).

--- a/src/cider/nrepl/middleware/test.clj
+++ b/src/cider/nrepl/middleware/test.clj
@@ -378,6 +378,21 @@
                         :ns-elapsed-time @time-info})
        @current-report))))
 
+(defn- with-test-ns-hook-namespaces
+  "Augment `corpus` (a map of namespace -> test vars) with namespaces matching
+  `ns-query` that define a `test-ns-hook` but contribute no vars of their own.
+  `clojure.test` runs such a namespace's tests entirely through the hook, so
+  without this they would be silently skipped (reported as \"No assertions\").
+  `:has-tests?` is cleared because a hook-only namespace has no test vars and
+  would otherwise be filtered out. See #680."
+  [corpus ns-query]
+  (let [already-tested (set (keys corpus))]
+    (into corpus
+          (comp (remove already-tested)
+                (filter #(ns-resolve % 'test-ns-hook))
+                (map (fn [ns] [ns nil])))
+          (query/namespaces (assoc ns-query :has-tests? false)))))
+
 (defn test-var-query
   "Call `test-ns` for each var found via var-query."
   ([var-query]
@@ -386,9 +401,10 @@
   ([var-query fail-fast?]
    (report-reset!)
    (let [elapsed-time (atom nil)
-         corpus (group-by
-                 (comp :ns meta)
-                 (query/vars var-query))]
+         corpus (-> (group-by
+                     (comp :ns meta)
+                     (query/vars var-query))
+                    (with-test-ns-hook-namespaces (:ns-query var-query)))]
      (timing elapsed-time
        (reduce (fn [_ [ns vars]]
                  (cond-> (test-ns ns vars fail-fast?)

--- a/test/clj/cider/nrepl/middleware/test_ns_hook_tests.clj
+++ b/test/clj/cider/nrepl/middleware/test_ns_hook_tests.clj
@@ -1,0 +1,13 @@
+(ns cider.nrepl.middleware.test-ns-hook-tests
+  "Fixture namespace for issue #680: its assertions run only through a
+  `test-ns-hook`, with no standalone `deftest` vars for the var query to
+  discover. Used to verify the test ops still honor the hook."
+  (:require
+   [clojure.test :refer [is testing]]))
+
+(defn a-hook-driven-check []
+  (testing "ran via test-ns-hook"
+    (is (= :ok :ok))))
+
+(defn test-ns-hook []
+  (a-hook-driven-check))

--- a/test/clj/cider/nrepl/middleware/test_test.clj
+++ b/test/clj/cider/nrepl/middleware/test_test.clj
@@ -13,6 +13,7 @@
 ;; Ensure tested tests are loaded:
 (require 'cider.nrepl.middleware.test-filter-tests)
 (require 'cider.nrepl.middleware.test-report-counters-tests)
+(require 'cider.nrepl.middleware.test-ns-hook-tests)
 
 (use-fixtures :each session/session-fixture)
 
@@ -38,6 +39,15 @@
       [:a-smokey-test]
       [:a-puff-of-smoke-test :a-smokey-test]
       [:a-puff-of-smoke-test :a-smokey-test :yet-an-other-test])))
+
+(deftest test-ns-hook-test
+  ;; #680: a namespace whose assertions run only through `test-ns-hook` (with no
+  ;; standalone `deftest` vars for the var query to find) must still be
+  ;; exercised, instead of being silently skipped as "No assertions were run".
+  (testing "the test op honors test-ns-hook for a hook-only namespace"
+    (is+ {:summary {:test 1 :pass 1 :fail 0 :error 0}}
+         (session/message {:op "test"
+                           :ns "cider.nrepl.middleware.test-ns-hook-tests"}))))
 
 (deftest only-smoke-test-run-test-deprecated
   (testing "only test marked as smoke is run when test-all is used"


### PR DESCRIPTION
Fixes #680.

The test ops build their corpus from vars matched by the var query, so a namespace whose tests run entirely through a `test-ns-hook` - with no standalone `deftest` vars - contributed nothing to the corpus and was silently skipped (`cider-test-run-ns-tests` reported "No assertions (or tests) were run").

`test-ns` already honors the hook; the gap was upstream of it, in how the corpus is assembled. The fix augments the corpus with namespaces matching the ns-query that define a `test-ns-hook`, mirroring `clojure.test/test-ns` semantics. This covers `test`, `test-var-query` and `test-all`.

Added a hook-only fixture namespace and a test asserting the hook's assertions actually run.

- [x] The commits are consistent with the contribution guidelines
- [x] You've added tests to cover your change(s)
- [x] You've updated the changelog
- [ ] Middleware documentation is up to date - n/a