### PR TITLE
[debug] Don't instrument deftype/defrecord method bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#750](https://github.com/clojure-emacs/cider-nrepl/issues/750): A form too large to instrument for debugging no longer fails with a raw `Method code too large!` compiler error. It's first retried without local capture (with a warning; breakpoints still work), and if it still won't fit, cider-nrepl reports a clear error and leaves it unevaluated rather than silently evaluating it without instrumentation.
 * [#1022](https://github.com/clojure-emacs/cider-nrepl/issues/1022): Fix a debugger instrumentation crash (`Symbol cannot be cast to Keyword`) when a function argument is destructured with more than eight explicit key/val pairs.
 * [#764](https://github.com/clojure-emacs/cider-nrepl/issues/764): Fix enlighten (and the debugger) corrupting record literals embedded in the code - e.g. compojure's compiled routes - into plain maps, which broke protocol dispatch on them (`No implementation of method ... found for class ... PersistentArrayMap`).
+* [#1032](https://github.com/clojure-emacs/cider-nrepl/pull/1032): Fix enlighten (and the debugger) throwing `Unable to resolve symbol: STATE__` on a `defrecord`/`deftype` with inline protocol methods: those bodies compile to real class methods that can't close over the debugger's state, so they are now left uninstrumented (`reify` bodies, which capture their environment, remain instrumentable).
 
 ## 0.62.0 (2026-07-08)
 

--- a/src/cider/nrepl/middleware/util/instrument.clj
+++ b/src/cider/nrepl/middleware/util/instrument.clj
@@ -98,12 +98,17 @@
                                             (map-indexed (first args))
                                             vec)
                                         (instrument-coll (rest args)))
-            '#{reify* deftype*} (map #(if (seq? %)
-                                        (let [[a1 a2 & ar] %]
-                                          (m/merge-meta (list* a1 a2 (instrument-coll ar))
-                                            (meta %)))
-                                        %)
-                                     args)
+            '#{reify*} (map #(if (seq? %)
+                               (let [[a1 a2 & ar] %]
+                                 (m/merge-meta (list* a1 a2 (instrument-coll ar))
+                                   (meta %)))
+                               %)
+                            args)
+            ;; `deftype*` method bodies compile to real class methods that
+            ;; can't close over the enclosing `STATE__` local (unlike `reify*`,
+            ;; which captures its environment), so instrumenting them yields an
+            ;; unresolvable `STATE__`. Leave them untouched.
+            '#{deftype*} args
             ;; `fn*` has several possible syntaxes.
             '#{fn*} (let [[a1 & [a2 & ar :as a1r]] args]
                       (cond

--- a/test/clj/cider/nrepl/middleware/debug_test.clj
+++ b/test/clj/cider/nrepl/middleware/debug_test.clj
@@ -298,6 +298,19 @@
       (let [v (d/instrument-and-eval (read-with-debug-readers "#light (defn l1017-run [x] (+ x 1))"))]
         (is (= 42 (v 41)))))))
 
+(deftest instrument-defrecord-with-methods-test
+  ;; A `defrecord`/`deftype` with inline protocol methods used to throw "Unable
+  ;; to resolve symbol: STATE__" under instrumentation, because the method bodies
+  ;; compile to real class methods that can't close over the STATE__ local. The
+  ;; bodies are now left uninstrumented, so the form compiles and its methods run.
+  (binding [d/*skip-breaks* (atom {:mode :all})]
+    (is (some? (d/instrument-and-eval
+                (read-with-debug-readers
+                 "#dbg (defrecord DbgRec [x] clojure.lang.IDeref (deref [_] (inc x)))")))
+        "compiles without an unresolved STATE__")
+    (is (= 6 (eval '(deref (->DbgRec 5))))
+        "the record's instrumented method still works")))
+
 (deftest method-too-large?-test
   (are [msg] (#'d/method-too-large? msg)
     (RuntimeException. "blah Method code too large! blah")

--- a/test/clj/cider/nrepl/middleware/util/instrument_test.clj
+++ b/test/clj/cider/nrepl/middleware/util/instrument_test.clj
@@ -16,15 +16,29 @@
     '(inc 2)
     '(case i nil {:foo :bar} :default)))
 
-(deftest instrument-defrecord-and-new-test
-  (are [exp res] (set/subset? res (t/breakpoint-tester exp))
-    '(defrecord TestRec [arg arg2]
-       java.lang.Iterable
-       (iterator [this] (inc 1)))
-    '#{[(inc 1) [4 2]]}
+(deftest instrument-new-test
+  (is (set/subset? '#{[(new java.lang.Integer 1) []]}
+                   (t/breakpoint-tester '(new java.lang.Integer 1)))))
 
-    '(new java.lang.Integer 1)
-    '#{[(new java.lang.Integer 1) []]}))
+(deftest deftype-method-bodies-not-instrumented-test
+  ;; `deftype*`/`defrecord` method bodies compile to real class methods that
+  ;; can't close over the debugger's STATE__ local, so instrumenting them throws
+  ;; "Unable to resolve symbol: STATE__" at runtime. They must be left alone -
+  ;; unlike `reify*`, which captures its environment and stays instrumentable.
+  (let [values #(set (map first (t/breakpoint-tester %)))]
+    (is (not (contains? (values '(defrecord TestRec [arg arg2]
+                                   java.lang.Iterable
+                                   (iterator [this] (inc 1))))
+                        '(inc 1)))
+        "defrecord method body is not instrumented")
+    (is (not (contains? (values '(deftype TestType [arg]
+                                   java.lang.Iterable
+                                   (iterator [this] (inc 1))))
+                        '(inc 1)))
+        "deftype method body is not instrumented")
+    (is (contains? (values '(reify java.lang.Iterable (iterator [this] (inc 1))))
+                   '(inc 1))
+        "reify method body is still instrumented")))
 
 (deftest instrument-clauses-test
   (are [exp res] (set/subset? res (t/breakpoint-tester exp))


### PR DESCRIPTION
While fixing #764 I found a related bug: with the debugger (`#dbg`) or `cider-enlighten-mode`, instrumenting a `defrecord`/`deftype` that has **inline protocol methods** throws `Unable to resolve symbol: STATE__`.

Cause: those method bodies compile to real class methods, which can't close over the enclosing `STATE__` local that the instrumentation relies on (unlike `reify`, whose body captures its environment). So the breakpoint / light calls woven into them referenced an unbound symbol.

Fix: leave `deftype*` method bodies uninstrumented; `reify*` bodies stay instrumentable. This also corrects an old test that asserted the broken behavior - it only "passed" because `breakpoint-tester` uses a fake breakpoint macro with no `STATE__`.

Verified with a runtime test (compiles + the record's method runs) and a walker-level test; both fail without the fix. Full base suite green on Clojure 1.10 and 1.12.
