### PR TITLE
[Fix #903] Back the default pprint with orchard.pp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* [#903](https://github.com/clojure-emacs/cider-nrepl/issues/903): Back `cider.nrepl.pprint/pprint` with `orchard.pp` instead of `clojure.pprint`, so pretty-printing a lazy sequence no longer interleaves its realization side effects into the result. The previous `clojure.pprint` behavior is still available as `cider.nrepl.pprint/clojure-pprint`.
 * [#1010](https://github.com/clojure-emacs/cider-nrepl/pull/1010): The `tap` middleware now works in ClojureScript: a runtime helper buffers values sent to `tap>` and the JVM side polls and streams them (the same approach the cljs test middleware uses for async tests). Streaming only - cljs tapped values aren't inspectable, since the value lives in the JS runtime.
 * [#680](https://github.com/clojure-emacs/cider-nrepl/issues/680): The test ops now honor a namespace's `test-ns-hook`, so a namespace whose tests run only through the hook (with no standalone `deftest` vars) is no longer silently skipped.
 * [#1007](https://github.com/clojure-emacs/cider-nrepl/pull/1007): Don't crash at startup on an older JDK when a Java-21 ClojureScript (recent closure-compiler) is on the classpath: the ClojureScript load probes now catch `Throwable`, so cider-nrepl falls back to a Clojure-only setup instead of failing to load.

--- a/src/cider/nrepl/pprint.clj
+++ b/src/cider/nrepl/pprint.clj
@@ -48,18 +48,42 @@
        (print-dup value writer)
        (print-method value writer)))))
 
+(defn- orchard-pp
+  "Pretty-print `value` to `writer` with `orchard.pp`, translating the common
+  print options it doesn't read natively: `:right-margin` becomes its
+  `:max-width`, and `:length`/`:level` are bound to `*print-length*` /
+  `*print-level*` (the vars orchard.pp consults)."
+  [value writer {:keys [length level right-margin] :as options}]
+  (binding [*print-length* (if (contains? options :length) length *print-length*)
+            *print-level*  (if (contains? options :level) level *print-level*)]
+    (pp/pprint writer value (cond-> options
+                              right-margin (assoc :max-width right-margin)))))
+
 (defn pprint
-  "A simple wrapper around `clojure.pprint/write`."
+  "Pretty-print `value` using `orchard.pp`. Unlike `clojure.pprint`, it does not
+  realize lazy sequences while printing, so it won't interleave their side
+  effects into - and corrupt - the printed result (see #903). Honors the usual
+  `:length`, `:level` and `:right-margin` print options."
   ([value writer]
    (pprint value writer {}))
+  ([value writer options]
+   (orchard-pp value writer options)))
+
+(defn clojure-pprint
+  "Pretty-print `value` with `clojure.pprint/write`. Prefer `pprint` (backed by
+  `orchard.pp`); this is kept for callers that specifically want
+  `clojure.pprint`'s output, but note that it realizes lazy seqs as it prints."
+  ([value writer]
+   (clojure-pprint value writer {}))
   ([value writer options]
    (apply clojure.pprint/write value (mapcat identity (assoc options :stream writer)))))
 
 (defn orchard-pprint
+  "Alias of `pprint`; both are backed by `orchard.pp`."
   ([value writer]
-   (pp/pprint writer value {}))
+   (orchard-pp value writer {}))
   ([value writer options]
-   (pp/pprint writer value options)))
+   (orchard-pp value writer options)))
 
 (def ^:private fipp-printer
   (delay (try-resolve 'fipp.edn/pprint "Fipp")))
@@ -71,8 +95,8 @@
    (if-some [fipp @fipp-printer]
      (binding [*out* writer]
        (fipp value options))
-     ;; Default to orchard.pp/pprint if Fipp could not be loaded.
-     (pp/pprint writer value options))))
+     ;; Default to orchard.pp if Fipp could not be loaded.
+     (orchard-pp value writer options))))
 
 (def ^:private puget-printer
   (delay (try-resolve 'puget.printer/pprint "Puget")))
@@ -84,8 +108,8 @@
    (if-some [puget @puget-printer]
      (binding [*out* writer]
        (puget value options))
-     ;; Default to orchard.pp/pprint if Puget could not be loaded.
-     (pp/pprint writer value options))))
+     ;; Default to orchard.pp if Puget could not be loaded.
+     (orchard-pp value writer options))))
 
 (def ^:private zprint-printer
   (delay (try-resolve 'zprint.core/zprint "zprint")))
@@ -97,5 +121,5 @@
    (if-some [zprint @zprint-printer]
      (binding [*out* writer]
        (zprint value options))
-     ;; Default to orchard.pp/pprint if Puget could not be loaded.
-     (pp/pprint writer value options))))
+     ;; Default to orchard.pp if zprint could not be loaded.
+     (orchard-pp value writer options))))

--- a/test/clj/cider/nrepl/middleware/inspect_test.clj
+++ b/test/clj/cider/nrepl/middleware/inspect_test.clj
@@ -590,7 +590,9 @@
 
 (deftest inspect-print-current-value-no-value-test
   (testing "inspect-print-current-value returns nil if nothing has been inspected yet"
-    (is+ {:value ["nil"]}
+    ;; `pprint` is backed by orchard.pp, which terminates the output with a
+    ;; newline (like `clojure.pprint/pprint`).
+    (is+ {:value ["nil\n"]}
          (session/message
           {:op "cider/inspect-print-current-value"
            :nrepl.middleware.print/print "cider.nrepl.pprint/pprint"}))))

--- a/test/clj/cider/nrepl/pprint_test.clj
+++ b/test/clj/cider/nrepl/pprint_test.clj
@@ -1,0 +1,38 @@
+(ns cider.nrepl.pprint-test
+  (:require
+   [cider.nrepl.pprint :as sut]
+   [clojure.test :refer [deftest is testing]]))
+
+(defn- render [f value opts]
+  (let [writer (java.io.StringWriter.)]
+    (f value writer opts)
+    (str writer)))
+
+(deftest pprint-lazy-output-test
+  ;; #903: clojure.pprint binds *out* to the target writer while printing, so a
+  ;; lazy seq whose realization writes to *out* gets its side-effect output
+  ;; interleaved into - and corrupting - the printed value. orchard.pp prints to
+  ;; the writer explicitly without rebinding *out*, so the two stay separate.
+  (testing "a lazy seq's realization side effects don't leak into the printed value"
+    (let [value-writer (java.io.StringWriter.)
+          side-writer (java.io.StringWriter.)
+          lazy (lazy-seq (do (print "SIDE-EFFECT") (cons 1 nil)))]
+      (binding [*out* side-writer]
+        (sut/pprint lazy value-writer {}))
+      (is (= "(1)\n" (str value-writer)))
+      (is (= "SIDE-EFFECT" (str side-writer))))))
+
+(deftest pprint-options-test
+  (testing ":right-margin controls wrapping"
+    (is (= "[1 2 3]\n" (render sut/pprint [1 2 3] {})))
+    (is (= "[1\n 2\n 3]\n" (render sut/pprint [1 2 3] {:right-margin 2}))))
+
+  (testing ":length truncates long seqs"
+    (is (= "(0 1 2 ...)\n" (render sut/pprint (range 100) {:length 3}))))
+
+  (testing ":level truncates deep nesting"
+    (is (= "[[#]]\n" (render sut/pprint [[[1]]] {:level 2})))))
+
+(deftest clojure-pprint-still-available-test
+  (testing "clojure-pprint keeps the clojure.pprint behaviour"
+    (is (= "[1\n 2\n 3]" (render sut/clojure-pprint [1 2 3] {:right-margin 2})))))


### PR DESCRIPTION
Fixes #903.

`clojure.pprint` binds `*out*` to the target writer while printing, so a lazy seq whose realization writes to `*out*` (e.g. `(for [...] (println ...))`) gets its side-effect output spliced into - and corrupting - the printed value. `orchard.pp` prints to the writer explicitly without rebinding `*out*`, so the two stay separate (and it's faster). This makes it the implementation of `cider.nrepl.pprint/pprint`, as suggested in the issue.

The standard print options are translated for orchard.pp: `:right-margin` -> its `:max-width`, and `:length`/`:level` are bound to `*print-length*`/`*print-level*` (the vars orchard.pp consults), so width/length control keeps working.

Two things worth a look:
- Trailing newline handling: orchard.pp terminates output with a newline (like `clojure.pprint/pprint`), whereas the old `clojure.pprint/write`-based `pprint` didn't. This matches the existing `orchard-pprint` behavior; I updated one inspect test that pinned the old no-newline output.
- `clojure-pprint` escape hatch: I kept the old `clojure.pprint` behavior available as `cider.nrepl.pprint/clojure-pprint` in case anyone wants the exact old output. Happy to drop it if you'd rather keep the API lean.

The fipp/puget/zprint fallbacks now route through the same option-aware orchard.pp helper too.

- [x] The commits are consistent with the contribution guidelines
- [x] You've added tests to cover your change(s)
- [x] You've updated the changelog
- [ ] Middleware documentation is up to date - n/a (printer fns are documented in CIDER's manual)