### PR TITLE
Make the cider/format-code formatter configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* [#453](https://github.com/clojure-emacs/cider-nrepl/issues/453): The `cider/format-code` op now accepts a `formatter` argument, the fully-qualified name of a formatting function `[code options] -> code`, so projects can format with zprint (`cider.nrepl.middleware.format/zprint`) instead of the default cljfmt.
 * [#903](https://github.com/clojure-emacs/cider-nrepl/issues/903): Back `cider.nrepl.pprint/pprint` with `orchard.pp` instead of `clojure.pprint`, so pretty-printing a lazy sequence no longer interleaves its realization side effects into the result. The previous `clojure.pprint` behavior is still available as `cider.nrepl.pprint/clojure-pprint`.
 * [#1010](https://github.com/clojure-emacs/cider-nrepl/pull/1010): The `tap` middleware now works in ClojureScript: a runtime helper buffers values sent to `tap>` and the JVM side polls and streams them (the same approach the cljs test middleware uses for async tests). Streaming only - cljs tapped values aren't inspectable, since the value lives in the JS runtime.
 * [#680](https://github.com/clojure-emacs/cider-nrepl/issues/680): The test ops now honor a namespace's `test-ns-hook`, so a namespace whose tests run only through the hook (with no standalone `deftest` vars) is no longer silently skipped.

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -278,7 +278,8 @@ Depending on the type of the return value of the evaluation this middleware may 
               {"cider/format-code"
                {:doc "Reformats the given Clojure code, returning the result as a string. The project's `.cljfmt.edn`/`.cljfmt.clj` (if any) is applied automatically, with the supplied `options` taking precedence."
                 :requires {"code" "The code to format."}
-                :optional {"options" "Configuration map for cljfmt, layered on top of the project's cljfmt configuration."}
+                :optional {"options" "Configuration map passed to the formatter. For the default cljfmt formatter it is layered on top of the project's cljfmt configuration."
+                           "formatter" "The fully-qualified name of the formatting function to use, e.g. `cider.nrepl.middleware.format/zprint`. Defaults to cljfmt. The function takes `[code options]` and returns the formatted code."}
                 :returns {"formatted-code" "The formatted code."}}
                "cider/format-edn"
                {:doc "Reformats the given EDN data, returning the result as a string."

--- a/src/cider/nrepl/middleware/format.clj
+++ b/src/cider/nrepl/middleware/format.clj
@@ -8,7 +8,8 @@
    [clojure.edn :as edn]
    [clojure.string :as str]
    [clojure.walk :as walk]
-   [nrepl.middleware.print :as print])
+   [nrepl.middleware.print :as print]
+   [orchard.misc :as misc])
   (:import
    (java.io PushbackReader StringReader StringWriter)))
 
@@ -55,8 +56,17 @@
     (:alias-map options)
     (assoc :alias-map (reduce-kv (fn [m k v] (assoc m (name k) v)) {} (:alias-map options)))))
 
-(defn format-code-reply
-  [{:keys [code options]}]
+;;; Formatters
+;;;
+;;; A formatter is a function of `[code options] -> formatted-code`. Each one
+;;; decides for itself how to interpret `options`, just as the EDN printers do.
+;;; `cljfmt` is the default; alternative formatters are selected by passing the
+;;; fully-qualified name of their var as the `formatter` op argument.
+
+(defn cljfmt
+  "The default code formatter. Reformats `code` with cljfmt, layering the
+  editor-supplied `options` on top of the project's cljfmt configuration."
+  [code options]
   (let [config (or (project-config) {})
         request (request-overrides options)
         ;; The project's config applies first; the request options layer on top.
@@ -66,7 +76,48 @@
         opts (cond-> config
                (:indents request)   (update :extra-indents merge (:indents request))
                (:alias-map request) (update :alias-map merge (:alias-map request)))]
-    {:formatted-code (fmt/reformat-string code opts)}))
+    (fmt/reformat-string code opts)))
+
+;; zprint is an optional dependency; resolve it lazily and only once, mirroring
+;; the optional printers in `cider.nrepl.pprint`.
+(def ^:private zprint-file-str
+  (delay (misc/require-and-resolve 'zprint.core/zprint-file-str)))
+
+(defn zprint
+  "A code formatter backed by zprint, for projects that prefer it over cljfmt.
+  zprint must be on the classpath; the editor-supplied `options` are passed
+  straight through to `zprint.core/zprint-file-str` as a zprint options map."
+  [code options]
+  (if-let [f @zprint-file-str]
+    (f code "<stdin>" options)
+    (throw (ex-info "zprint is not available on the classpath" {}))))
+
+(defn- resolve-formatter
+  "Resolve the `formatter` op argument (a fully-qualified var name) to a
+  formatting function, defaulting to `cljfmt`. Throws a clear error when the
+  formatter's namespace fails to load, when the var doesn't exist, or when it
+  doesn't resolve to a function."
+  [formatter]
+  (if formatter
+    (let [sym (symbol formatter)
+          resolved (try
+                     (requiring-resolve sym)
+                     (catch Exception e
+                       (throw (ex-info (str "Couldn't load formatter " formatter ": " (.getMessage e))
+                                       {:formatter formatter} e))))]
+      (when-not resolved
+        (throw (ex-info (str "Couldn't resolve formatter " formatter)
+                        {:formatter formatter})))
+      (let [f (var-get resolved)]
+        (when-not (ifn? f)
+          (throw (ex-info (str "Formatter " formatter " is not a function")
+                          {:formatter formatter})))
+        f))
+    cljfmt))
+
+(defn format-code-reply
+  [{:keys [code options formatter]}]
+  {:formatted-code ((resolve-formatter formatter) code options)})
 
 ;;; EDN formatting
 (defn- read-edn

--- a/test/clj/cider/nrepl/middleware/format_test.clj
+++ b/test/clj/cider/nrepl/middleware/format_test.clj
@@ -106,6 +106,58 @@
                            :code "(+ 1 2 3)"
                            :options {"alias-map" "INVALID"}}))))
 
+(defn shout-formatter
+  "A trivial custom formatter used to exercise the `formatter` argument."
+  [code _options]
+  (.toUpperCase ^String code))
+
+(def not-a-formatter
+  "A non-fn var, to exercise the formatter-isn't-a-function guard."
+  42)
+
+(deftest configurable-formatter-test
+  (testing "a custom formatter is selected by its fully-qualified name"
+    (is+ {:status #{"done"}
+          :formatted-code "(FOO BAR)"}
+         (session/message {:op "cider/format-code"
+                           :code "(foo bar)"
+                           :formatter "cider.nrepl.middleware.format-test/shout-formatter"})))
+
+  (testing "a missing var in an existing namespace returns a resolve error"
+    (is+ {:status #{"cider/format-code-error" "done"}
+          :err #"Couldn't resolve formatter cider.nrepl.middleware.format-test/no-such-fn"}
+         (session/message {:op "cider/format-code"
+                           :code "(foo bar)"
+                           :formatter "cider.nrepl.middleware.format-test/no-such-fn"})))
+
+  (testing "a formatter whose namespace can't be loaded returns a load error"
+    (is+ {:status #{"cider/format-code-error" "done"}
+          :err #"Couldn't load formatter no.such.ns/formatter"}
+         (session/message {:op "cider/format-code"
+                           :code "(foo bar)"
+                           :formatter "no.such.ns/formatter"})))
+
+  (testing "a formatter that isn't a function returns an error"
+    (is+ {:status #{"cider/format-code-error" "done"}
+          :err #"Formatter cider.nrepl.middleware.format-test/not-a-formatter is not a function"}
+         (session/message {:op "cider/format-code"
+                           :code "(foo bar)"
+                           :formatter "cider.nrepl.middleware.format-test/not-a-formatter"})))
+
+  (testing "the cljfmt default still applies when no formatter is given"
+    (is+ {:status #{"done"}
+          :formatted-code formatted-code-sample}
+         (session/message {:op "cider/format-code" :code ugly-code-sample}))))
+
+(deftest zprint-formatter-test
+  ;; zprint isn't a dependency of cider-nrepl, so the built-in adapter can only
+  ;; be exercised on its "not available" path here. The happy path is covered by
+  ;; projects that put zprint on their own classpath.
+  (testing "the built-in zprint formatter reports when zprint is absent"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"zprint is not available on the classpath"
+         (format/zprint "(foo bar)" {})))))
+
 (defn- with-temp-config*
   "Write CONTENTS to a temp cljfmt config file, make cljfmt's config lookup
   return it for the duration of THUNK, then clean up."


### PR DESCRIPTION
Closes #453.

`cider/format-code` has always been hardwired to cljfmt. This adds a `formatter` argument: the fully-qualified name of a formatting function `[code options] -> code`, defaulting to cljfmt, so projects can swap in their own formatter the same way the EDN side already lets you swap the printer.

A zprint adapter (`cider.nrepl.middleware.format/zprint`) ships out of the box, but zprint stays an optional dependency, resolved lazily. Since it's not on cider-nrepl's classpath, only its "not available" path is covered by tests; the happy path is exercised by projects that put zprint on their own classpath.