### PR TITLE
Preserve record literals through debugger/enlighten instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#1020](https://github.com/clojure-emacs/cider-nrepl/issues/1020): Fix a test-reporter crash (`no conversion to symbol`) when a test is interrupted (or otherwise throws outside both an `is` assertion and a fixture); the escaped exception is now reported as an error instead.
 * [#750](https://github.com/clojure-emacs/cider-nrepl/issues/750): A form too large to instrument for debugging no longer fails with a raw `Method code too large!` compiler error. It's first retried without local capture (with a warning; breakpoints still work), and if it still won't fit, cider-nrepl reports a clear error and leaves it unevaluated rather than silently evaluating it without instrumentation.
 * [#1022](https://github.com/clojure-emacs/cider-nrepl/issues/1022): Fix a debugger instrumentation crash (`Symbol cannot be cast to Keyword`) when a function argument is destructured with more than eight explicit key/val pairs.
+* [#764](https://github.com/clojure-emacs/cider-nrepl/issues/764): Fix enlighten (and the debugger) corrupting record literals embedded in the code - e.g. compojure's compiled routes - into plain maps, which broke protocol dispatch on them (`No implementation of method ... found for class ... PersistentArrayMap`).
 
 ## 0.62.0 (2026-07-08)
 

--- a/src/cider/nrepl/middleware/util/instrument.clj
+++ b/src/cider/nrepl/middleware/util/instrument.clj
@@ -261,6 +261,12 @@
                                             (walk-indexed (conj coor (inc (* 2 i))) f v)])
                                          map))
          result (cond
+                  ;; Records are `map?`, but rebuilding them like a map (below)
+                  ;; would strip their type and turn them into plain maps -
+                  ;; breaking protocol dispatch on record literals embedded in
+                  ;; the (macroexpanded) code, e.g. compojure's compiled routes
+                  ;; under enlighten (#764). Leave them untouched.
+                  (record? form) form
                   (map? form) (if (<= (count form) 8)
                                 (into {} (walk-indexed-map form))
                                 (try

--- a/test/clj/cider/nrepl/middleware/util/instrument_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/instrument_test.clj
@@ -216,3 +216,19 @@
     '(fn [{a :a b :b c :c d :d e :e f :f g :g h :h i :i}] a)
     ;; with :as/:or present, which is what actually triggers the bad lookup
     '(fn [{a :a b :b c :c d :d e :e f :f g :g h :h i :i :or {a 0} :as m}] [a m])))
+
+(defrecord InstrumentTestRecord [x])
+
+(deftest instrument-preserves-record-literals-test
+  ;; #764: a record literal embedded in the (macroexpanded) code - e.g.
+  ;; compojure's compiled routes, when instrumented under enlighten - must keep
+  ;; its type. Records are `map?`, so rebuilding them like a map stripped the
+  ;; type and turned them into plain maps, breaking protocol dispatch on them.
+  (let [rec    (->InstrumentTestRecord 1)
+        result (-> (list 'clojure.core/identity rec)
+                   (t/tag-form-recursively #'t/bp)
+                   t/instrument-tagged-code
+                   eval)]
+    (is (instance? InstrumentTestRecord result)
+        "the record survives instrumentation as a record, not a plain map")
+    (is (= rec result))))


### PR DESCRIPTION
With `cider-enlighten-mode` on, evaluating a compojure app threw `No implementation of method: :route-matches of protocol: #'clout.core/Route found for class: clojure.lang.PersistentArrayMap` - something that works fine with enlighten off.

Root cause: enlighten (and the debugger) instrument a form by walking its full macroexpansion. Compojure compiles its routes at macroexpansion time and embeds them as clout `CompiledRoute` **records** in the expanded code. Records satisfy `map?`, so `walk-indexed` rebuilt them via `(into {} ...)` into plain maps, stripping the record type - and protocol dispatch on the resulting map fails.

Fix: leave records untouched in the walk (like we already do for sets), preserving their type. Same class of bug as #1022 (walk-indexed mishandling a map subtype).

Verified with the compojure repro from the issue, plus a compojure-free regression test that confirms a record literal survives instrumentation as a record rather than a plain map. Full base suite green on Clojure 1.10 and 1.12.

Fixes #764.
