### PR TITLE
Harden the content-type and slurp middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* Harden the rich-content middleware ([#2825 in CIDER](https://github.com/clojure-emacs/cider/issues/2825)): only `file:`/`http:`/`https:` URIs and URLs are annotated as fetchable content (a `mailto:` URI no longer triggers a slurp attempt), `cider/slurp` reads at most 4MB (configurable via `cider.nrepl.middleware.slurp/*max-content-size*`) with buffered IO and connect/read timeouts instead of an unbounded byte-at-a-time loop, and a failed fetch replies with a plain-text explanation instead of crashing the nREPL handler.
 * [#1015](https://github.com/clojure-emacs/cider-nrepl/pull/1015): Document the response keys several ops actually return but didn't list in their descriptor (`cider/info`, `cider/refresh`, the `test` ops, the stacktrace ops, `cider/undef`, `cider/profile-summary`, and others), and fix `cider.clj-reload/reload-all` documenting the wrong return key. Adds a `make descriptor-contract` check that keeps the descriptors honest.
 * Simplify the deferred middleware-loading machinery to use `requiring-resolve` (which already serializes the `require` that the old hand-rolled lock guarded), removing the internal `delayed-handlers`, `require-lock`, and `run-deferred-handler` vars. No change in boot time or behavior.
 * [#980](https://github.com/clojure-emacs/cider-nrepl/pull/980): Migrate the build from Leiningen to tools.deps (the source-shading of cljfmt/tools.namespace/tools.reader is now driven by mranderson's Leiningen-free `inline-deps` entry point).

--- a/src/cider/nrepl.clj
+++ b/src/cider/nrepl.clj
@@ -167,7 +167,7 @@
    :handles {"content-type"
              {:doc "Enhances the `eval` op by adding `content-type` and `body` to certain `eval` responses. Not an op in itself.
 
-Depending on the type of the return value of the evaluation this middleware may kick in and include a representation of the result in the response, together with a MIME/Media type to indicate how it should be handled by the client. Comes with implementations for `URI`, `URL`, `File`, and `java.awt.Image`. More type handlers can be provided by the user by extending the `cider.nrepl.middleware.content-type/content-type-response` multimethod. This dispatches using `clojure.core/type`, so `:type` metadata on plain Clojure values can be used to provide custom handling."
+Depending on the type of the return value of the evaluation this middleware may kick in and include a representation of the result in the response, together with a MIME/Media type to indicate how it should be handled by the client. Comes with implementations for `URI`, `URL`, `File`, and `java.awt.Image`. URIs and URLs are only annotated when their scheme names fetchable content (`file`, `http` or `https`); other schemes (`mailto:`, `jar:`, ...) print as usual. More type handlers can be provided by the user by extending the `cider.nrepl.middleware.content-type/content-type-response` multimethod. This dispatches using `clojure.core/type`, so `:type` metadata on plain Clojure values can be used to provide custom handling."
               :returns {"body" "The rich response document, if applicable."
                         "content-type" "The Media type (MIME type) of the reponse, structured as a pair, `[type {:as attrs}]`."
                         "content-transfer-encoding" "The encoding of the response body (Optional, currently only one possible value: `\"base64\"`)."}
@@ -177,7 +177,7 @@ Depending on the type of the return value of the evaluation this middleware may 
   {:doc "Middleware that handles slurp requests."
    :handles (with-deprecated-aliases
               {"cider/slurp"
-               {:doc "Slurps a URL from the nREPL server, returning MIME data."
+               {:doc "Slurps a URL from the nREPL server, returning MIME data. Reads at most `cider.nrepl.middleware.slurp/*max-content-size*` bytes (4MB by default); larger resources yield a size-only placeholder. A failed fetch yields a plain-text explanation instead of an error."
                 :returns {"content-type" "A MIME type for the response, if one can be detected."
                           "content-transfer-encoding" "The encoding (if any) for the content."
                           "body" "The slurped content body."}}})})

--- a/src/cider/nrepl/middleware/content_type.clj
+++ b/src/cider/nrepl/middleware/content_type.clj
@@ -97,11 +97,22 @@
 (defmethod content-type-response :default [response]
   response)
 
-(defmethod content-type-response URI [{:keys [value] :as response}]
-  (merge response (external-body-response value)))
+(def external-body-schemes
+  "The URI/URL schemes that get advertised as slurpable external bodies.
+  Values with any other scheme (mailto:, jar:, data:, ...) are left alone
+  and print as usual - they don't name content a client could sensibly
+  fetch and render, and fetching them can have side effects."
+  #{"file" "http" "https"})
 
-(defmethod content-type-response URL [{:keys [value] :as response}]
-  (merge response (external-body-response value)))
+(defmethod content-type-response URI [{^URI value :value :as response}]
+  (if (contains? external-body-schemes (.getScheme value))
+    (merge response (external-body-response value))
+    response))
+
+(defmethod content-type-response URL [{^URL value :value :as response}]
+  (if (contains? external-body-schemes (.getProtocol value))
+    (merge response (external-body-response value))
+    response))
 
 (defmethod content-type-response File [{^File file :value :as response}]
   (if (.exists file)

--- a/src/cider/nrepl/middleware/slurp.clj
+++ b/src/cider/nrepl/middleware/slurp.clj
@@ -10,10 +10,20 @@
    [clojure.java.io :as io]
    [clojure.string :as str])
   (:import
-   (java.io ByteArrayOutputStream FileNotFoundException InputStream)
+   (java.io ByteArrayOutputStream InputStream)
    (java.net MalformedURLException URI URL URLConnection)
    (java.nio.file Files Path Paths)
    (java.util Base64)))
+
+(def ^:dynamic *max-content-size*
+  "Maximum number of bytes `cider/slurp` is willing to read.
+  Larger resources get a size-only placeholder reply instead of their
+  content, protecting both the JVM and the client from unbounded reads."
+  (* 4 1024 1024))
+
+(def connection-timeout-ms
+  "Connect/read timeout for slurping non-file URLs."
+  10000)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -78,8 +88,31 @@
        :content-transfer-encoding "base64"
        :body (base64-bytes buff)})))
 
+(defn- too-large-reply
+  "A size-only placeholder reply for content exceeding `*max-content-size*`."
+  [location size]
+  {:content-type (normalize-content-type "application/octet-stream")
+   :body (str "#binary[location=" location ",size=" size "]")})
+
+(defn- read-bounded
+  "Read IS into a byte array, up to `*max-content-size*` bytes.
+  Returns the bytes, or nil if the stream exceeds the limit."
+  [^InputStream is]
+  (let [os (ByteArrayOutputStream.)
+        buff (byte-array 8192)]
+    (loop [total 0]
+      (let [n (.read is buff)]
+        (cond
+          (neg? n) (.toByteArray os)
+          (> (+ total n) *max-content-size*) nil
+          :else (do (.write os buff 0 n)
+                    (recur (+ total n))))))))
+
 (defn slurp-url-to-content+body
-  "Attempts to parse and then to slurp a URL, producing a content-typed response."
+  "Attempts to parse and then to slurp a URL, producing a content-typed response.
+  Reads at most `*max-content-size*` bytes; larger resources produce a
+  size-only placeholder.  IO failures throw - `handle-slurp` turns them
+  into a graceful reply."
   [url-str]
   (when-let [^URL url (try (.toURL (URI. url-str))
                            (catch MalformedURLException _e nil))]
@@ -89,40 +122,39 @@
         (if dir?
           {:content-type (normalize-content-type "application/octet-stream")
            :body (str "#binary[location=" p ",size=0]")}
-          (let [content-type (normalize-content-type (get-file-content-type p))
-                buff (Files/readAllBytes p)]
-            (slurp-reply p content-type buff))))
+          (let [size (Files/size p)]
+            (if (> size *max-content-size*)
+              (too-large-reply p size)
+              (slurp-reply p (normalize-content-type (get-file-content-type p))
+                           (Files/readAllBytes p))))))
 
-      ;; It's not a file, so just try to open it on up
-      (let [^URLConnection conn (.openConnection url)
+      ;; It's not a file, so try to fetch it, within bounds
+      (let [^URLConnection conn (doto (.openConnection url)
+                                  (.setConnectTimeout connection-timeout-ms)
+                                  (.setReadTimeout connection-timeout-ms))
             content-type (normalize-content-type
-                          (or (try
-                                (.getContentType conn)
-                                (catch FileNotFoundException _))
-                              "application/octet-stream"))
-            ;; FIXME (arrdem 2018-04-03):
-            ;;   There's gotta be a better way here
-            ^InputStream is (try
-                              (.getInputStream conn)
-                              (catch FileNotFoundException _
-                                (proxy [InputStream] []
-                                  (read []
-                                    -1))))
-            os (ByteArrayOutputStream.)]
-        (loop []
-          (let [b (.read is)]
-            (when (<= 0 b)
-              (.write os b)
-              (recur))))
-        (slurp-reply url content-type (.toByteArray os))))))
+                          (or (.getContentType conn)
+                              "application/octet-stream"))]
+        (with-open [^InputStream is (.getInputStream conn)]
+          (if-let [buff (read-bounded is)]
+            (slurp-reply url content-type buff)
+            (too-large-reply url (str ">" *max-content-size*))))))))
 
 (defn handle-slurp
   "Message handler which just responds to slurp ops.
 
-  If the slurp is malformed, or fails, lets the rest of the stack keep going."
+  If the slurp is malformed, or fails, replies with a plain-text
+  explanation rather than letting the error take down the handler."
   [handler msg]
-  (let [{:keys [op url transport]} msg]
+  (let [{:keys [op url]} msg]
     (if (and (#{"cider/slurp" "slurp"} op) url)
-      (do (respond-to msg (slurp-url-to-content+body url))
+      (do (respond-to msg (try
+                            (or (slurp-url-to-content+body url)
+                                {:content-type ["text/plain" {}]
+                                 :body (str "Don't know how to slurp " url)})
+                            (catch Exception e
+                              {:content-type ["text/plain" {}]
+                               :body (str "Couldn't slurp " url ": "
+                                          (or (.getMessage e) (str (class e))))})))
           (respond-to msg :status :done))
       (handler msg))))

--- a/test/clj/cider/nrepl/middleware/content_type_test.clj
+++ b/test/clj/cider/nrepl/middleware/content_type_test.clj
@@ -74,3 +74,26 @@
                                        {:name "foo"
                                         :edges [["a" "b"] ["b" "c"]]}))
                            :content-type "true"}))))
+
+(deftest non-fetchable-scheme-test
+  (testing "a URI whose scheme isn't fetchable content is not wrapped"
+    (let [resp (session/message {:op "eval"
+                                 :code "(java.net.URI. \"mailto:foo@bar.com\")"
+                                 :content-type "true"})]
+      (is (nil? (:content-type resp)))
+      (is (seq (:value resp)))
+      (is (contains? (:status resp) "done")))))
+
+(deftest slurp-error-handling-test
+  (testing "slurping a URL that can't provide content replies gracefully"
+    (is+ {:content-type ["text/plain" {}]
+          :body #"Couldn't slurp"
+          :status #{"done"}}
+         (session/message {:op "cider/slurp"
+                           :url "mailto:foo@bar.com"})))
+  (testing "slurping a malformed URL replies gracefully"
+    (is+ {:content-type ["text/plain" {}]
+          :body #"Don't know how to slurp"
+          :status #{"done"}}
+         (session/message {:op "cider/slurp"
+                           :url "no-such-scheme:borken"}))))

--- a/test/clj/cider/nrepl/middleware/slurp_test.clj
+++ b/test/clj/cider/nrepl/middleware/slurp_test.clj
@@ -1,6 +1,6 @@
 (ns cider.nrepl.middleware.slurp-test
   (:require
-   [cider.nrepl.middleware.slurp :refer [slurp-url-to-content+body]]
+   [cider.nrepl.middleware.slurp :as slurp :refer [slurp-url-to-content+body]]
    [clojure.java.io :as io]
    [clojure.test :as t]
    [clojure.string :as str]
@@ -39,3 +39,24 @@
     (t/is (= ["application/octet-stream" {}] (:content-type resp)))
     (t/is (str/starts-with? (:body resp) "#binary[location="))
     (t/is (str/ends-with? (:body resp) ",size=0]"))))
+
+(t/deftest test-oversized-content-is-not-slurped
+  (binding [slurp/*max-content-size* 100]
+    (t/testing "a local file over the limit yields a size-only placeholder"
+      (let [resp (-> "build/main.clj"
+                     io/file
+                     io/as-url
+                     .toString
+                     slurp-url-to-content+body)]
+        (t/is (= ["application/octet-stream" {}] (:content-type resp)))
+        (t/is (str/starts-with? (:body resp) "#binary[location="))
+        (t/is (nil? (:content-transfer-encoding resp)))))
+    (t/testing "a non-file resource over the limit yields a size-only placeholder"
+      ;; jar: resources go through the URLConnection (non-file) branch
+      (let [resp (slurp-url-to-content+body
+                  (.toString (io/resource "clojure/core.clj")))]
+        (t/is (str/starts-with? (:body resp) "#binary[location="))
+        (t/is (str/ends-with? (:body resp) (str ",size=>" slurp/*max-content-size* "]")))))))
+
+(t/deftest test-malformed-url-returns-nil
+  (t/is (nil? (slurp-url-to-content+body "no-such-scheme:borken"))))


### PR DESCRIPTION
Server-side half of reviving rich content for CIDER 2 (see clojure-emacs/cider#2825 for the history):

- Only `file:`/`http:`/`https:` URIs and URLs are annotated as fetchable external bodies. Evaluating `(java.net.URI. "mailto:foo@bar.com")` with content-types on now just prints the value, instead of steering the client into a doomed slurp.
- `cider/slurp` reads at most 4MB (`*max-content-size*`, dynamic) with buffered IO and 10s connect/read timeouts, replacing the unbounded byte-at-a-time loop from 2018. Oversized resources get a size-only `#binary[...]` placeholder.
- A failed fetch (unknown service, 404, timeout, malformed URL) replies with a plain-text explanation instead of crashing the nREPL handler loop.

Descriptors updated accordingly; new unit and session-level tests cover the mailto crash, size caps and malformed URLs. The client-side follow-up (click-to-fetch instead of auto-slurp, then enabling the feature by default) is coming separately in CIDER.