### PR TITLE
Add documentation for tool authors

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,14 @@
+config:
+  default: true
+
+  line-length:
+    line_length: 100
+    code_blocks: false
+    tables: false
+
+  no-duplicate-heading:
+    allow_different_nesting: true
+
+  no-inline-html: false
+
+  first-line-heading: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,533 +1,537 @@
 # Changelog
 
+<!-- Entries are one line per item and section headings repeat for every release,
+     so the line-length and duplicate-heading rules don't fit this file. -->
+<!-- markdownlint-disable MD013 MD024 -->
+
 ## master (unreleased)
 
 ## 0.62.1 (2026-07-15)
 
-* [#1016](https://github.com/clojure-emacs/cider-nrepl/issues/1016): Fix a debugger crash (`Unable to resolve symbol: STATE__`) when `#dbg` is placed on a bare collection literal that closes over a local or a qualified name (e.g. `#dbg [x]`).
-* [#1017](https://github.com/clojure-emacs/cider-nrepl/issues/1017): Fix the same `STATE__` error for the `#light` enlighten reader.
-* [#1020](https://github.com/clojure-emacs/cider-nrepl/issues/1020): Fix a test-reporter crash (`no conversion to symbol`) when a test is interrupted (or otherwise throws outside both an `is` assertion and a fixture); the escaped exception is now reported as an error instead.
-* [#750](https://github.com/clojure-emacs/cider-nrepl/issues/750): A form too large to instrument for debugging no longer fails with a raw `Method code too large!` compiler error. It's first retried without local capture (with a warning; breakpoints still work), and if it still won't fit, cider-nrepl reports a clear error and leaves it unevaluated rather than silently evaluating it without instrumentation.
-* [#1022](https://github.com/clojure-emacs/cider-nrepl/issues/1022): Fix a debugger instrumentation crash (`Symbol cannot be cast to Keyword`) when a function argument is destructured with more than eight explicit key/val pairs.
-* [#764](https://github.com/clojure-emacs/cider-nrepl/issues/764): Fix enlighten (and the debugger) corrupting record literals embedded in the code - e.g. compojure's compiled routes - into plain maps, which broke protocol dispatch on them (`No implementation of method ... found for class ... PersistentArrayMap`).
-* [#1032](https://github.com/clojure-emacs/cider-nrepl/pull/1032): Fix enlighten (and the debugger) throwing `Unable to resolve symbol: STATE__` on a `defrecord`/`deftype` with inline protocol methods: those bodies compile to real class methods that can't close over the debugger's state, so they are now left uninstrumented (`reify` bodies, which capture their environment, remain instrumentable).
+- [#1016](https://github.com/clojure-emacs/cider-nrepl/issues/1016): Fix a debugger crash (`Unable to resolve symbol: STATE__`) when `#dbg` is placed on a bare collection literal that closes over a local or a qualified name (e.g. `#dbg [x]`).
+- [#1017](https://github.com/clojure-emacs/cider-nrepl/issues/1017): Fix the same `STATE__` error for the `#light` enlighten reader.
+- [#1020](https://github.com/clojure-emacs/cider-nrepl/issues/1020): Fix a test-reporter crash (`no conversion to symbol`) when a test is interrupted (or otherwise throws outside both an `is` assertion and a fixture); the escaped exception is now reported as an error instead.
+- [#750](https://github.com/clojure-emacs/cider-nrepl/issues/750): A form too large to instrument for debugging no longer fails with a raw `Method code too large!` compiler error. It's first retried without local capture (with a warning; breakpoints still work), and if it still won't fit, cider-nrepl reports a clear error and leaves it unevaluated rather than silently evaluating it without instrumentation.
+- [#1022](https://github.com/clojure-emacs/cider-nrepl/issues/1022): Fix a debugger instrumentation crash (`Symbol cannot be cast to Keyword`) when a function argument is destructured with more than eight explicit key/val pairs.
+- [#764](https://github.com/clojure-emacs/cider-nrepl/issues/764): Fix enlighten (and the debugger) corrupting record literals embedded in the code - e.g. compojure's compiled routes - into plain maps, which broke protocol dispatch on them (`No implementation of method ... found for class ... PersistentArrayMap`).
+- [#1032](https://github.com/clojure-emacs/cider-nrepl/pull/1032): Fix enlighten (and the debugger) throwing `Unable to resolve symbol: STATE__` on a `defrecord`/`deftype` with inline protocol methods: those bodies compile to real class methods that can't close over the debugger's state, so they are now left uninstrumented (`reify` bodies, which capture their environment, remain instrumentable).
 
 ## 0.62.0 (2026-07-08)
 
-* Bump `orchard` to [0.44.0](https://github.com/clojure-emacs/orchard/blob/v0.44.0/CHANGELOG.md) (inspector: the Datafy section is gone, `ARef` contents render fully, and wide columns are truncated in table mode).
-* [#1018](https://github.com/clojure-emacs/cider-nrepl/issues/1018): Abort a debug session via nREPL's `interrupt-stop` instead of the deprecated `Thread.stop`, so quitting the debugger keeps working on JDKs where `Thread.stop` was removed (also fixes a `NullPointerException` when the session carries no thread).
-* Drop `value` from responses the content-type middleware decorates: the requester opted in to content types and renders the `body` instead, and clients that naively rendered both slots used to show results twice. Responses the middleware leaves alone (unrecognized types, non-fetchable URI schemes) keep their `value` as before.
-* Harden the rich-content middleware ([#2825 in CIDER](https://github.com/clojure-emacs/cider/issues/2825)): only `file:`/`http:`/`https:` URIs and URLs are annotated as fetchable content (a `mailto:` URI no longer triggers a slurp attempt), `cider/slurp` reads at most 4MB (configurable via `cider.nrepl.middleware.slurp/*max-content-size*`) with buffered IO and connect/read timeouts instead of an unbounded byte-at-a-time loop, and a failed fetch replies with a plain-text explanation instead of crashing the nREPL handler.
-* [#1015](https://github.com/clojure-emacs/cider-nrepl/pull/1015): Document the response keys several ops actually return but didn't list in their descriptor (`cider/info`, `cider/refresh`, the `test` ops, the stacktrace ops, `cider/undef`, `cider/profile-summary`, and others), and fix `cider.clj-reload/reload-all` documenting the wrong return key. Adds a `make descriptor-contract` check that keeps the descriptors honest.
-* Simplify the deferred middleware-loading machinery to use `requiring-resolve` (which already serializes the `require` that the old hand-rolled lock guarded), removing the internal `delayed-handlers`, `require-lock`, and `run-deferred-handler` vars. No change in boot time or behavior.
-* [#980](https://github.com/clojure-emacs/cider-nrepl/pull/980): Migrate the build from Leiningen to tools.deps (the source-shading of cljfmt/tools.namespace/tools.reader is now driven by mranderson's Leiningen-free `inline-deps` entry point).
+- Bump `orchard` to [0.44.0](https://github.com/clojure-emacs/orchard/blob/v0.44.0/CHANGELOG.md) (inspector: the Datafy section is gone, `ARef` contents render fully, and wide columns are truncated in table mode).
+- [#1018](https://github.com/clojure-emacs/cider-nrepl/issues/1018): Abort a debug session via nREPL's `interrupt-stop` instead of the deprecated `Thread.stop`, so quitting the debugger keeps working on JDKs where `Thread.stop` was removed (also fixes a `NullPointerException` when the session carries no thread).
+- Drop `value` from responses the content-type middleware decorates: the requester opted in to content types and renders the `body` instead, and clients that naively rendered both slots used to show results twice. Responses the middleware leaves alone (unrecognized types, non-fetchable URI schemes) keep their `value` as before.
+- Harden the rich-content middleware ([#2825 in CIDER](https://github.com/clojure-emacs/cider/issues/2825)): only `file:`/`http:`/`https:` URIs and URLs are annotated as fetchable content (a `mailto:` URI no longer triggers a slurp attempt), `cider/slurp` reads at most 4MB (configurable via `cider.nrepl.middleware.slurp/*max-content-size*`) with buffered IO and connect/read timeouts instead of an unbounded byte-at-a-time loop, and a failed fetch replies with a plain-text explanation instead of crashing the nREPL handler.
+- [#1015](https://github.com/clojure-emacs/cider-nrepl/pull/1015): Document the response keys several ops actually return but didn't list in their descriptor (`cider/info`, `cider/refresh`, the `test` ops, the stacktrace ops, `cider/undef`, `cider/profile-summary`, and others), and fix `cider.clj-reload/reload-all` documenting the wrong return key. Adds a `make descriptor-contract` check that keeps the descriptors honest.
+- Simplify the deferred middleware-loading machinery to use `requiring-resolve` (which already serializes the `require` that the old hand-rolled lock guarded), removing the internal `delayed-handlers`, `require-lock`, and `run-deferred-handler` vars. No change in boot time or behavior.
+- [#980](https://github.com/clojure-emacs/cider-nrepl/pull/980): Migrate the build from Leiningen to tools.deps (the source-shading of cljfmt/tools.namespace/tools.reader is now driven by mranderson's Leiningen-free `inline-deps` entry point).
 
 ## 0.61.0 (2026-06-29)
 
-* [#453](https://github.com/clojure-emacs/cider-nrepl/issues/453): The `cider/format-code` op now accepts a `formatter` argument, the fully-qualified name of a formatting function `[code options] -> code`, so projects can format with zprint (`cider.nrepl.middleware.format/zprint`) instead of the default cljfmt.
-* [#903](https://github.com/clojure-emacs/cider-nrepl/issues/903): Back `cider.nrepl.pprint/pprint` with `orchard.pp` instead of `clojure.pprint`, so pretty-printing a lazy sequence no longer interleaves its realization side effects into the result. The previous `clojure.pprint` behavior is still available as `cider.nrepl.pprint/clojure-pprint`.
-* [#1010](https://github.com/clojure-emacs/cider-nrepl/pull/1010): The `tap` middleware now works in ClojureScript: a runtime helper buffers values sent to `tap>` and the JVM side polls and streams them (the same approach the cljs test middleware uses for async tests). Streaming only - cljs tapped values aren't inspectable, since the value lives in the JS runtime.
-* [#680](https://github.com/clojure-emacs/cider-nrepl/issues/680): The test ops now honor a namespace's `test-ns-hook`, so a namespace whose tests run only through the hook (with no standalone `deftest` vars) is no longer silently skipped.
-* [#1007](https://github.com/clojure-emacs/cider-nrepl/pull/1007): Don't crash at startup on an older JDK when a Java-21 ClojureScript (recent closure-compiler) is on the classpath: the ClojureScript load probes now catch `Throwable`, so cider-nrepl falls back to a Clojure-only setup instead of failing to load.
-* [#1006](https://github.com/clojure-emacs/cider-nrepl/pull/1006): Add a `tap` middleware: `cider/tap-subscribe` streams a summary of every value sent to `tap>` (retaining recent ones, bounded), `cider/tap-inspect` opens an inspector session on a retained value by index, and `cider/tap-unsubscribe` stops the stream. Clojure-only for now.
-* Bump `compliment` to [0.8.0](https://github.com/alexander-yakushev/compliment/blob/0.8.0/CHANGELOG.md) (adds Babashka compatibility).
-* [#1003](https://github.com/clojure-emacs/cider-nrepl/pull/1003): Resolve the ClojureScript compiler environment through a provider chain instead of piggieback alone, adding a shadow-cljs provider so the static-analysis ops keep working in a shadow REPL that doesn't load piggieback.
-* [#994](https://github.com/clojure-emacs/cider-nrepl/pull/994): Error handling: catch `Throwable` (not just `Exception`) when handling ops, so an op that hits an `Error` (e.g. `StackOverflowError`, `AssertionError`) returns a proper error response instead of hanging the client without a terminal `done`. The stacktrace ops, which reply outside the shared error machinery, got the same guarantee.
-* [#993](https://github.com/clojure-emacs/cider-nrepl/pull/993): Fix op descriptor metadata: document `cider/get-state`'s return values (previously rendered blank) and correct the `cider/log-remove-consumer` return key.
-* [#992](https://github.com/clojure-emacs/cider-nrepl/pull/992): Bump `cljfmt` to 0.16.4 (from 0.9.2).
-* [#955](https://github.com/clojure-emacs/cider-nrepl/issues/955): The `cider/format-code` op now applies the project's `.cljfmt.edn`/`.cljfmt.clj` configuration automatically, with any options passed in the request taking precedence.
-* [clojure-emacs/cider#2099](https://github.com/clojure-emacs/cider/issues/2099): Fix ClojureScript macroexpansion of user-defined macros (e.g. those referred via `:refer-macros`), which previously echoed back unexpanded because the compiler env was passed to the analyzer instead of a proper analysis environment.
-* [clojure-emacs/cider#2198](https://github.com/clojure-emacs/cider/issues/2198): Clojure-only ops (apropos, xref, trace, profile, refresh, reload, undef, spec) now reply with a `clojure-only` status when a ClojureScript REPL is active, instead of a confusing failure or a JVM-only result.
-* [#555](https://github.com/clojure-emacs/cider-nrepl/issues/555): The `test` ops (`cider/test`, `cider/test-var-query`, `cider/test-all`, `cider/retest`) now run ClojureScript tests via `cljs.test` when a ClojureScript REPL is active, returning the same report shape as for Clojure. Asynchronous (`cljs.test/async`) tests are awaited, bounded by an optional `:timeout` (default 30s).
+- [#453](https://github.com/clojure-emacs/cider-nrepl/issues/453): The `cider/format-code` op now accepts a `formatter` argument, the fully-qualified name of a formatting function `[code options] -> code`, so projects can format with zprint (`cider.nrepl.middleware.format/zprint`) instead of the default cljfmt.
+- [#903](https://github.com/clojure-emacs/cider-nrepl/issues/903): Back `cider.nrepl.pprint/pprint` with `orchard.pp` instead of `clojure.pprint`, so pretty-printing a lazy sequence no longer interleaves its realization side effects into the result. The previous `clojure.pprint` behavior is still available as `cider.nrepl.pprint/clojure-pprint`.
+- [#1010](https://github.com/clojure-emacs/cider-nrepl/pull/1010): The `tap` middleware now works in ClojureScript: a runtime helper buffers values sent to `tap>` and the JVM side polls and streams them (the same approach the cljs test middleware uses for async tests). Streaming only - cljs tapped values aren't inspectable, since the value lives in the JS runtime.
+- [#680](https://github.com/clojure-emacs/cider-nrepl/issues/680): The test ops now honor a namespace's `test-ns-hook`, so a namespace whose tests run only through the hook (with no standalone `deftest` vars) is no longer silently skipped.
+- [#1007](https://github.com/clojure-emacs/cider-nrepl/pull/1007): Don't crash at startup on an older JDK when a Java-21 ClojureScript (recent closure-compiler) is on the classpath: the ClojureScript load probes now catch `Throwable`, so cider-nrepl falls back to a Clojure-only setup instead of failing to load.
+- [#1006](https://github.com/clojure-emacs/cider-nrepl/pull/1006): Add a `tap` middleware: `cider/tap-subscribe` streams a summary of every value sent to `tap>` (retaining recent ones, bounded), `cider/tap-inspect` opens an inspector session on a retained value by index, and `cider/tap-unsubscribe` stops the stream. Clojure-only for now.
+- Bump `compliment` to [0.8.0](https://github.com/alexander-yakushev/compliment/blob/0.8.0/CHANGELOG.md) (adds Babashka compatibility).
+- [#1003](https://github.com/clojure-emacs/cider-nrepl/pull/1003): Resolve the ClojureScript compiler environment through a provider chain instead of piggieback alone, adding a shadow-cljs provider so the static-analysis ops keep working in a shadow REPL that doesn't load piggieback.
+- [#994](https://github.com/clojure-emacs/cider-nrepl/pull/994): Error handling: catch `Throwable` (not just `Exception`) when handling ops, so an op that hits an `Error` (e.g. `StackOverflowError`, `AssertionError`) returns a proper error response instead of hanging the client without a terminal `done`. The stacktrace ops, which reply outside the shared error machinery, got the same guarantee.
+- [#993](https://github.com/clojure-emacs/cider-nrepl/pull/993): Fix op descriptor metadata: document `cider/get-state`'s return values (previously rendered blank) and correct the `cider/log-remove-consumer` return key.
+- [#992](https://github.com/clojure-emacs/cider-nrepl/pull/992): Bump `cljfmt` to 0.16.4 (from 0.9.2).
+- [#955](https://github.com/clojure-emacs/cider-nrepl/issues/955): The `cider/format-code` op now applies the project's `.cljfmt.edn`/`.cljfmt.clj` configuration automatically, with any options passed in the request taking precedence.
+- [clojure-emacs/cider#2099](https://github.com/clojure-emacs/cider/issues/2099): Fix ClojureScript macroexpansion of user-defined macros (e.g. those referred via `:refer-macros`), which previously echoed back unexpanded because the compiler env was passed to the analyzer instead of a proper analysis environment.
+- [clojure-emacs/cider#2198](https://github.com/clojure-emacs/cider/issues/2198): Clojure-only ops (apropos, xref, trace, profile, refresh, reload, undef, spec) now reply with a `clojure-only` status when a ClojureScript REPL is active, instead of a confusing failure or a JVM-only result.
+- [#555](https://github.com/clojure-emacs/cider-nrepl/issues/555): The `test` ops (`cider/test`, `cider/test-var-query`, `cider/test-all`, `cider/retest`) now run ClojureScript tests via `cljs.test` when a ClojureScript REPL is active, returning the same report shape as for Clojure. Asynchronous (`cljs.test/async`) tests are awaited, bounded by an optional `:timeout` (default 30s).
 
 ## 0.60.0 (2026-06-24)
 
-* [#986](https://github.com/clojure-emacs/cider-nrepl/pull/986): Add the `cider/type-protocols` op (the protocols a type implements) and the `cider/protocols-with-method` op (the protocols declaring a method of a given name), each returning `:name :file :file-url :line :column` maps (requires `orchard` 0.43.0).
-* [#985](https://github.com/clojure-emacs/cider-nrepl/pull/985): Add the `cider/who-implements` op, returning the implementations of a protocol (both `extend`-style and inline `defrecord`/`deftype`, with source locations) or the dispatch values of a multimethod (requires `orchard` 0.43.0).
-* [#984](https://github.com/clojure-emacs/cider-nrepl/pull/984): Enlighten now reports the value of every sub-expression as it runs, not just a definition's return value and locals - so the whole computation lights up, much closer to the Light Table feature it was modeled on.
-* [#983](https://github.com/clojure-emacs/cider-nrepl/pull/983): Fix enlighten overlay placement when one evaluation spans several top-level forms (e.g. evaluating a region): each form's values are now reported at that form's own line instead of the line where the evaluation started.
-* [#982](https://github.com/clojure-emacs/cider-nrepl/pull/982): Add the `cider/trace-subscribe` and `cider/trace-unsubscribe` ops, streaming a structured event for every traced call and return so clients can render trace output in a dedicated buffer instead of the REPL (requires `orchard` 0.43.0).
-* [#981](https://github.com/clojure-emacs/cider-nrepl/pull/981): Add the `cider/list-traced` op (listing the currently traced vars and namespaces) and the `cider/untrace-all` op (untracing everything at once).
-* [#979](https://github.com/clojure-emacs/cider-nrepl/pull/979): Bump `orchard` to 0.42.0 and adapt to its removal of the inspector analytics hint (the `:display-analytics-hint` inspect option is gone; use the `cider/inspect-display-analytics` op to show analytics on demand).
-* [#978](https://github.com/clojure-emacs/cider-nrepl/pull/978): Add the `cider/classify-symbols` op, classifying the given symbols as macros, inline-expandable functions, special forms or plain functions, for both Clojure and ClojureScript.
+- [#986](https://github.com/clojure-emacs/cider-nrepl/pull/986): Add the `cider/type-protocols` op (the protocols a type implements) and the `cider/protocols-with-method` op (the protocols declaring a method of a given name), each returning `:name :file :file-url :line :column` maps (requires `orchard` 0.43.0).
+- [#985](https://github.com/clojure-emacs/cider-nrepl/pull/985): Add the `cider/who-implements` op, returning the implementations of a protocol (both `extend`-style and inline `defrecord`/`deftype`, with source locations) or the dispatch values of a multimethod (requires `orchard` 0.43.0).
+- [#984](https://github.com/clojure-emacs/cider-nrepl/pull/984): Enlighten now reports the value of every sub-expression as it runs, not just a definition's return value and locals - so the whole computation lights up, much closer to the Light Table feature it was modeled on.
+- [#983](https://github.com/clojure-emacs/cider-nrepl/pull/983): Fix enlighten overlay placement when one evaluation spans several top-level forms (e.g. evaluating a region): each form's values are now reported at that form's own line instead of the line where the evaluation started.
+- [#982](https://github.com/clojure-emacs/cider-nrepl/pull/982): Add the `cider/trace-subscribe` and `cider/trace-unsubscribe` ops, streaming a structured event for every traced call and return so clients can render trace output in a dedicated buffer instead of the REPL (requires `orchard` 0.43.0).
+- [#981](https://github.com/clojure-emacs/cider-nrepl/pull/981): Add the `cider/list-traced` op (listing the currently traced vars and namespaces) and the `cider/untrace-all` op (untracing everything at once).
+- [#979](https://github.com/clojure-emacs/cider-nrepl/pull/979): Bump `orchard` to 0.42.0 and adapt to its removal of the inspector analytics hint (the `:display-analytics-hint` inspect option is gone; use the `cider/inspect-display-analytics` op to show analytics on demand).
+- [#978](https://github.com/clojure-emacs/cider-nrepl/pull/978): Add the `cider/classify-symbols` op, classifying the given symbols as macros, inline-expandable functions, special forms or plain functions, for both Clojure and ClojureScript.
 
 ## 0.59.0 (2026-04-14)
 
-* Bump `nrepl` to [1.7.0](https://github.com/nrepl/nrepl/blob/master/CHANGELOG.md#170-2026-04-14).
-* Bump `tools.reader` to 1.6.0.
-* Bump `tools.namespace` to 1.5.1.
-* Bump `orchard` to [0.41.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0410-2026-04-13).
-* [#959](https://github.com/clojure-emacs/cider-nrepl/pull/959): Stop shading Compliment and clj-reload.
-* [#710](https://github.com/clojure-emacs/cider-nrepl/issues/710): Make namespaced ops (e.g., `cider/complete`) the default and keep the old names as deprecated aliases.
-* [#965](https://github.com/clojure-emacs/cider-nrepl/issues/965): Stop losing quotes in matcher-combinators test output.
-* [#972](https://github.com/clojure-emacs/cider-nrepl/issues/972): Stop relying on tools.reader functions in our code.
-* [#971](https://github.com/clojure-emacs/cider-nrepl/issues/971): Middleware: refactor how piggieback dependencies are established.
+- Bump `nrepl` to [1.7.0](https://github.com/nrepl/nrepl/blob/master/CHANGELOG.md#170-2026-04-14).
+- Bump `tools.reader` to 1.6.0.
+- Bump `tools.namespace` to 1.5.1.
+- Bump `orchard` to [0.41.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0410-2026-04-13).
+- [#959](https://github.com/clojure-emacs/cider-nrepl/pull/959): Stop shading Compliment and clj-reload.
+- [#710](https://github.com/clojure-emacs/cider-nrepl/issues/710): Make namespaced ops (e.g., `cider/complete`) the default and keep the old names as deprecated aliases.
+- [#965](https://github.com/clojure-emacs/cider-nrepl/issues/965): Stop losing quotes in matcher-combinators test output.
+- [#972](https://github.com/clojure-emacs/cider-nrepl/issues/972): Stop relying on tools.reader functions in our code.
+- [#971](https://github.com/clojure-emacs/cider-nrepl/issues/971): Middleware: refactor how piggieback dependencies are established.
 
 ## 0.58.0 (2025-10-16)
 
-* Bump `nrepl` to [1.5.0](https://github.com/nrepl/nrepl/blob/master/CHANGELOG.md#150-2025-10-15).
-* Bump `orchard` to [0.37.1](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0371-2025-10-14).
-* Bump `compliment` to [0.7.1](https://github.com/alexander-yakushev/compliment/blob/master/CHANGELOG.md#071-2025-09-19).
-* [#950](https://github.com/clojure-emacs/cider-nrepl/pull/950): Inspect: support tidying qualified keywords.
-* [#951](https://github.com/clojure-emacs/cider-nrepl/pull/951): Debug: correctly process #dbg tag during load-file.
+- Bump `nrepl` to [1.5.0](https://github.com/nrepl/nrepl/blob/master/CHANGELOG.md#150-2025-10-15).
+- Bump `orchard` to [0.37.1](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0371-2025-10-14).
+- Bump `compliment` to [0.7.1](https://github.com/alexander-yakushev/compliment/blob/master/CHANGELOG.md#071-2025-09-19).
+- [#950](https://github.com/clojure-emacs/cider-nrepl/pull/950): Inspect: support tidying qualified keywords.
+- [#951](https://github.com/clojure-emacs/cider-nrepl/pull/951): Debug: correctly process #dbg tag during load-file.
 
 ## 0.57.0 (2025-06-29)
 
-* Bump `orchard` to [0.36.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0360-2025-06-29).
+- Bump `orchard` to [0.36.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0360-2025-06-29).
 
 ## 0.56.0 (2025-05-29)
 
-* Bump `orchard` to [0.35.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0350-2025-05-28).
-* [#941](https://github.com/clojure-emacs/cider-nrepl/pull/941): Stop vendoring Fipp dependency.
-* [#941](https://github.com/clojure-emacs/cider-nrepl/pull/941): Default to orchard.pp printer when Fipp/Puget/Zprint is selected but not found on classpath.
-* [#943](https://github.com/clojure-emacs/cider-nrepl/pull/943): Debug: reduce insrumentation bytecode footprint.
+- Bump `orchard` to [0.35.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0350-2025-05-28).
+- [#941](https://github.com/clojure-emacs/cider-nrepl/pull/941): Stop vendoring Fipp dependency.
+- [#941](https://github.com/clojure-emacs/cider-nrepl/pull/941): Default to orchard.pp printer when Fipp/Puget/Zprint is selected but not found on classpath.
+- [#943](https://github.com/clojure-emacs/cider-nrepl/pull/943): Debug: reduce insrumentation bytecode footprint.
 
 ## 0.55.7 (2025-04-29)
 
-* [#939](https://github.com/clojure-emacs/cider-nrepl/pull/939): Tracker: synchronize access to WeakHashMap cache to prevent infinite loops.
+- [#939](https://github.com/clojure-emacs/cider-nrepl/pull/939): Tracker: synchronize access to WeakHashMap cache to prevent infinite loops.
 
 ## 0.55.6 (2025-04-28)
 
-* Bump `orchard` to [0.34.3](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0343-2025-04-28).
+- Bump `orchard` to [0.34.3](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0343-2025-04-28).
 
 ## 0.55.4 (2025-04-26)
 
-* Bump `orchard` to [0.34.2](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0342-2025-04-26).
+- Bump `orchard` to [0.34.2](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0342-2025-04-26).
 
 ## 0.55.3 (2025-04-24)
 
-* [#933](https://github.com/clojure-emacs/cider-nrepl/pull/933): Add the `cider-inspector-print-current-value` command to print the current value of the inspector.
-* Bump `orchard` to [0.34.1](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0341-2025-04-23).
-* [#935](https://github.com/clojure-emacs/cider-nrepl/pull/935): Unify injected print-method implementations with orchard.print.
+- [#933](https://github.com/clojure-emacs/cider-nrepl/pull/933): Add the `cider-inspector-print-current-value` command to print the current value of the inspector.
+- Bump `orchard` to [0.34.1](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0341-2025-04-23).
+- [#935](https://github.com/clojure-emacs/cider-nrepl/pull/935): Unify injected print-method implementations with orchard.print.
 
 ## 0.55.2 (2025-04-18)
 
-* Bump `orchard` to [0.34.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0340-2025-04-18).
-* [#934](https://github.com/clojure-emacs/cider-nrepl/pull/934): **BREAKING** — Remove Boot support.
-* [#932](https://github.com/clojure-emacs/cider-nrepl/pull/932): Inspector: add pretty-printing support.
+- Bump `orchard` to [0.34.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0340-2025-04-18).
+- [#934](https://github.com/clojure-emacs/cider-nrepl/pull/934): **BREAKING** — Remove Boot support.
+- [#932](https://github.com/clojure-emacs/cider-nrepl/pull/932): Inspector: add pretty-printing support.
 
 ## 0.55.1 (2025-04-14)
 
-* [#931](https://github.com/clojure-emacs/cider-nrepl/pull/931): Redesign and optimize track-state middleware.
+- [#931](https://github.com/clojure-emacs/cider-nrepl/pull/931): Redesign and optimize track-state middleware.
 
 ## 0.55.0 (2025-04-10)
 
-* Bump `orchard` to [0.33.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0330-2025-04-08).
-* [#929](https://github.com/clojure-emacs/cider-nrepl/pull/929): Migrate profiling middleware to orchard.profile.
-* [#930](https://github.com/clojure-emacs/cider-nrepl/pull/930): Stacktrace: add support for directly inspecting ex-data
+- Bump `orchard` to [0.33.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0330-2025-04-08).
+- [#929](https://github.com/clojure-emacs/cider-nrepl/pull/929): Migrate profiling middleware to orchard.profile.
+- [#930](https://github.com/clojure-emacs/cider-nrepl/pull/930): Stacktrace: add support for directly inspecting ex-data
 
 ## 0.54.0 (2025-04-05)
 
-* Bump `orchard` to [0.32.1](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0320-2025-04-05).
-* [#925](https://github.com/clojure-emacs/cider-nrepl/pull/925): Stop vendoring Puget dependency.
-* [#917](https://github.com/clojure-emacs/cider-nrepl/pull/917): Sort printed maps in test output.
-* [#927](https://github.com/clojure-emacs/cider-nrepl/pull/927): Add `inspect-display-analytics` op.
-* [#928](https://github.com/clojure-emacs/cider-nrepl/pull/922): Add support for `:table` view-mode in inspector.
+- Bump `orchard` to [0.32.1](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0320-2025-04-05).
+- [#925](https://github.com/clojure-emacs/cider-nrepl/pull/925): Stop vendoring Puget dependency.
+- [#917](https://github.com/clojure-emacs/cider-nrepl/pull/917): Sort printed maps in test output.
+- [#927](https://github.com/clojure-emacs/cider-nrepl/pull/927): Add `inspect-display-analytics` op.
+- [#928](https://github.com/clojure-emacs/cider-nrepl/pull/922): Add support for `:table` view-mode in inspector.
 
 ## 0.53.2 (2025-03-26)
 
-* [#923](https://github.com/clojure-emacs/cider-nrepl/pull/923): Complete: make sorting order customizable.
+- [#923](https://github.com/clojure-emacs/cider-nrepl/pull/923): Complete: make sorting order customizable.
 
 ## 0.53.1 (2025-03-26)
 
-* Bump `compliment` to [0.7.0](https://github.com/alexander-yakushev/compliment/blob/master/CHANGELOG.md#070-2025-03-25).
+- Bump `compliment` to [0.7.0](https://github.com/alexander-yakushev/compliment/blob/master/CHANGELOG.md#070-2025-03-25).
 
 ## 0.53.0 (2025-03-19)
 
-* Bump `orchard` to [0.31.1](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0311-2025-03-19).
+- Bump `orchard` to [0.31.1](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0311-2025-03-19).
   - Info: recognize printed Java classes/methods and munged Clojure functions in stacktrace outputs.
   - Add dedicated renderers for exceptions in inspector and debugger.
-* [#919](https://github.com/clojure-emacs/cider-nrepl/pull/919): Move exception analysis to Orchard.
+- [#919](https://github.com/clojure-emacs/cider-nrepl/pull/919): Move exception analysis to Orchard.
   - **BREAKING**: Remove `analyze-stacktrace` and `cider/log-analyze-stacktrace` ops.
   - Stop vendoring Haystack dependency.
-* [#913](https://github.com/clojure-emacs/cider-nrepl/pull/913): Disable background warmup of `orchard.java` cache.
-* [#913](https://github.com/clojure-emacs/cider-nrepl/pull/913): Enable background warmup of Compliment cache.
-* [#914](https://github.com/clojure-emacs/cider-nrepl/pull/914): Remove javadoc section from the inspector output.
+- [#913](https://github.com/clojure-emacs/cider-nrepl/pull/913): Disable background warmup of `orchard.java` cache.
+- [#913](https://github.com/clojure-emacs/cider-nrepl/pull/913): Enable background warmup of Compliment cache.
+- [#914](https://github.com/clojure-emacs/cider-nrepl/pull/914): Remove javadoc section from the inspector output.
 
 ## 0.52.1 (2025-02-24)
 
-* Bump `orchard` to [0.30.1](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0301-2025-02-24).
+- Bump `orchard` to [0.30.1](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0301-2025-02-24).
 
 ## 0.52.0 (2025-01-10)
 
-* Bump `orchard` to [0.30.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0300-2025-01-10).
-* * [#911](https://github.com/clojure-emacs/cider-nrepl/pull/911): Add support for automatically downloading sources JARs in `info` op.
+- Bump `orchard` to [0.30.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0300-2025-01-10).
+- [#911](https://github.com/clojure-emacs/cider-nrepl/pull/911): Add support for automatically downloading sources JARs in `info` op.
 
 ## 0.51.1 (2025-01-03)
 
-* Bump `orchard` to [0.29.1](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0291-2025-01-03).
-* [#910](https://github.com/clojure-emacs/cider-nrepl/pull/910): Protect Orchard Java machinery initialization with a try/catch.
+- Bump `orchard` to [0.29.1](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0291-2025-01-03).
+- [#910](https://github.com/clojure-emacs/cider-nrepl/pull/910): Protect Orchard Java machinery initialization with a try/catch.
 
 ## 0.51.0 (2025-01-01)
 
-* Bump `orchard` to [0.29.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0290-2024-12-31).
+- Bump `orchard` to [0.29.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0290-2024-12-31).
   - **BREAKING**: Drop support for Java sources parsing on JDK8.
   - Rework Java sources discovery.
 
 ## 0.50.3 (2024-12-02)
 
-* Bump `orchard` to [0.28.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0280-2024-10-31).
-* [#885 (partial)](https://github.com/clojure-emacs/cider-nrepl/issues/885): Limited update to `info` op doc (`arglists-str`, `file`, `line`, `column`, `name` and `ns` return keys).
+- Bump `orchard` to [0.28.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0280-2024-10-31).
+- [#885 (partial)](https://github.com/clojure-emacs/cider-nrepl/issues/885): Limited update to `info` op doc (`arglists-str`, `file`, `line`, `column`, `name` and `ns` return keys).
 
 ## 0.50.2 (2024-09-03)
 
-* [#900](https://github.com/clojure-emacs/cider-nrepl/pull/900): Fix print middleware interfering with macroexpansion.
+- [#900](https://github.com/clojure-emacs/cider-nrepl/pull/900): Fix print middleware interfering with macroexpansion.
 
 ## 0.50.1 (2024-08-28)
 
-* Bump `orchard` to [0.27.2](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0272-2024-08-28).
+- Bump `orchard` to [0.27.2](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0272-2024-08-28).
 
 ## 0.50.0 (2024-08-28)
 
-* [#893](https://github.com/clojure-emacs/cider-nrepl/pull/893): Replace `clojure.tools.trace` with `orchard.trace`.
-* [#894](https://github.com/clojure-emacs/cider-nrepl/pull/894): Delegate actual macroexpansion to "eval" command in middleware.macroexpand.
-* Bump `orchard` to [0.27.1](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0271-2024-08-27).
+- [#893](https://github.com/clojure-emacs/cider-nrepl/pull/893): Replace `clojure.tools.trace` with `orchard.trace`.
+- [#894](https://github.com/clojure-emacs/cider-nrepl/pull/894): Delegate actual macroexpansion to "eval" command in middleware.macroexpand.
+- Bump `orchard` to [0.27.1](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0271-2024-08-27).
   - BREAKING: Remove special handling of Boot classpath.
 
 ## 0.49.3 (2024-08-13)
 
 ### Changes
 
-* Bump `compliment` to [0.6.0](https://github.com/alexander-yakushev/compliment/blob/master/CHANGELOG.md#060-2024-08-13).
+- Bump `compliment` to [0.6.0](https://github.com/alexander-yakushev/compliment/blob/master/CHANGELOG.md#060-2024-08-13).
 
 ## 0.49.2 (2024-07-19)
 
 ### Changes
 
-* Bump `orchard` to [0.26.2](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0262-2024-07-19)
+- Bump `orchard` to [0.26.2](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0262-2024-07-19)
 
 ## 0.49.1 (2024-06-30)
 
 ### Changes
 
-* [#883](https://github.com/clojure-emacs/cider-nrepl/pull/883): Reduce minimal Clojure requirement to 1.10.0.
+- [#883](https://github.com/clojure-emacs/cider-nrepl/pull/883): Reduce minimal Clojure requirement to 1.10.0.
 
 ## Bugs fixed
 
-* [CIDER#3684](https://github.com/clojure-emacs/cider/issues/3684): Don't apply indentation inference for `:style/indent nil` metadata.
+- [CIDER#3684](https://github.com/clojure-emacs/cider/issues/3684): Don't apply indentation inference for `:style/indent nil` metadata.
 
 ## 0.49.0 (2024-06-02)
 
 ### Changes
 
-* [#877](https://github.com/clojure-emacs/cider-nrepl/pull/877): `inspect-refresh` middleware is now capable of setting all config options that `orchard.inspect` supports.
-* [#877](https://github.com/clojure-emacs/cider-nrepl/pull/877): Deprecate all `inspect-set-*` middleware ops.
-* [#879](https://github.com/clojure-emacs/cider-nrepl/pull/879), [#880](https://github.com/clojure-emacs/cider-nrepl/pull/880): Add `inspect-toggle-view-mode` op.
-* Bump `orchard` to [0.26.1](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0261-2024-06-02)
+- [#877](https://github.com/clojure-emacs/cider-nrepl/pull/877): `inspect-refresh` middleware is now capable of setting all config options that `orchard.inspect` supports.
+- [#877](https://github.com/clojure-emacs/cider-nrepl/pull/877): Deprecate all `inspect-set-*` middleware ops.
+- [#879](https://github.com/clojure-emacs/cider-nrepl/pull/879), [#880](https://github.com/clojure-emacs/cider-nrepl/pull/880): Add `inspect-toggle-view-mode` op.
+- Bump `orchard` to [0.26.1](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0261-2024-06-02)
 
 ## 0.48.0 (2024-05-13)
 
 ### Changes
 
-* [#868](https://github.com/clojure-emacs/cider-nrepl/pull/868): Drop support for Clojure 1.9.
-* Refine `ops-that-can-eval` internals, adapting them to the new `cider.nrepl.middleware.reload` ops.
-* Bump `nrepl` to [1.1.1](https://github.com/nrepl/nrepl/blob/master/CHANGELOG.md#111-2024-02-20).
-* Bump `compliment` to [0.5.5](https://github.com/alexander-yakushev/compliment/blob/master/CHANGELOG.md#055-2024-05-06).
-* Bump `clj-reload` to [0.6.0](https://github.com/tonsky/clj-reload/blob/0.6.0/CHANGELOG.md#060---may-3-2024).
-* Bump `tools.trace` to 0.8.0 (no changes in source code).
-* Bump `tools.reader` to [1.4.1](https://github.com/clojure/tools.reader/blob/master/CHANGELOG.md).
-* Bump `orchard` to [0.25.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0250-2024-05-03).
-  * Bring many improvements to CIDER Inspector (see Orchard CHANGELOG).
-* Add `inspect-set-max-nested-depth` op that customizes how many nested levels the Inspector will print before abridging.
-* [#826](https://github.com/clojure-emacs/cider-nrepl/pull/826): Remove broken `inspect-get-path` middleware op, return path in every inspector middleware op instead.
-* Reduce the print length of values that CIDER debugger produces for overlay.
-* [cider#3652](https://github.com/clojure-emacs/cider/issues/3652) `middleware.refresh`: elide a lock for the `"refresh-clear"` op.
+- [#868](https://github.com/clojure-emacs/cider-nrepl/pull/868): Drop support for Clojure 1.9.
+- Refine `ops-that-can-eval` internals, adapting them to the new `cider.nrepl.middleware.reload` ops.
+- Bump `nrepl` to [1.1.1](https://github.com/nrepl/nrepl/blob/master/CHANGELOG.md#111-2024-02-20).
+- Bump `compliment` to [0.5.5](https://github.com/alexander-yakushev/compliment/blob/master/CHANGELOG.md#055-2024-05-06).
+- Bump `clj-reload` to [0.6.0](https://github.com/tonsky/clj-reload/blob/0.6.0/CHANGELOG.md#060---may-3-2024).
+- Bump `tools.trace` to 0.8.0 (no changes in source code).
+- Bump `tools.reader` to [1.4.1](https://github.com/clojure/tools.reader/blob/master/CHANGELOG.md).
+- Bump `orchard` to [0.25.0](https://github.com/clojure-emacs/orchard/blob/master/CHANGELOG.md#0250-2024-05-03).
+  - Bring many improvements to CIDER Inspector (see Orchard CHANGELOG).
+- Add `inspect-set-max-nested-depth` op that customizes how many nested levels the Inspector will print before abridging.
+- [#826](https://github.com/clojure-emacs/cider-nrepl/pull/826): Remove broken `inspect-get-path` middleware op, return path in every inspector middleware op instead.
+- Reduce the print length of values that CIDER debugger produces for overlay.
+- [cider#3652](https://github.com/clojure-emacs/cider/issues/3652) `middleware.refresh`: elide a lock for the `"refresh-clear"` op.
 
 ## 0.47.1 (2024-03-24)
 
 ### Changes
 
-* Bump `orchard` to [0.23.3](https://github.com/clojure-emacs/orchard/blob/v0.23.3/CHANGELOG.md#0233-2024-03-24).
+- Bump `orchard` to [0.23.3](https://github.com/clojure-emacs/orchard/blob/v0.23.3/CHANGELOG.md#0233-2024-03-24).
 
 ## 0.47.0 (2024-03-10)
 
 ### Changes
 
-* Bump `orchard` to [0.23.2](https://github.com/clojure-emacs/orchard/blob/v0.23.2/CHANGELOG.md#0232-2024-03-10).
-* Bump `compliment` to [0.5.2](https://github.com/alexander-yakushev/compliment/blob/14329344/CHANGELOG.md#052-2024-03-07).
+- Bump `orchard` to [0.23.2](https://github.com/clojure-emacs/orchard/blob/v0.23.2/CHANGELOG.md#0232-2024-03-10).
+- Bump `compliment` to [0.5.2](https://github.com/alexander-yakushev/compliment/blob/14329344/CHANGELOG.md#052-2024-03-07).
 
 ## Bugs fixed
 
-* [#854](https://github.com/clojure-emacs/cider-nrepl/pull/854): Fix `cider.nrepl.middleware.reload/reload-all`.
-* `cider.nrepl.middleware.reload`: support `:before` / `:after` functions.
+- [#854](https://github.com/clojure-emacs/cider-nrepl/pull/854): Fix `cider.nrepl.middleware.reload/reload-all`.
+- `cider.nrepl.middleware.reload`: support `:before` / `:after` functions.
 
 ## 0.46.0 (2024-03-05)
 
 ### New features
 
-* [#850](https://github.com/clojure-emacs/cider-nrepl/pull/850): Add [clj-reload](https://github.com/tonsky/clj-reload) functionality by implementing new `cider.clj-reload/reload`, `cider.clj-reload/reload-all`, `cider.clj-reload/reload-clear` ops.
-  * These are drop-in replacements for `refresh`, `refresh-all`, `refresh-clear`.
+- [#850](https://github.com/clojure-emacs/cider-nrepl/pull/850): Add [clj-reload](https://github.com/tonsky/clj-reload) functionality by implementing new `cider.clj-reload/reload`, `cider.clj-reload/reload-all`, `cider.clj-reload/reload-clear` ops.
+  - These are drop-in replacements for `refresh`, `refresh-all`, `refresh-clear`.
 
 ### Changes
 
-* Bump `orchard` to [0.23.0](https://github.com/clojure-emacs/orchard/blob/v0.23.0/CHANGELOG.md#0230-2024-03-03).
-* Bump `logjam` to [0.3.0](https://github.com/clojure-emacs/logjam/blob/v0.3.0/CHANGELOG.md#030-2024-03-03).
-* [#851](https://github.com/clojure-emacs/cider-nrepl/issues/851): `middleware.info`: offer new `var-meta-allowlist` option.
+- Bump `orchard` to [0.23.0](https://github.com/clojure-emacs/orchard/blob/v0.23.0/CHANGELOG.md#0230-2024-03-03).
+- Bump `logjam` to [0.3.0](https://github.com/clojure-emacs/logjam/blob/v0.3.0/CHANGELOG.md#030-2024-03-03).
+- [#851](https://github.com/clojure-emacs/cider-nrepl/issues/851): `middleware.info`: offer new `var-meta-allowlist` option.
 
 ## Bugs fixed
 
-*  [#846](https://github.com/clojure-emacs/cider-nrepl/issues/846): `middleware.debug`: use `resolve` with `&env` to fix debugging in case of a local shadows a var.
+- [#846](https://github.com/clojure-emacs/cider-nrepl/issues/846): `middleware.debug`: use `resolve` with `&env` to fix debugging in case of a local shadows a var.
 
 ## 0.45.0 (2024-01-14)
 
 ### Changes
 
-* Bump `orchard` to [0.22.0](https://github.com/clojure-emacs/orchard/blob/v0.22.0/CHANGELOG.md#0220-2024-01-14).
-* Bump `logjam` to [0.2.0](https://github.com/clojure-emacs/logjam/blob/v0.2.0/CHANGELOG.md#020-2024-01-04).
-* Bump `suitable` to [0.6.2](https://github.com/clojure-emacs/clj-suitable/blob/v0.6.2/CHANGELOG.md#062-2033-01-14).
-* Bump `compliment` to [0.5.1](https://github.com/alexander-yakushev/compliment/blob/6119d8/CHANGELOG.md#051-2023-11-30).
-* [#842](https://github.com/clojure-emacs/cider-nrepl/issues/842): Initial cache warmup: ensure that no classes' static initializers are run.
-* [#840](https://github.com/clojure-emacs/cider-nrepl/pull/840): Drop support for Clojure 1.8.
-* Forcibly exit the JVM on older (unsupported) Clojure versions.
-  * This can help users and maintainers alike diagnose issues more quickly, avoiding problematic code paths in our middleware, and clients like cider.el.
+- Bump `orchard` to [0.22.0](https://github.com/clojure-emacs/orchard/blob/v0.22.0/CHANGELOG.md#0220-2024-01-14).
+- Bump `logjam` to [0.2.0](https://github.com/clojure-emacs/logjam/blob/v0.2.0/CHANGELOG.md#020-2024-01-04).
+- Bump `suitable` to [0.6.2](https://github.com/clojure-emacs/clj-suitable/blob/v0.6.2/CHANGELOG.md#062-2033-01-14).
+- Bump `compliment` to [0.5.1](https://github.com/alexander-yakushev/compliment/blob/6119d8/CHANGELOG.md#051-2023-11-30).
+- [#842](https://github.com/clojure-emacs/cider-nrepl/issues/842): Initial cache warmup: ensure that no classes' static initializers are run.
+- [#840](https://github.com/clojure-emacs/cider-nrepl/pull/840): Drop support for Clojure 1.8.
+- Forcibly exit the JVM on older (unsupported) Clojure versions.
+  - This can help users and maintainers alike diagnose issues more quickly, avoiding problematic code paths in our middleware, and clients like cider.el.
 
 ## 0.44.0 (2023-11-24)
 
 ### New features
 
-* Add `inspect-tap-indexed` op.
+- Add `inspect-tap-indexed` op.
 
 ### Changes
 
-* `middleware.inspect:` warm up Orchard info for a value's class implemented interfaces in advance.
-  * Can speed up navigation.
+- `middleware.inspect:` warm up Orchard info for a value's class implemented interfaces in advance.
+  - Can speed up navigation.
 
 ## 0.43.3 (2023-11-11)
 
 ### Changes
 
-* Bump `orchard` to [0.20.0](https://github.com/clojure-emacs/orchard/blob/v0.20.0/CHANGELOG.md#0200-2023-11-11).
-* Bump `haystack` to [0.3.3](https://github.com/clojure-emacs/haystack/blob/v0.3.3/CHANGELOG.md#033-2023-11-11).
-  * Fixes a performance regression.
+- Bump `orchard` to [0.20.0](https://github.com/clojure-emacs/orchard/blob/v0.20.0/CHANGELOG.md#0200-2023-11-11).
+- Bump `haystack` to [0.3.3](https://github.com/clojure-emacs/haystack/blob/v0.3.3/CHANGELOG.md#033-2023-11-11).
+  - Fixes a performance regression.
 
 ## 0.43.1 (2023-11-07)
 
 ### Changes
 
-* [#828](https://github.com/clojure-emacs/cider-nrepl/issues/828): Warmup Orchard caches for compile-time exceptions in advance.
-  * This is similar to a change introduced in 0.43.0, but for compile-time exceptions this time.
-* Bump `suitable` to [0.6.1](https://github.com/clojure-emacs/clj-suitable/blob/62785/CHANGELOG.md#061-2023-11-07).
+- [#828](https://github.com/clojure-emacs/cider-nrepl/issues/828): Warmup Orchard caches for compile-time exceptions in advance.
+  - This is similar to a change introduced in 0.43.0, but for compile-time exceptions this time.
+- Bump `suitable` to [0.6.1](https://github.com/clojure-emacs/clj-suitable/blob/62785/CHANGELOG.md#061-2023-11-07).
 
 ## Bugs fixed
 
-* Make `"inspect-refresh"` op work again.
+- Make `"inspect-refresh"` op work again.
 
 ## 0.43.0 (2023-11-04)
 
 ### New features
 
-* [cider#3565](https://github.com/clojure-emacs/cider/issues/3565): Add new [`inspect-last-exception`](https://docs.cider.mx/cider-nrepl/nrepl-api/ops.html#inspect-last-exception) op.
-* Inspector: include [`:doc-fragments`](https://docs.cider.mx/cider-nrepl/nrepl-api/ops.html#inspect-push) for all responses which `:value` is a Class, Field or Method.
+- [cider#3565](https://github.com/clojure-emacs/cider/issues/3565): Add new [`inspect-last-exception`](https://docs.cider.mx/cider-nrepl/nrepl-api/ops.html#inspect-last-exception) op.
+- Inspector: include [`:doc-fragments`](https://docs.cider.mx/cider-nrepl/nrepl-api/ops.html#inspect-push) for all responses which `:value` is a Class, Field or Method.
 
 ### Changes
 
-* [#830](https://github.com/clojure-emacs/cider-nrepl/issues/830): Warmup Orchard caches for Java imported classes in advance.
-  * Speculatively improves performance for the classes that users are more likely to use in a given project.
-* [#828](https://github.com/clojure-emacs/cider-nrepl/issues/828): Warmup Orchard caches for exceptions in advance.
-  * This noticeably improves the first-time performance of exception-related ops, e.g. `analyze-last-stacktrace`.
-* Bump `orchard` to [0.19.0](https://github.com/clojure-emacs/orchard/blob/v0.19.0/CHANGELOG.md#0190-2023-11-04).
+- [#830](https://github.com/clojure-emacs/cider-nrepl/issues/830): Warmup Orchard caches for Java imported classes in advance.
+  - Speculatively improves performance for the classes that users are more likely to use in a given project.
+- [#828](https://github.com/clojure-emacs/cider-nrepl/issues/828): Warmup Orchard caches for exceptions in advance.
+  - This noticeably improves the first-time performance of exception-related ops, e.g. `analyze-last-stacktrace`.
+- Bump `orchard` to [0.19.0](https://github.com/clojure-emacs/orchard/blob/v0.19.0/CHANGELOG.md#0190-2023-11-04).
 
 ## 0.42.1 (2023-10-31)
 
-* Bump `suitable` to [0.5.1](https://github.com/clojure-emacs/clj-suitable/blob/v0.5.1/CHANGELOG.md#051-2023-10-31).
+- Bump `suitable` to [0.5.1](https://github.com/clojure-emacs/clj-suitable/blob/v0.5.1/CHANGELOG.md#051-2023-10-31).
 
 ## 0.42.0 (2023-10-30)
 
 ### Changes
 
-* Bump `orchard` to [0.18.0](https://github.com/clojure-emacs/orchard/blob/v0.18.0/CHANGELOG.md#0180-2023-10-30).
-* Warmup Orchard (`info`, `complete`, `eldoc`) caches in advance.
-  * Restores the first-time performance that had been lost for a few releases.
+- Bump `orchard` to [0.18.0](https://github.com/clojure-emacs/orchard/blob/v0.18.0/CHANGELOG.md#0180-2023-10-30).
+- Warmup Orchard (`info`, `complete`, `eldoc`) caches in advance.
+  - Restores the first-time performance that had been lost for a few releases.
 
 ## 0.41.0 (2023-10-24)
 
 ### New features
 
-* `middleware.inspect:` add new `inspect-tap-current-value` op.
-* `middleware.inspect:` add new `inspect-previous-sibling`, `inspect-next-sibling` ops.
+- `middleware.inspect:` add new `inspect-tap-current-value` op.
+- `middleware.inspect:` add new `inspect-previous-sibling`, `inspect-next-sibling` ops.
 
 ## 0.40.0 (2023-10-15)
 
 ### Changes
 
-* `track-state`: include var info for macros defined for ClojureScript namespaces.
-  * e.g. for `foo.cljs`, now var info for any macros contained in `foo.clj` is also included.
+- `track-state`: include var info for macros defined for ClojureScript namespaces.
+  - e.g. for `foo.cljs`, now var info for any macros contained in `foo.clj` is also included.
 
 ## 0.39.1 (2023-10-12)
 
 ### Changes
 
-* Bump `compliment` to [0.4.4](https://github.com/alexander-yakushev/compliment/blob/0.4.4/CHANGELOG.md#044-2023-10-10).
+- Bump `compliment` to [0.4.4](https://github.com/alexander-yakushev/compliment/blob/0.4.4/CHANGELOG.md#044-2023-10-10).
 
 ## 0.39.0 (2023-10-05)
 
 ### Changes
 
-* Bump `orchard` to [0.16.1](https://github.com/clojure-emacs/orchard/blob/v0.16.1/CHANGELOG.md#0161-2023-10-05).
-* Bump `haystack` to [0.3.1](https://github.com/clojure-emacs/haystack/blob/v0.3.1/CHANGELOG.md#031-2023-09-29).
+- Bump `orchard` to [0.16.1](https://github.com/clojure-emacs/orchard/blob/v0.16.1/CHANGELOG.md#0161-2023-10-05).
+- Bump `haystack` to [0.3.1](https://github.com/clojure-emacs/haystack/blob/v0.3.1/CHANGELOG.md#031-2023-09-29).
 
 ### Bugs Fixed
 
-* `info` and `eldoc` ops: fix regression for the special form `..`.
+- `info` and `eldoc` ops: fix regression for the special form `..`.
 
 ## 0.38.1 (2023-09-21)
 
-* Bump `orchard` to [0.15.1](https://github.com/clojure-emacs/orchard/blob/v0.15.1/CHANGELOG.md#0151-2023-09-21).
+- Bump `orchard` to [0.15.1](https://github.com/clojure-emacs/orchard/blob/v0.15.1/CHANGELOG.md#0151-2023-09-21).
 
 ## 0.38.0 (2023-09-21)
 
 ### Changes
 
-* `info` and `eldoc` ops: also return `:doc-fragments`, `:doc-first-sentence-fragments`, `:doc-first-sentence-fragments` attributes when available.
-  * These are explained in https://github.com/clojure-emacs/orchard/blob/v0.15.0/src-newer-jdks/orchard/java/parser_next.clj#L2-L20
-  * These typically are only available when running a modern JDK through enrich-classpath.
-* `info` and `eldoc` ops: accept a Compliment-style `context` parameter that helps infering the Java class of the object being queried.
-* Bump `orchard` to [1.5.0](https://github.com/clojure-emacs/orchard/blob/v0.15.0/CHANGELOG.md#0150-2023-09-20).
-* Bump `compliment` to [0.4.3](https://github.com/alexander-yakushev/compliment/blob/0.4.3/CHANGELOG.md#043-2023-09-21).
+- `info` and `eldoc` ops: also return `:doc-fragments`, `:doc-first-sentence-fragments`, `:doc-first-sentence-fragments` attributes when available.
+  - These are explained in <https://github.com/clojure-emacs/orchard/blob/v0.15.0/src-newer-jdks/orchard/java/parser_next.clj#L2-L20>
+  - These typically are only available when running a modern JDK through enrich-classpath.
+- `info` and `eldoc` ops: accept a Compliment-style `context` parameter that helps infering the Java class of the object being queried.
+- Bump `orchard` to [1.5.0](https://github.com/clojure-emacs/orchard/blob/v0.15.0/CHANGELOG.md#0150-2023-09-20).
+- Bump `compliment` to [0.4.3](https://github.com/alexander-yakushev/compliment/blob/0.4.3/CHANGELOG.md#043-2023-09-21).
 
 ## 0.37.1 (2023-09-08)
 
 ### Bugs Fixed
 
-* `middleware.track-state`: handle non-existing .jar files that may be in the classpath.
+- `middleware.track-state`: handle non-existing .jar files that may be in the classpath.
 
 ## 0.37.0 (2023-08-27)
 
 ### Changes
 
-* `"ns-path"` op: also include a `:url` attribute in the response.
+- `"ns-path"` op: also include a `:url` attribute in the response.
 
 ## 0.36.1 (2023-08-22)
 
 ### Changes
 
-* Bump `compliment` to [0.4.1](https://github.com/alexander-yakushev/compliment/blob/master/CHANGELOG.md#041-2023-08-23).
+- Bump `compliment` to [0.4.1](https://github.com/alexander-yakushev/compliment/blob/master/CHANGELOG.md#041-2023-08-23).
 
 ## 0.36.0 (2023-08-21)
 
 ### Changes
 
-* Bump `haystack` to [0.2.0](https://github.com/clojure-emacs/haystack/blob/0077b5c49f4aef1c7f89d5430d6dda2f9e7d78d4/CHANGELOG.md#020-2023-08-20).
+- Bump `haystack` to [0.2.0](https://github.com/clojure-emacs/haystack/blob/0077b5c49f4aef1c7f89d5430d6dda2f9e7d78d4/CHANGELOG.md#020-2023-08-20).
 
 ## 0.35.1 (2023-08-18)
 
 ### Changes
 
-* Bump `haystack` to [0.1.0](https://github.com/clojure-emacs/haystack/blob/v0.1.0/CHANGELOG.md#010).
+- Bump `haystack` to [0.1.0](https://github.com/clojure-emacs/haystack/blob/v0.1.0/CHANGELOG.md#010).
 
 ## 0.35.0 (2023-08-09)
 
 ### New features
 
-* Make the `track-state` middleware invokeable directly, by requesting the new `"cider/get-state"` op.
-  * This makes it possible to access `:changed-namespaces` info on demand, which can be necessary for:
-    * non-Piggieback based clojurescript repls
-    * re-computing the ns info responding to external (non-nREPL triggered) events.
+- Make the `track-state` middleware invokeable directly, by requesting the new `"cider/get-state"` op.
+  - This makes it possible to access `:changed-namespaces` info on demand, which can be necessary for:
+    - non-Piggieback based clojurescript repls
+    - re-computing the ns info responding to external (non-nREPL triggered) events.
 
 ### Changes
 
-* [#796](https://github.com/clojure-emacs/cider-nrepl/issues/796): `fn-refs` and `fn-deps` middleware: add new `:file-url` field.
-  * these are absolute and prefixed by `file:` or `file:jar:`, whenever possible.
-* `fn-refs` and `fn-deps` middleware: sort the results by file, line and column.
-* Bump `orchard` to [1.4.2](https://github.com/clojure-emacs/orchard/blob/v0.14.2/CHANGELOG.md#0142-2023-08-09).
+- [#796](https://github.com/clojure-emacs/cider-nrepl/issues/796): `fn-refs` and `fn-deps` middleware: add new `:file-url` field.
+  - these are absolute and prefixed by `file:` or `file:jar:`, whenever possible.
+- `fn-refs` and `fn-deps` middleware: sort the results by file, line and column.
+- Bump `orchard` to [1.4.2](https://github.com/clojure-emacs/orchard/blob/v0.14.2/CHANGELOG.md#0142-2023-08-09).
 
 ## 0.34.0 (2023-08-03)
 
-* Bump `orchard` to [1.4.0](https://github.com/clojure-emacs/orchard/blob/v0.14.0/CHANGELOG.md#0140-2023-08-03).
+- Bump `orchard` to [1.4.0](https://github.com/clojure-emacs/orchard/blob/v0.14.0/CHANGELOG.md#0140-2023-08-03).
 
 ## 0.33.0 (2023-07-31)
 
 ### New features
 
-* [#777](https://github.com/clojure-emacs/cider-nrepl/issues/777) `middleware.track-state`: now an inferred `:style/indent` metadata value is included, when adequate.
+- [#777](https://github.com/clojure-emacs/cider-nrepl/issues/777) `middleware.track-state`: now an inferred `:style/indent` metadata value is included, when adequate.
 
 ### Changes
 
-* Bump `suitable` to [0.5.0](https://github.com/clojure-emacs/clj-suitable/blob/v0.5.0/CHANGELOG.md#050-2023-07-28).
+- Bump `suitable` to [0.5.0](https://github.com/clojure-emacs/clj-suitable/blob/v0.5.0/CHANGELOG.md#050-2023-07-28).
 
 ### Bugs Fixed
 
-* [CIDER #3385](https://github.com/clojure-emacs/cider/issues/3385): `track-state`: Include `cljs.core` ns info.
+- [CIDER #3385](https://github.com/clojure-emacs/cider/issues/3385): `track-state`: Include `cljs.core` ns info.
 
 ## 0.32.0 (2023-07-26)
 
 ### New features
 
-* [#773](https://github.com/clojure-emacs/cider-nrepl/pull/773) Add middleware to capture, debug, inspect and view log events emitted by Java logging frameworks.
-* [#755](https://github.com/clojure-emacs/cider-nrepl/pull/755) `middleware.test`: now timing information is returned at var and ns level under the `:ms`/`:humanized` keys.
-* `middleware.test`: only include `:diff` data when the expected/actual mismatch is deemed diffable.
-  * i.e., maps, sets and sequences are diffable, scalar values are not.
-* [#709](https://github.com/clojure-emacs/cider-nrepl/pull/709) `middleware.test`: offer fail-fast functionality.
+- [#773](https://github.com/clojure-emacs/cider-nrepl/pull/773) Add middleware to capture, debug, inspect and view log events emitted by Java logging frameworks.
+- [#755](https://github.com/clojure-emacs/cider-nrepl/pull/755) `middleware.test`: now timing information is returned at var and ns level under the `:ms`/`:humanized` keys.
+- `middleware.test`: only include `:diff` data when the expected/actual mismatch is deemed diffable.
+  - i.e., maps, sets and sequences are diffable, scalar values are not.
+- [#709](https://github.com/clojure-emacs/cider-nrepl/pull/709) `middleware.test`: offer fail-fast functionality.
 
 ### Changes
 
-* Bump `orchard` to 0.13.0.
-* Bump `compliment` to [0.4.0](https://github.com/alexander-yakushev/compliment/blob/0.4.0/CHANGELOG.md#040-2023-07-05).
-* The `track-state` middleware now returns accurate metadata for cljs requests.
+- Bump `orchard` to 0.13.0.
+- Bump `compliment` to [0.4.0](https://github.com/alexander-yakushev/compliment/blob/0.4.0/CHANGELOG.md#040-2023-07-05).
+- The `track-state` middleware now returns accurate metadata for cljs requests.
 
 ## 0.31.0 (2023-06-23)
 
 ### Changes
 
-* Bump `cljfmt` to 0.9.2.
-* Bump `puget` to 1.3.4.
-* Bump `compliment` to 0.3.16.
-* [#769](https://github.com/clojure-emacs/cider-nrepl/issues/769): Introduce new `#break!` and `#dbg!` reader macros for breaking on exception
-* [#772](https://github.com/clojure-emacs/cider-nrepl/issues/772): Improve debugger heuristics on "interesting" breakpoints (Always break on forms tagged with #break, including vectors and maps)
-* The `wrap-debug` middleware now adds an optional `:caught-msg` key to the `eval` op response, containing the exception message when caught by the debugger.
+- Bump `cljfmt` to 0.9.2.
+- Bump `puget` to 1.3.4.
+- Bump `compliment` to 0.3.16.
+- [#769](https://github.com/clojure-emacs/cider-nrepl/issues/769): Introduce new `#break!` and `#dbg!` reader macros for breaking on exception
+- [#772](https://github.com/clojure-emacs/cider-nrepl/issues/772): Improve debugger heuristics on "interesting" breakpoints (Always break on forms tagged with #break, including vectors and maps)
+- The `wrap-debug` middleware now adds an optional `:caught-msg` key to the `eval` op response, containing the exception message when caught by the debugger.
 
 ## 0.30.0 (2023-01-31)
 
 ### New features
 
-* [#766](https://github.com/clojure-emacs/cider-nrepl/issues/766): Complete local bindings for ClojureScript files.
+- [#766](https://github.com/clojure-emacs/cider-nrepl/issues/766): Complete local bindings for ClojureScript files.
 
 ## 0.29.0 (2022-12-05)
 
 ### New features
 
-* [#758](https://github.com/clojure-emacs/cider-nrepl/pull/758): Add nREPL op to parse stacktraces into data (`analyze-stacktrace`), rename `stacktrace` op to `analyze-last-stacktrace` and deprecate `stacktrace`.
+- [#758](https://github.com/clojure-emacs/cider-nrepl/pull/758): Add nREPL op to parse stacktraces into data (`analyze-stacktrace`), rename `stacktrace` op to `analyze-last-stacktrace` and deprecate `stacktrace`.
 
 ### Changes
 
-* Bump `puget` to 1.3.3.
+- Bump `puget` to 1.3.3.
 
 ## 0.28.7 (2022-10-25)
 
 ### Changes
 
-* Bump `orchard` to 0.11.0 (this adds support for Spec 2).
+- Bump `orchard` to 0.11.0 (this adds support for Spec 2).
 
 ## 0.28.6 (2022-09-19)
 
 ### Changes
 
-* Bump `orchard` to version [0.10.0](https://github.com/clojure-emacs/orchard/releases/tag/v0.10.0).
-* Bump `compliment` to version [0.3.14](https://github.com/alexander-yakushev/compliment/blob/master/CHANGELOG.md#0314-2022-07-11).
-* Bump `fipp` to 0.6.26.
-* Bump `cljfmt` to 0.9.0.
+- Bump `orchard` to version [0.10.0](https://github.com/clojure-emacs/orchard/releases/tag/v0.10.0).
+- Bump `compliment` to version [0.3.14](https://github.com/alexander-yakushev/compliment/blob/master/CHANGELOG.md#0314-2022-07-11).
+- Bump `fipp` to 0.6.26.
+- Bump `cljfmt` to 0.9.0.
 
 ## 0.28.5 (2022-06-19)
 
 ### Changes
 
-* Bump `compliment` to version [0.3.13](https://github.com/alexander-yakushev/compliment/blob/master/CHANGELOG.md#0313-2022-06-18).
+- Bump `compliment` to version [0.3.13](https://github.com/alexander-yakushev/compliment/blob/master/CHANGELOG.md#0313-2022-06-18).
 
 ## 0.28.4 (2022-05-18)
 
 ### Bugs Fixed
 
-* [#751](https://github.com/clojure-emacs/cider-nrepl/issues/751): Skip unmapping of default imports in `undef-all` op.
+- [#751](https://github.com/clojure-emacs/cider-nrepl/issues/751): Skip unmapping of default imports in `undef-all` op.
 
 ### Changes
 
-* Use `tools.namespace`[1.3.0](https://github.com/clojure/tools.namespace/compare/v1.2.0...v1.3.0).
+- Use `tools.namespace`[1.3.0](https://github.com/clojure/tools.namespace/compare/v1.2.0...v1.3.0).
 
 ## 0.28.3 (2022-02-22)
 
 ### Changes
 
-* Upgrade [Orchard to version 0.9.2](https://github.com/clojure-emacs/orchard/blob/v0.9.2/CHANGELOG.md#092-2022-02-22).
+- Upgrade [Orchard to version 0.9.2](https://github.com/clojure-emacs/orchard/blob/v0.9.2/CHANGELOG.md#092-2022-02-22).
 
 ## 0.28.2 (2022-02-01)
 
@@ -537,195 +541,195 @@ Upgrade `tools.trace`.
 
 ### Changes
 
-* Upgrade [Orchard to version 0.9.1](https://github.com/clojure-emacs/orchard/blob/v0.9.1/CHANGELOG.md#091-2022-01-17).
+- Upgrade [Orchard to version 0.9.1](https://github.com/clojure-emacs/orchard/blob/v0.9.1/CHANGELOG.md#091-2022-01-17).
 
 ## 0.28.0 (2022-01-11)
 
 ### New features
 
-* [#548](https://github.com/clojure-emacs/cider-nrepl/pull/548): Make the content-type middleware extensible via multimethod.
+- [#548](https://github.com/clojure-emacs/cider-nrepl/pull/548): Make the content-type middleware extensible via multimethod.
 
 ## Changes
 
-* Upgrade [Orchard to version 0.9](https://github.com/clojure-emacs/orchard/releases/tag/v0.9.0).
+- Upgrade [Orchard to version 0.9](https://github.com/clojure-emacs/orchard/releases/tag/v0.9.0).
 
 ## 0.27.4 (2021-12-15)
 
 ### Bugs fixed
 
-* [#721](https://github.com/clojure-emacs/cider-nrepl/issues/721): `middleware.macroexpand`: support a corner case for tools.deps.
-* [#735](https://github.com/clojure-emacs/cider-nrepl/issues/735): `middleware.test.extensions`: make `:actual` reporting clearer.
-* [#737](https://github.com/clojure-emacs/cider-nrepl/pull/737): Fix a regression in `middleware.out` that could result in duplicate output.
-* Update `orchard` to 0.8, which addresses a bunch of dynapath-related classloader issues. Navigation to Java sources should work more reliably now.
+- [#721](https://github.com/clojure-emacs/cider-nrepl/issues/721): `middleware.macroexpand`: support a corner case for tools.deps.
+- [#735](https://github.com/clojure-emacs/cider-nrepl/issues/735): `middleware.test.extensions`: make `:actual` reporting clearer.
+- [#737](https://github.com/clojure-emacs/cider-nrepl/pull/737): Fix a regression in `middleware.out` that could result in duplicate output.
+- Update `orchard` to 0.8, which addresses a bunch of dynapath-related classloader issues. Navigation to Java sources should work more reliably now.
 
 ## 0.27.3 (2021-12-07)
 
 ### Bugs fixed
 
-* [#733](https://github.com/clojure-emacs/cider-nrepl/issues/719): `middleware.out`: remove reflection.
-* [#719](https://github.com/clojure-emacs/cider-nrepl/issues/719): `middleware.test`: gracefully handle exceptions thrown within fixtures.
-* [#722](https://github.com/clojure-emacs/cider-nrepl/issues/722): `middleware.format`: print otherwise non-serializable objects as strings.
-* [#708](https://github.com/clojure-emacs/cider-nrepl/issues/708): Upgrade Compliment, improving how autocompletion works in Windows.
-* [#713](https://github.com/clojure-emacs/cider-nrepl/pull/713): Fix a regression in test results formatting.
+- [#733](https://github.com/clojure-emacs/cider-nrepl/issues/719): `middleware.out`: remove reflection.
+- [#719](https://github.com/clojure-emacs/cider-nrepl/issues/719): `middleware.test`: gracefully handle exceptions thrown within fixtures.
+- [#722](https://github.com/clojure-emacs/cider-nrepl/issues/722): `middleware.format`: print otherwise non-serializable objects as strings.
+- [#708](https://github.com/clojure-emacs/cider-nrepl/issues/708): Upgrade Compliment, improving how autocompletion works in Windows.
+- [#713](https://github.com/clojure-emacs/cider-nrepl/pull/713): Fix a regression in test results formatting.
 
 ## 0.27.2 (2021-10-03)
 
 ### Bugs fixed
 
-* [#716](https://github.com/clojure-emacs/cider-nrepl/issues/716): Fix StackOverflowErrors related to `*out*` handling.
+- [#716](https://github.com/clojure-emacs/cider-nrepl/issues/716): Fix StackOverflowErrors related to `*out*` handling.
 
 ## 0.27.1 (2021-10-02)
 
 ### Bugs fixed
 
-* Upgrade `suitable` and `orchard`, bringing in related bugfixes.
+- Upgrade `suitable` and `orchard`, bringing in related bugfixes.
 
 ## 0.27.0 (2021-09-30)
 
 ### New features
 
-* [#698](https://github.com/clojure-emacs/cider-nrepl/pull/698): Add `undef-all` op to undefine all symbols and aliases in namespace.
-* Introduce `cider.nrepl.middleware.test/*test-error-handler*` var which you can override with arbitrary functions.
+- [#698](https://github.com/clojure-emacs/cider-nrepl/pull/698): Add `undef-all` op to undefine all symbols and aliases in namespace.
+- Introduce `cider.nrepl.middleware.test/*test-error-handler*` var which you can override with arbitrary functions.
 
 ### Bugs fixed
 
-* Make `middleware.stacktrace` detect a given project's common ns prefix even in face of single-segment namespaces such as `user`.
+- Make `middleware.stacktrace` detect a given project's common ns prefix even in face of single-segment namespaces such as `user`.
 
 ### Changes
 
-* Parallelize `cider.nrepl.middleware.stacktrace/analyze-stacktrace`.
-* [#705](https://github.com/clojure-emacs/cider-nrepl/pull/705): Use the session classloader when loading deferred middleware.
+- Parallelize `cider.nrepl.middleware.stacktrace/analyze-stacktrace`.
+- [#705](https://github.com/clojure-emacs/cider-nrepl/pull/705): Use the session classloader when loading deferred middleware.
 
 ## 0.26.0 (2021-04-22)
 
 ### New features
 
-* [#694](https://github.com/clojure-emacs/cider-nrepl/pull/694): [Inspector] Configure truncation limits.
+- [#694](https://github.com/clojure-emacs/cider-nrepl/pull/694): [Inspector] Configure truncation limits.
 
 ### Bugs fixed
 
-* Update `clj-suitable` to version 0.4 and re-enable enhanced completions for `shadow-cljs`.
+- Update `clj-suitable` to version 0.4 and re-enable enhanced completions for `shadow-cljs`.
 
 ## 0.25.11 (2021-04-12)
 
 ### Bugs Fixed
 
-* [#695](https://github.com/clojure-emacs/cider-nrepl/pull/695): Fix debugger quit for http handler functions.
+- [#695](https://github.com/clojure-emacs/cider-nrepl/pull/695): Fix debugger quit for http handler functions.
 
 ## 0.25.10 (2021-04-08)
 
 ### Bugs Fixed
 
-* Enable `suitable`'s enhanced completions for anything but `shadow-cljs`.
+- Enable `suitable`'s enhanced completions for anything but `shadow-cljs`.
 
 ## 0.25.9 (2021-02-13)
 
 ### Bugs Fixed
 
-* [cider#2979](https://github.com/clojure-emacs/cider/issues/2979): Convert non-integer numbers to strings.
-* Another fix for the dynamic classpath modification (in Orchard 0.6.5).
+- [cider#2979](https://github.com/clojure-emacs/cider/issues/2979): Convert non-integer numbers to strings.
+- Another fix for the dynamic classpath modification (in Orchard 0.6.5).
 
 ## 0.25.8 (2021-01-25)
 
 ### Bugs Fixed
 
-* Make dynamic classpath modification robust to compiler loader binding (fixed in Orchard 0.6.4).
+- Make dynamic classpath modification robust to compiler loader binding (fixed in Orchard 0.6.4).
 
 ## 0.25.7 (2021-01-21)
 
 ### Bugs Fixed
 
-* [#687](https://github.com/clojure-emacs/cider-nrepl/issues/687): Make sure that the Orchard JDK sources cache is visible in nREPL (the actual fix is in Orchard 0.6.3).
+- [#687](https://github.com/clojure-emacs/cider-nrepl/issues/687): Make sure that the Orchard JDK sources cache is visible in nREPL (the actual fix is in Orchard 0.6.3).
 
 ## 0.25.6 (2021-01-04)
 
 ### Bugs Fixed
 
-* Fetch ClojureDocs data from updated location (fixed in Orchard 0.6.2).
-* Fix compatibility with Java 15 (fixed in Orchard 0.6.2).
+- Fetch ClojureDocs data from updated location (fixed in Orchard 0.6.2).
+- Fix compatibility with Java 15 (fixed in Orchard 0.6.2).
 
 ## 0.25.5 (2020-11-24)
 
 ### Bugs Fixed
 
-* [#684](https://github.com/clojure-emacs/cider-nrepl/pull/684): Fix delayed middleware loading issue.
-* [#683](https://github.com/clojure-emacs/cider-nrepl/pull/683): Support custom `print-method`s in test reports.
+- [#684](https://github.com/clojure-emacs/cider-nrepl/pull/684): Fix delayed middleware loading issue.
+- [#683](https://github.com/clojure-emacs/cider-nrepl/pull/683): Support custom `print-method`s in test reports.
 
 ## 0.25.4 (2020-10-08)
 
 ### Changes
 
-* Address reflection warnings in `compliment` and `orchard`.
+- Address reflection warnings in `compliment` and `orchard`.
 
 ## 0.25.3 (2020-07-31)
 
 ### Bugs fixed
 
-* [#667](https://github.com/clojure-emacs/cider-nrepl/pull/667): Filter non file urls from classpath response.
+- [#667](https://github.com/clojure-emacs/cider-nrepl/pull/667): Filter non file urls from classpath response.
 
 ### Changes
 
-* [#679](https://github.com/clojure-emacs/cider-nrepl/pull/679): Update to use bundled ClojureDocs documents.
+- [#679](https://github.com/clojure-emacs/cider-nrepl/pull/679): Update to use bundled ClojureDocs documents.
 
 ## 0.25.2 (2020-06-07)
 
 ### Bugs fixed
 
-* Remove workaround for converting column numbers to 0-based indexing. ([Cider issue](https://github.com/clojure-emacs/cider/issues/2852))
+- Remove workaround for converting column numbers to 0-based indexing. ([Cider issue](https://github.com/clojure-emacs/cider/issues/2852))
 
 ## 0.25.1 (2020-06-04)
 
 ### Bugs fixed
 
-* Bump Orchard to 0.5.10, as the 0.5.9 was a bad build. ([Orchard issue](https://github.com/clojure-emacs/orchard/issues/91))
+- Bump Orchard to 0.5.10, as the 0.5.9 was a bad build. ([Orchard issue](https://github.com/clojure-emacs/orchard/issues/91))
 
 ## 0.25.0 (2020-05-30)
 
 ### New Features
 
-* [#670](https://github.com/clojure-emacs/cider-nrepl/pull/670): Extend `undef` op to work on fully qualified symbols.
+- [#670](https://github.com/clojure-emacs/cider-nrepl/pull/670): Extend `undef` op to work on fully qualified symbols.
 
 ### Bugs fixed
 
-* [#666](https://github.com/clojure-emacs/cider-nrepl/pull/666): Add a `nil` `:query` check in apropos's `var-query-map`.
-* [#669](https://github.com/clojure-emacs/cider-nrepl/pull/669): Fix NPE and add `isDirectory` check in slurp middleware.
-* [#672](https://github.com/clojure-emacs/cider-nrepl/pull/672): Fix debug instrumentation for a dot special form case.
+- [#666](https://github.com/clojure-emacs/cider-nrepl/pull/666): Add a `nil` `:query` check in apropos's `var-query-map`.
+- [#669](https://github.com/clojure-emacs/cider-nrepl/pull/669): Fix NPE and add `isDirectory` check in slurp middleware.
+- [#672](https://github.com/clojure-emacs/cider-nrepl/pull/672): Fix debug instrumentation for a dot special form case.
 
 ### Changes
 
-* Rename the `symbol` param in the `undef` middleware to `sym`. (the old name is retained for backwards compatibility)
-* Rename the `symbol` param in the `complete` middleware to `prefix`. (the old name is retained for backwards compatibility)
-* Rename the `symbol` param in all the `info` middleware ops to `sym`. (the old name is retained for backwards compatibility)
+- Rename the `symbol` param in the `undef` middleware to `sym`. (the old name is retained for backwards compatibility)
+- Rename the `symbol` param in the `complete` middleware to `prefix`. (the old name is retained for backwards compatibility)
+- Rename the `symbol` param in all the `info` middleware ops to `sym`. (the old name is retained for backwards compatibility)
 
 ## 0.24.0 (2020-02-14)
 
 ### Bugs fixed
 
-* [#663](https://github.com/clojure-emacs/cider-nrepl/pull/663): Fix non-recognized `recur` inside `case` in the debugger.
-* [#664](https://github.com/clojure-emacs/cider-nrepl/pull/664): Fix continue-all in conditional break.
-* [#665](https://github.com/clojure-emacs/cider-nrepl/pull/665): Fix form location in map literals.
+- [#663](https://github.com/clojure-emacs/cider-nrepl/pull/663): Fix non-recognized `recur` inside `case` in the debugger.
+- [#664](https://github.com/clojure-emacs/cider-nrepl/pull/664): Fix continue-all in conditional break.
+- [#665](https://github.com/clojure-emacs/cider-nrepl/pull/665): Fix form location in map literals.
 
 ### Changes
 
-* [#641](https://github.com/clojure-emacs/cider-nrepl/pull/641): Integrate the new suitable ClojureScript completion.
+- [#641](https://github.com/clojure-emacs/cider-nrepl/pull/641): Integrate the new suitable ClojureScript completion.
 
 ## 0.23.0 (2019-01-18)
 
 ### New Features
 
-* [#613](https://github.com/clojure-emacs/cider-nrepl/pull/613): Change the `:inspect` command to work on the current expression. Add a new command `:inspect-prompt` to inspect an arbitrary value.
-* [#654](https://github.com/clojure-emacs/cider-nrepl/pull/654): Change the format of debugger command messages to a set of command names, leaving key mappings up to client implementations.
-* [#653](https://github.com/clojure-emacs/cider-nrepl/pull/653): Add `inspect-def-current-value` to inspect middleware.
+- [#613](https://github.com/clojure-emacs/cider-nrepl/pull/613): Change the `:inspect` command to work on the current expression. Add a new command `:inspect-prompt` to inspect an arbitrary value.
+- [#654](https://github.com/clojure-emacs/cider-nrepl/pull/654): Change the format of debugger command messages to a set of command names, leaving key mappings up to client implementations.
+- [#653](https://github.com/clojure-emacs/cider-nrepl/pull/653): Add `inspect-def-current-value` to inspect middleware.
 
 ### Bugs fixed
 
-* [#661](https://github.com/clojure-emacs/cider-nrepl/pull/661): Fix `info` op not to return nil as a value of key.
+- [#661](https://github.com/clojure-emacs/cider-nrepl/pull/661): Fix `info` op not to return nil as a value of key.
 
 ## 0.22.4 (2019-10-08)
 
 ### Changes
 
-* Dynamic cljs completions (via suitable) are only enabled when adding `enhanced-cljs-completion` to cljs message like:
+- Dynamic cljs completions (via suitable) are only enabled when adding `enhanced-cljs-completion` to cljs message like:
 
 ```clojure
 {:op "complete"
@@ -736,127 +740,127 @@ Upgrade `tools.trace`.
 
 ### Bugs fixed
 
-* [#652](https://github.com/clojure-emacs/cider-nrepl/pull/652): Respect `*print-length*` and `*print-level*` in the debugger.
-* Respect nREPL print options in the debugger.
-* Fix lockups and exceptions caused by clojuredocs cache download/corruption (fixed in Orchard 0.5.2).
+- [#652](https://github.com/clojure-emacs/cider-nrepl/pull/652): Respect `*print-length*` and `*print-level*` in the debugger.
+- Respect nREPL print options in the debugger.
+- Fix lockups and exceptions caused by clojuredocs cache download/corruption (fixed in Orchard 0.5.2).
 
 ## 0.22.3 (2019-09-11)
 
 ### Bugs fixed
 
-* Bump the `orchard` dep to 0.5.1 to address missing specs for var metadata.
-* Bump the `suitable` dep to address a NPE.
+- Bump the `orchard` dep to 0.5.1 to address missing specs for var metadata.
+- Bump the `suitable` dep to address a NPE.
 
 ## 0.22.2 (2019-09-03)
 
 ### Bugs fixed
 
-* [#643](https://github.com/clojure-emacs/cider-nrepl/issues/643): Fix ClojureScript completion when using a `node` REPL.
+- [#643](https://github.com/clojure-emacs/cider-nrepl/issues/643): Fix ClojureScript completion when using a `node` REPL.
 
 ## 0.22.1 (2019-09-01)
 
 ### Bugs fixed
 
-* [#642](https://github.com/clojure-emacs/cider-nrepl/pull/642): This fixes calls to suitable when the completion context contains no `__prefix__`.
+- [#642](https://github.com/clojure-emacs/cider-nrepl/pull/642): This fixes calls to suitable when the completion context contains no `__prefix__`.
 
 ## 0.22.0 (2019-08-29)
 
 ### New features
 
-* [#605](https://github.com/clojure-emacs/cider-nrepl/pull/605): Added a option for filtering vars to the ns-vars middleware.
-* Added `xref` middleware providing `fn-deps` and `fn-refs` ops.
-* [#628](https://github.com/clojure-emacs/cider-nrepl/pull/628): Added `clojuredocs` middleware providing `clojuredocs-lookup` and `clojuredocs-refresh-cache` ops.
-* [#633](https://github.com/clojure-emacs/cider-nrepl/pull/633) Added runtime code completion for ClojureScript via [suitable](https://github.com/rksm/clj-suitable).
+- [#605](https://github.com/clojure-emacs/cider-nrepl/pull/605): Added a option for filtering vars to the ns-vars middleware.
+- Added `xref` middleware providing `fn-deps` and `fn-refs` ops.
+- [#628](https://github.com/clojure-emacs/cider-nrepl/pull/628): Added `clojuredocs` middleware providing `clojuredocs-lookup` and `clojuredocs-refresh-cache` ops.
+- [#633](https://github.com/clojure-emacs/cider-nrepl/pull/633) Added runtime code completion for ClojureScript via [suitable](https://github.com/rksm/clj-suitable).
 
 ### Bugs fixed
 
-* Fix some functions defined with `def` not being properly font locked when using dynamic font locking for ClojureScript.
-* [#618](https://github.com/clojure-emacs/cider-nrepl/pull/618): Fix apropos to honor exclude-regexps to filter out namespaces by regex
-* [#605](https://github.com/clojure-emacs/cider-nrepl/pull/605): Fix `ns-vars-with-meta` to return public vars.
+- Fix some functions defined with `def` not being properly font locked when using dynamic font locking for ClojureScript.
+- [#618](https://github.com/clojure-emacs/cider-nrepl/pull/618): Fix apropos to honor exclude-regexps to filter out namespaces by regex
+- [#605](https://github.com/clojure-emacs/cider-nrepl/pull/605): Fix `ns-vars-with-meta` to return public vars.
 
 ### Changes
 
-* **(Breaking)** Removed the `cider.nrepl.main` namespace. The functionality in it has been superseded by `nrepl.cmdline`.
-* [#615](https://github.com/clojure-emacs/cider-nrepl/pull/615): **(Breaking)** Removed the `cider.tasks/nrepl-server` custom task.
+- **(Breaking)** Removed the `cider.nrepl.main` namespace. The functionality in it has been superseded by `nrepl.cmdline`.
+- [#615](https://github.com/clojure-emacs/cider-nrepl/pull/615): **(Breaking)** Removed the `cider.tasks/nrepl-server` custom task.
 
 ## 0.21.1 (2019-02-15)
 
 ### New features
 
-* Add a wrapper function for `zprint`, suitable for using with `nrepl.middleware.print`.
+- Add a wrapper function for `zprint`, suitable for using with `nrepl.middleware.print`.
 
 ## 0.21.0 (2019-02-11)
 
 ### New features
 
-* The `refresh` op is now interruptible.
+- The `refresh` op is now interruptible.
 
 ### Changes
 
-* **(Breaking)** Upgrade to nREPL 0.6.0. This is now the minimum required version.
-* **(Breaking)** Upgrade to piggieback 0.4.0. This is now the minimum required version.
-* **(Breaking)** Remove `cider.nrepl.middleware.pprint`. All functionality has been replaced by the built-in printing support in nREPL 0.6.0.
+- **(Breaking)** Upgrade to nREPL 0.6.0. This is now the minimum required version.
+- **(Breaking)** Upgrade to piggieback 0.4.0. This is now the minimum required version.
+- **(Breaking)** Remove `cider.nrepl.middleware.pprint`. All functionality has been replaced by the built-in printing support in nREPL 0.6.0.
 
 ## 0.20.0 (2019-01-14)
 
 ### New features
 
-* Add print functions compatible with nREPL 0.5 to `cider.nrepl.pprint` namespace.
+- Add print functions compatible with nREPL 0.5 to `cider.nrepl.pprint` namespace.
 
 ### Changes
 
-* **(Breaking)** Drop support for nREPL 0.2.x (aka `tools.nrepl`). Now nREPL 0.4+ is required.
-* **(Breaking)** Drop support for Piggieback 0.2.x (aka `cemerick.piggieback`).  Now Piggieback 0.3+ is required.
-* Deprecated `cider.nrepl.middleware.pprint` if favour of the built-in pprint support in nREPL 0.5.
+- **(Breaking)** Drop support for nREPL 0.2.x (aka `tools.nrepl`). Now nREPL 0.4+ is required.
+- **(Breaking)** Drop support for Piggieback 0.2.x (aka `cemerick.piggieback`).  Now Piggieback 0.3+ is required.
+- Deprecated `cider.nrepl.middleware.pprint` if favour of the built-in pprint support in nREPL 0.5.
 
 ## 0.19.0 (2019-01-01)
 
 ### New features
 
-* [#546](https://github.com/clojure-emacs/cider-nrepl/pull/546): Added support for matcher-combinators to the test middleware.
-* [#556](https://github.com/clojure-emacs/cider-nrepl/pull/556): Added configuration option for cljfmt to the format middleware.
-* [#558](https://github.com/clojure-emacs/cider-nrepl/pull/558): Added the `ns-aliases` op to the ns middleware.
+- [#546](https://github.com/clojure-emacs/cider-nrepl/pull/546): Added support for matcher-combinators to the test middleware.
+- [#556](https://github.com/clojure-emacs/cider-nrepl/pull/556): Added configuration option for cljfmt to the format middleware.
+- [#558](https://github.com/clojure-emacs/cider-nrepl/pull/558): Added the `ns-aliases` op to the ns middleware.
 
 ### Changes
 
-* [#550](https://github.com/clojure-emacs/cider-nrepl/pull/550): Always return test documentation messages as strings.
-* [#563](https://github.com/clojure-emacs/cider-nrepl/pull/563): Add :root-ex key to error summary that contains the classname of the root cause.
+- [#550](https://github.com/clojure-emacs/cider-nrepl/pull/550): Always return test documentation messages as strings.
+- [#563](https://github.com/clojure-emacs/cider-nrepl/pull/563): Add :root-ex key to error summary that contains the classname of the root cause.
 
 ### Bugs fixed
 
-* [#573](https://github.com/clojure-emacs/cider-nrepl/pull/573): Fix inspector silently doing nothing if eval errored
+- [#573](https://github.com/clojure-emacs/cider-nrepl/pull/573): Fix inspector silently doing nothing if eval errored
 
 ## 0.18.0 (2018-08-06)
 
 ### New features
 
-* [#540](https://github.com/clojure-emacs/cider-nrepl/pull/540): Added support for nREPL 0.4.
-* [#532](https://github.com/clojure-emacs/cider-nrepl/pull/532): Added a boot task to start the nREPL server (allows us to run nREPL 0.4 before boot upgrades to it).
+- [#540](https://github.com/clojure-emacs/cider-nrepl/pull/540): Added support for nREPL 0.4.
+- [#532](https://github.com/clojure-emacs/cider-nrepl/pull/532): Added a boot task to start the nREPL server (allows us to run nREPL 0.4 before boot upgrades to it).
 
 ### Changes
 
-* Drop "official" support for Java 7 and Clojure 1.7 (although they might still work for a while).
-* Extract the `info` related functionality to `orchard`.
+- Drop "official" support for Java 7 and Clojure 1.7 (although they might still work for a while).
+- Extract the `info` related functionality to `orchard`.
 
 ### Bugs fixed
 
-* [#535](https://github.com/clojure-emacs/cider-nrepl/pull/535): Check for cemerick/piggieback, before checking for
+- [#535](https://github.com/clojure-emacs/cider-nrepl/pull/535): Check for cemerick/piggieback, before checking for
 cider/piggieback.
-* [#542](https://github.com/clojure-emacs/cider-nrepl/issues/542): Qualify references to `*out*` and `*err*` in `wrap-out`.
+- [#542](https://github.com/clojure-emacs/cider-nrepl/issues/542): Qualify references to `*out*` and `*err*` in `wrap-out`.
 
 ## 0.17.0 (2018-05-07)
 
 ### New features
 
-* Extracted part of the nREPL-agnostic functionality to `orchard`.
-* Added a profiling middleware.
-* Support for orchard var-query in apropos.
-* Support for orchard var-query in test, introducing new test-var-query.
+- Extracted part of the nREPL-agnostic functionality to `orchard`.
+- Added a profiling middleware.
+- Support for orchard var-query in apropos.
+- Support for orchard var-query in test, introducing new test-var-query.
 
 ### Changes
 
-* Remove support for cljx.
-* Remove support for piggieback 0.1.x.
-* Add support for piggieback 0.3 or newer (aka `cider/piggieback`).
-* Deprecate the `test` and `test-all` ops.
-* Deprecated non-test-var filters in the `apropos` middleware.
+- Remove support for cljx.
+- Remove support for piggieback 0.1.x.
+- Add support for piggieback 0.3 or newer (aka `cider/piggieback`).
+- Deprecate the `test` and `test-all` ops.
+- Deprecated non-test-var filters in the `apropos` middleware.

--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -7,6 +7,12 @@
   ["nREPL API" {}
    ["Supplied Middleware" {:file "doc/modules/ROOT/pages/nrepl-api/supplied_middleware.adoc"}]
    ["Supplied Ops" {:file "doc/modules/ROOT/pages/nrepl-api/ops.adoc"}]]
+  ["For Tool Authors" {}
+   ["Integrating cider-nrepl" {:file "doc/modules/ROOT/pages/tool-authors/index.adoc"}]
+   ["The Debugger Protocol" {:file "doc/modules/ROOT/pages/tool-authors/debugger.adoc"}]
+   ["The Inspector Protocol" {:file "doc/modules/ROOT/pages/tool-authors/inspector.adoc"}]
+   ["The Test Protocol" {:file "doc/modules/ROOT/pages/tool-authors/testing.adoc"}]
+   ["State Tracking" {:file "doc/modules/ROOT/pages/tool-authors/state-tracking.adoc"}]]
   ["Hacking on CIDER nREPL" {:file "doc/modules/ROOT/pages/hacking.adoc"}]
   ["Compatibility" {:file "doc/modules/ROOT/pages/compatibility.adoc"}]
   ["Release Policy" {:file "doc/modules/ROOT/pages/release_policy.adoc"}]

--- a/doc/modules/ROOT/nav.adoc
+++ b/doc/modules/ROOT/nav.adoc
@@ -5,6 +5,12 @@
 * nREPL API
 ** xref:nrepl-api/supplied_middleware.adoc[Supplied Middleware]
 ** xref:nrepl-api/ops.adoc[Supplied Ops]
+* For Tool Authors
+** xref:tool-authors/index.adoc[Integrating cider-nrepl]
+** xref:tool-authors/debugger.adoc[The Debugger Protocol]
+** xref:tool-authors/inspector.adoc[The Inspector Protocol]
+** xref:tool-authors/testing.adoc[The Test Protocol]
+** xref:tool-authors/state-tracking.adoc[State Tracking]
 * xref:hacking.adoc[Hacking on CIDER nREPL]
 * xref:compatibility.adoc[Compatibility]
 * xref:release_policy.adoc[Release Policy]

--- a/doc/modules/ROOT/pages/tool-authors/debugger.adoc
+++ b/doc/modules/ROOT/pages/tool-authors/debugger.adoc
@@ -1,0 +1,223 @@
+= The Debugger Protocol
+
+The interactive debugger is the most involved protocol in cider-nrepl. It
+consists of two dedicated ops (`cider/init-debugger` and
+`cider/debug-input`), a hook into the regular `eval` op, and a small
+command language. This page describes the wire protocol; CIDER's own
+debugger UI is just one possible client of it.
+
+== Big Picture
+
+1. The client sends *one* `cider/init-debugger` message per connection. It
+   never receives a normal reply; instead the server holds on to it and uses
+   it as a *channel*: every debugger-initiated message (a hit breakpoint, a
+   stacktrace, a notification) is sent as a response to this message, i.e.
+   carrying its `id` and `session`.
+2. The client instruments code by including reader tags (`#break`, `#dbg`,
+   ...) in the code it sends to the plain `eval` op. No special op is needed.
+3. When instrumented code hits a breakpoint, the *evaluating thread blocks*
+   and the client receives a message with status `need-debug-input` on the
+   init-debugger channel.
+4. The client answers with a `cider/debug-input` message. Its `key` param
+   pairs the answer to the blocked breakpoint (concurrent breakpoints on
+   different threads are disambiguated this way). The thread wakes up, acts
+   on the command and either resumes or breaks again.
+
+== Instrumenting Code
+
+The following reader tags trigger instrumentation when they appear in code
+sent to `eval` (or `load-file`):
+
+|===
+| Tag | Effect
+
+| `#break`
+| Pause when execution reaches this form (after it's evaluated).
+
+| `#dbg`
+| Instrument the whole form: pause at every "interesting" sub-form
+  (function calls, loop iterations, etc.).
+
+| `#break!` / `#exn`
+| Like `#break`, but pause only if the form throws.
+
+| `#dbg!` / `#dbgexn`
+| Like `#dbg`, but pause only on exceptions.
+
+| `#light`
+| Enlighten mode - no pauses; see
+  xref:tool-authors/debugger.adoc#enlighten[Enlighten] below.
+|===
+
+The op remains an ordinary `eval`; the value of the instrumented form is
+returned as usual once execution completes. The `cider/debug-instrumented-defs`
+op returns the vars currently believed to be instrumented, grouped by
+namespace (it can contain false positives, but no false negatives).
+
+== The Breakpoint Message
+
+When a breakpoint is hit, the init-debugger channel receives a message with
+`status` `need-debug-input` and these keys:
+
+|===
+| Key | Meaning
+
+| `key`
+| Unique token for this pause; echo it back in `cider/debug-input`.
+
+| `input-type`
+| Either a list of currently allowed command keywords, or `expression` when
+  the debugger expects a code snippet (e.g. after an `eval` command without
+  inline code).
+
+| `prompt`
+| Optional prompt string accompanying an `expression` request.
+
+| `debug-value`
+| Printed value of the form we're paused on (truncated for display).
+
+| `coor`
+| Coordinate of the paused form within the top-level form (see below).
+
+| `locals`
+| List of `[name value]` string pairs for the local bindings in scope.
+  Absent when local capture isn't available.
+
+| `code`, `file`, `line`, `column`, `original-ns`
+| Source context of the instrumented top-level form. `column` is 1-based.
+
+| `original-id`
+| The `id` of the eval message that instrumented this code, so the client
+  can correlate the pause with the evaluation that caused it.
+
+| `inspect`
+| Present only right after an `inspect`-style command: the rendered
+  inspector output for the requested value.
+
+| `caught-msg`
+| Present only for exception breakpoints: the exception's message.
+|===
+
+== Coordinates
+
+`coor` is a vector of integers addressing a sub-form inside the top-level
+form, one index per nesting level. `[3 2 0]` means: take the 3rd element of
+the top-level form, then that element's 2nd element, then that one's 0th.
+A few special rules:
+
+* In maps, the key at entry `i` has index `2*i` and its value `2*i+1`. Maps
+  with more than eight entries are addressed in sorted-key order (so
+  coordinates are stable across Clojure versions); maps whose keys can't be
+  sorted, and sets, are not instrumented at all.
+* Record literals are never instrumented.
+
+Clients typically use `coor` plus `line`/`column` of the top-level form to
+compute where to display the "paused here" overlay.
+
+== Debug Commands
+
+The client answers a `need-debug-input` message with:
+
+----
+{"op"    "cider/debug-input"
+ "key"   "<the key from the breakpoint message>"
+ "input" "<a command>"}
+----
+
+`input` is read as EDN. It's either a bare keyword (e.g. `:next`) or a map
+`{:response :here, :coord [3 1]}` when the command takes arguments. The
+available commands are advertised in the breakpoint message's `input-type`
+(commands that need locals disappear when locals aren't available; `:quit`
+disappears when the eval can't be aborted):
+
+|===
+| Command | Effect
+
+| `:next`
+| Continue to the next breakpoint.
+
+| `:in`
+| Step into the function call the debugger is paused on.
+
+| `:out`
+| Skip the remaining breakpoints in the current sexp. With `:force? true`,
+  breakpoints in other instrumented code reached along the way are skipped
+  too.
+
+| `:here`
+| Run until the given position; takes `:coord` (a coordinate vector) and
+  optionally `:force?` (as with `:out`).
+
+| `:continue`
+| Skip the remaining breakpoints for the current invocation of the
+  instrumented form (they fire again on the next invocation).
+
+| `:continue-all`
+| Disable all breakpoints for the rest of this evaluation.
+
+| `:trace`
+| Continue, reporting each intermediate form and value along the way.
+
+| `:eval`
+| Evaluate an expression in the context of the paused frame (with locals in
+  scope). Takes `:code`; without it the debugger asks for the expression via
+  an `input-type` = `expression` round-trip. The result arrives as an updated
+  `debug-value`.
+
+| `:inject`
+| Like `:eval`, but the result *replaces* the value of the paused form and
+  execution continues with it.
+
+| `:inspect`
+| Render the current value with the inspector; arrives in the `inspect` key
+  of the next prompt.
+
+| `:inspect-prompt`
+| Prompt for an expression, evaluate and inspect its result.
+
+| `:locals`
+| Inspect the map of local bindings.
+
+| `:stacktrace`
+| Sends a message with status `stack` and analyzed `causes` (same format as
+  the stacktrace middleware), then re-prompts.
+
+| `:quit`
+| Abort the evaluation (the eval returns the value `QUIT` and its thread is
+  interrupted).
+|===
+
+Errors during `:eval`/`:inject` produce a message with status `eval-error`
+and analyzed `causes` on the debugger channel; the breakpoint remains
+paused and re-prompts.
+
+== Other Messages on the Debugger Channel
+
+* `{:status :notification, :msg ..., :type ...}` - informational messages
+  the client should surface (e.g. a form too large to instrument with
+  locals).
+* `{:status :done}` - the channel was released, typically because a new
+  `init-debugger` message replaced it. Re-initialize if you didn't cause it.
+
+[#enlighten]
+== Enlighten
+
+The `#light` reader tag (or an `enlighten` flag on the `eval` message)
+enables enlighten mode: execution is *not* paused, but every instrumented
+sub-form reports its value as it runs, as messages with status `enlighten`
+on the debugger channel. Each carries `coor` and `debug-value` (very
+aggressively truncated), plus `erase-previous` when the client should clear
+overlays from a previous run of the same form (e.g. re-invoked functions).
+Enlighten requires an initialized debugger channel, since it reuses it.
+
+== Caveats
+
+* The debugger channel is currently *global to the middleware instance*, not
+  per-session: the most recent `init-debugger` wins and any previous channel
+  receives `done`. Send exactly one `init-debugger` per connection.
+* Debugging is JVM-only; ClojureScript can't block a JS runtime waiting for
+  debug input.
+* Instrumentation can push a big function over the JVM's 64KB method-size
+  limit. The debugger automatically retries without local capture (with a
+  `notification` warning); if the form still doesn't fit, it reports an
+  error and leaves the form unevaluated.

--- a/doc/modules/ROOT/pages/tool-authors/index.adoc
+++ b/doc/modules/ROOT/pages/tool-authors/index.adoc
@@ -1,0 +1,75 @@
+= Integrating cider-nrepl into Your Tool
+
+This section is aimed at people building editor plugins and other nREPL
+clients on top of `cider-nrepl`. It complements the generated
+xref:nrepl-api/ops.adoc[ops reference] (which documents the request/response
+keys of every op) with the things that aren't visible there - conventions,
+cross-cutting behaviors and the multi-message protocols of the more complex
+middleware:
+
+* xref:tool-authors/debugger.adoc[The Debugger Protocol]
+* xref:tool-authors/inspector.adoc[The Inspector Protocol]
+* xref:tool-authors/testing.adoc[The Test Protocol]
+* xref:tool-authors/state-tracking.adoc[State Tracking]
+
+== Op Naming
+
+Historically all cider-nrepl ops had plain names like `complete` or
+`test-var-query`. Those names live in a flat namespace shared with nREPL
+itself and every other middleware, so newer ops are namespaced with a
+`cider/` prefix (`cider/complete`, `cider/test-var-query`), and the old
+names are kept as deprecated aliases.
+
+New client code should always use the `cider/`-prefixed names. The
+deprecated aliases won't be removed lightly (see
+xref:compatibility.adoc[Compatibility]), but they no longer appear in new
+functionality - some recent ops (e.g. `cider/tap-subscribe`,
+`cider/get-state`) have no unprefixed alias at all.
+
+== Discovering Capabilities
+
+Don't assume a particular cider-nrepl version - probe for it:
+
+* nREPL's built-in `describe` op returns the full op list; check for the ops
+  you need. With `:verbose? "true"` it also returns each op's documented
+  request/response keys (that's what the xref:nrepl-api/ops.adoc[ops
+  reference] is generated from).
+* The `cider-version` op returns cider-nrepl's own version map.
+
+Because cider-nrepl's middleware is loaded lazily (see
+xref:internals.adoc[Understanding the Internals]), the first use of an op may
+take noticeably longer than subsequent ones - budget your timeouts
+accordingly.
+
+== ClojureScript Sessions
+
+Many ops are ClojureScript-aware and transparently operate on the cljs
+compiler environment when the session is a ClojureScript REPL (via
+Piggieback or shadow-cljs). Ops that only make sense on the JVM reply with a
+`clojure-only` status in a ClojureScript session, so your client can show a
+meaningful message instead of confusing JVM results. Handle that status
+generically and you're covered for all of them.
+
+== Bypassing the Middleware
+
+Any message carrying a truthy `inhibit-cider-middleware` key skips all of
+cider-nrepl's middleware and is handled as if only stock nREPL were present.
+This is occasionally useful for tooling-internal evals that shouldn't
+trigger side effects like state tracking or debugger instrumentation.
+
+== Printing
+
+cider-nrepl requires nREPL 1.0+ and builds on nREPL's `print` middleware.
+Ops that return printed values (`eval` and friends, but also e.g. the
+debugger and the test ops) accept the standard
+`nrepl.middleware.print/*` options (`print`, `quota`, `stream?`, ...);
+see the https://nrepl.org/nrepl/design/middleware.html[nREPL documentation]
+for details.
+
+== Errors
+
+cider-nrepl wraps its handlers in a "safe transport": if an op's handler
+throws, the client receives a response with an error status (typically
+`<op-name>-error`) and exception details instead of silence. Your client
+should still apply timeouts, but it doesn't need to guard against requests
+that never complete simply because a handler blew up.

--- a/doc/modules/ROOT/pages/tool-authors/inspector.adoc
+++ b/doc/modules/ROOT/pages/tool-authors/inspector.adoc
@@ -1,0 +1,134 @@
+= The Inspector Protocol
+
+The inspector renders any value as a navigable, paginated tree. Its state
+lives on the server, in the nREPL session; the client only ever holds the
+latest rendering and issues navigation commands against the server-side
+state. One inspector exists per session.
+
+== Starting an Inspection
+
+There is no `inspect-start` op. An inspection starts by riding along another
+op:
+
+* *eval* - send a normal `eval` message with a truthy `inspect` flag. The
+  eval's value is loaded into the session's inspector and the response's
+  `value` contains the rendering (described below) instead of the printed
+  value.
+* *exceptions* - `cider/inspect-last-exception` (after
+  `cider/analyze-last-stacktrace`) loads the exception cause at `index`
+  (with `ex-data "true"`, its ex-data) into the inspector.
+* *tap* - `cider/tap-inspect` loads a previously tapped value by its `idx`.
+* *logs* - `cider/log-inspect-event` loads a captured log event.
+
+== The Rendering Format
+
+Every inspector op responds with:
+
+|===
+| Key | Meaning
+
+| `value`
+| The rendering: a *string* containing an EDN sequence the client must read.
+
+| `path`
+| A string describing the navigation path from the root value to the
+  currently inspected one, e.g. `"((nth 2) :users)"`.
+
+| `status`
+| `done`.
+|===
+
+The `value` string, once read, is a flat sequence of rendering directives:
+
+* a plain string - literal text to display;
+* `[:newline]` - a line break;
+* `[:value "printed-representation" idx]` - a nested value the user can
+  navigate into. `idx` is the integer to send back with
+  `cider/inspect-push` (or `cider/inspect-tap-indexed`).
+
+Rendering is thus entirely server-driven: the client displays the directives
+in order, makes the `[:value ...]` elements interactive, and never needs to
+understand the inspected object itself.
+
+== Navigation and Actions
+
+All ops below operate on the session's current inspector and return the new
+rendering in the same format:
+
+|===
+| Op | Params | Effect
+
+| `cider/inspect-push`
+| `idx`
+| Descend into the nested value with that index.
+
+| `cider/inspect-pop`
+|
+| Go back up one level.
+
+| `cider/inspect-next-sibling` / `cider/inspect-previous-sibling`
+|
+| Move to the next/previous element of the parent collection.
+
+| `cider/inspect-next-page` / `cider/inspect-prev-page`
+|
+| Page through long collections.
+
+| `cider/inspect-refresh`
+| config (see below)
+| Re-render the current value, optionally changing configuration.
+
+| `cider/inspect-toggle-view-mode`
+|
+| Cycle the view mode (`normal` / `table` / `object`). Table mode works for
+  sequences of maps or tuples; object mode shows raw Java fields. The mode
+  resets to normal when navigating into a child.
+
+| `cider/inspect-toggle-pretty-print`
+|
+| Toggle pretty-printing of rendered values.
+
+| `cider/inspect-display-analytics`
+|
+| Compute and include an analytics section for the current object.
+
+| `cider/inspect-def-current-value`
+| `ns`, `var-name`
+| Def the currently inspected value into a var.
+
+| `cider/inspect-print-current-value`
+| print options
+| Stream the full printed value (as regular `value` responses, honoring the
+  nREPL print middleware options), then `done`.
+
+| `cider/inspect-tap-current-value`
+|
+| Send the current value to `tap>`.
+
+| `cider/inspect-tap-indexed`
+| `idx`
+| Send the nested value with that index to `tap>`.
+
+| `cider/inspect-clear`
+|
+| Reset the inspector state.
+|===
+
+== Configuration
+
+`cider/inspect-refresh` (and the initial `eval` + `inspect` message) accept
+configuration keys that persist in the session's inspector: `page-size`,
+`max-atom-length`, `max-coll-size`, `max-value-length`, `max-nested-depth`,
+`pretty-print`, `sort-maps`, `only-diff`, and `view-mode`. Boolean-ish
+options are transmitted as the string `"true"`.
+
+The older `cider/inspect-set-page-size`, `cider/inspect-set-max-atom-length`,
+`cider/inspect-set-max-coll-size` and `cider/inspect-set-max-nested-depth`
+ops still work but are deprecated in favor of passing the corresponding
+key to `cider/inspect-refresh`.
+
+== ClojureScript
+
+The inspector has partial ClojureScript support: values are round-tripped
+through the printer, so plain data inspects fine but live JS objects can't
+be navigated the way JVM objects can.

--- a/doc/modules/ROOT/pages/tool-authors/state-tracking.adoc
+++ b/doc/modules/ROOT/pages/tool-authors/state-tracking.adoc
@@ -1,0 +1,65 @@
+= State Tracking
+
+The `wrap-tracker` middleware keeps clients informed about the vars and
+namespaces of the project, so they can drive things like syntax
+highlighting of known vars, completion caches and namespace browsers
+without polling. CIDER uses it for its dynamic font-locking, for example.
+
+== How State Reaches the Client
+
+After every op that can change the runtime's state (`eval`, `load-file`,
+the refresh/reload ops, tracing, undef, ...) finishes, the middleware
+computes what changed and - when something did - sends *one additional
+message* on the same request, after the `done` response:
+
+|===
+| Key | Meaning
+
+| `status`
+| `state` - this is how the client recognizes the message.
+
+| `repl-type`
+| `clj` or `cljs`.
+
+| `changed-namespaces`
+| Map of namespace name → namespace state (see below). Only namespaces that
+  changed since the last update are included; an empty map means nothing
+  changed.
+|===
+
+There's also an explicit `cider/get-state` op returning the same payload
+on demand.
+
+== The Namespace State
+
+Each entry of `changed-namespaces` has the shape:
+
+----
+{"aliases" {"str" "clojure.string", ...}
+ "interns" {"my-fn" {"fn" "true", "arglists" ...}, ...}}
+----
+
+`interns` maps var names to a *filtered* metadata map. Only tooling-relevant
+keys are transmitted (things like `macro`, `deprecated`, `test`, `indent`,
+`style/indent`, `fn`, plus markers for instrumented/traced/profiled vars),
+and all values are strings produced by `pr-str` - read them if you need the
+data rather than a display string. Macros without an explicit
+`style/indent` may get an inferred one.
+
+== What the Client Should Do
+
+* Maintain an accumulated picture per session, applying each
+  `changed-namespaces` delta on top. A namespace absent from a delta is
+  unchanged - not removed.
+* The first update in a session is a full snapshot of the project's
+  namespaces and also includes `clojure.core` (or `cljs.core`), so clients
+  get the core vars without special-casing.
+* Library (jar) namespaces are excluded from the project state, except those
+  the project's namespaces alias directly.
+
+== Caveats
+
+State computation runs asynchronously after each eval, so a client that
+evaluates rapidly may want to debounce its processing. The payloads can be
+large on the first sync of a big project; everything after that is
+incremental.

--- a/doc/modules/ROOT/pages/tool-authors/testing.adoc
+++ b/doc/modules/ROOT/pages/tool-authors/testing.adoc
@@ -1,0 +1,99 @@
+= The Test Protocol
+
+The test middleware runs `clojure.test` (and `cljs.test`) tests on the
+server and returns structured results, so clients can build rich test
+reporting UIs without parsing printed output.
+
+== Running Tests
+
+The primary op is `cider/test-var-query`. It takes a `var-query` map
+describing which vars to run:
+
+----
+{"op"        "cider/test-var-query"
+ "var-query" {"ns-query" {"exactly" ["my.app.core-test"]}}}
+----
+
+Useful `var-query` shapes:
+
+* `{:ns-query {:exactly [ns1 ns2]}}` - all tests in the given namespaces;
+* `{:ns-query {:project? true, :load-project-ns? true}}` - all project
+  tests (this is what `cider/test-all` builds internally);
+* `{:exactly ["my.app.core-test/my-test"]}` - specific test vars;
+* `:include-meta-key` / `:exclude-meta-key` - select by var metadata (e.g.
+  `^:integration`).
+
+An optional `fail-fast "true"` stops the run at the first failure or error.
+
+Two convenience ops build the query for you: `cider/test-all` (all project
+tests, with optional `include`/`exclude` metadata filters and `load?`) and
+`cider/retest` (re-run everything that failed or errored in the previous
+run, using state cached on the server). The older `cider/test` op (per-ns
+with `tests` list) is deprecated in favor of `cider/test-var-query`.
+
+If a namespace in the query doesn't exist, the response has status
+`namespace-not-found`.
+
+== The Report
+
+While tests run, the client receives progress messages carrying
+`testing-ns`. The final response contains:
+
+|===
+| Key | Meaning
+
+| `results`
+| Nested map: namespace → var name → vector of assertion result maps (see
+  below).
+
+| `summary`
+| Counts: `ns`, `var`, `test`, `pass`, `fail`, `error`.
+
+| `elapsed-time`
+| `{:ms ..., :humanized "..."}` for the whole run; per-ns and per-var
+  variants arrive under `ns-elapsed-time` and `var-elapsed-time`.
+
+| `gen-input`
+| For `test.check`-style tests: the (shrunk) failing input, when available.
+|===
+
+Each assertion result map contains:
+
+* `type` - `pass`, `fail` or `error`;
+* `index` - 0-based position of the assertion within its var, used to
+  reference it later (see below);
+* `context` - the enclosing `testing` context string;
+* `message` - the assertion's message;
+* `expected` / `actual` - pretty-printed forms (`actual` for failures);
+* `diffs` - structured expected/actual diffs, when available;
+* `file` / `line` - source location;
+* `fault` - `true` for errors that escaped an assertion (e.g. a fixture
+  blowing up); such entries have no `expected`;
+* `error` - printed representation of the throwable, for `error` results.
+
+== Follow-up Ops
+
+The middleware caches the last run's results per session, which enables:
+
+* `cider/retest` - re-run only the vars that had failures or errors.
+* `cider/test-stacktrace` - takes `ns`, `var` and `index` identifying an
+  erring assertion from the last run and returns the analyzed exception
+  behind it, one message per cause (the same format the stacktrace
+  middleware uses), then `done`. Responds with status `no-error` if that
+  assertion has no stored exception.
+
+== ClojureScript
+
+The same ops work in a ClojureScript session (Piggieback or shadow-cljs) and
+return the same report shape. A few differences to be aware of:
+
+* Tests execute in the JS runtime via `cljs.test`, so `:out`/`:err` output
+  from the tests is forwarded as ordinary output messages.
+* Asynchronous tests (`cljs.test/async`) are awaited: the server polls the
+  runtime until the run completes or a deadline passes. The optional
+  `timeout` request param (milliseconds, default 30000) controls the
+  deadline; on timeout the response carries partial results plus a
+  `test-timeout` status.
+* `fail-fast` is ignored.
+* Running specific vars still executes their whole namespace (fixtures are
+  namespace-scoped); the report is filtered to the requested vars.


### PR DESCRIPTION
The generated ops reference tells you what keys each op takes and returns, but nothing documented the actual protocols: how the debugger's init-debugger channel and debug-input pairing work, what the inspector's chunked rendering format looks like, the shape of test reports, or how track-state deltas are meant to be consumed. In practice every non-CIDER client (Calva, vim-iced, Conjure, ...) has had to reverse-engineer cider.el to implement these.

This adds a "For Tool Authors" section to the manual: an integration guide (op naming and deprecation policy, capability discovery via describe, the clojure-only status, inhibit-cider-middleware) and protocol pages for the debugger (including the command language and coordinate format), the inspector, the test middleware and state tracking. Everything was written against the current source rather than from folklore, so it should be accurate as of 0.62.1.

- [x] The commits are consistent with our contribution guidelines
- [x] Middleware documentation is up to date

Docs-only, so no tests or changelog entry.