### PR TITLE
[#382] Regression test for enlightening deftest bodies

### DIFF
--- a/test/clj/cider/nrepl/middleware/enlighten_test.clj
+++ b/test/clj/cider/nrepl/middleware/enlighten_test.clj
@@ -64,3 +64,14 @@
       "try/catch")
   (is (= :ok (survives? '(defn f [xs] (map inc xs)) [1 2 3]))
       "lazy seq / higher-order"))
+
+(deftest enlightens-deftest-bodies
+  ;; #382: `deftest` stores its body in the var's `:test` metadata (the def value
+  ;; just calls `test-var`), so enlightening it has to reach the metadata. The
+  ;; body lights up when the test runs. (A minor gap remains: the innermost
+  ;; local binding isn't reported inside a deftest the way it is in a plain defn.)
+  (let [values (enlighten-values
+                '(clojure.test/deftest enl-deftest-sample
+                   (let [a 42] (clojure.test/is (= 43 (+ a 1))))))]
+    (is (contains? values "43")
+        "a sub-expression inside the deftest body lights up")))


### PR DESCRIPTION
#382 (from 2016) reported that `cider-enlighten-mode` doesn't work with `deftest` forms - the test body lives in the var's `:test` metadata (the def value just calls `test-var`), so enlighten never reached it.

That's no longer the case: the recent "enlighten every sub-expression" work (#984) instruments the def-symbol metadata too, so deftest bodies now light up. This adds a regression test that confirms a sub-expression inside a `deftest` reports its value, so the behavior doesn't silently regress.

One minor gap remains (noted in the test): the innermost local binding isn't reported inside a deftest the way it is in a plain defn. Filing that separately if it's worth pursuing; the core of #382 is resolved.

Closes #382.
