### PR TITLE
[ci] Cap the heap via JAVA_OPTS to fix jdk11 OOM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,13 @@ version: 2.1
 defaults: &defaults
   working_directory: ~/repo
   environment:
-    JVM_OPTS: >
-      -Xmx3200m
+    # NOTE: the Clojure CLI honors JAVA_OPTS, not JVM_OPTS (a Leiningen
+    # convention), so the previous JVM_OPTS was silently ignored. With no heap
+    # cap, JDK 11 - which lacks the cgroup memory-limit detection that JDK 17+
+    # have - sized its heap off the host's RAM and got OOM-killed inside the
+    # container. An explicit -Xmx applies regardless of cgroup detection.
+    JAVA_OPTS: >
+      -Xmx2500m
       -Dclojure.main.report=stderr
 
 # Runners for various OpenJDK versions, using the tools-deps (clojure CLI) images.


### PR DESCRIPTION
`test-1.12-jdk11` has been OOM-killed (`make: *** Killed`) intermittently - it dies at whatever test happens to be running when memory crosses the limit, which is why it looks flaky.

Root cause: the Clojure CLI honors `JAVA_OPTS`, not `JVM_OPTS` (a Leiningen convention), so the `-Xmx3200m` in the executor defaults was silently ignored. With no heap cap, JDK 11 - which lacks the cgroup memory-limit detection that JDK 17+ have - sizes its heap off the *host's* RAM and blows past the container limit. JDK 17/21/25/26 detect the cgroup limit and stay in bounds, which is why only jdk11 was affected.

Fix: set the limit via `JAVA_OPTS` (which is honored) with an explicit `-Xmx`, which applies regardless of cgroup detection. 2500m is plenty of headroom - the full suite passes well under it.
