### PR TITLE
Prune trace and tap subscriptions with dead transports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## master (unreleased)
 
+* [#1037](https://github.com/clojure-emacs/cider-nrepl/pull/1037): Drop trace and tap subscriptions whose client connection has died; a stale trace subscription used to break every traced evaluation with a `SocketException` until the server was restarted.
+
 ## 0.62.1 (2026-07-15)
 
 - [#1016](https://github.com/clojure-emacs/cider-nrepl/issues/1016): Fix a debugger crash (`Unable to resolve symbol: STATE__`) when `#dbg` is placed on a bare collection literal that closes over a local or a qualified name (e.g. `#dbg [x]`).

--- a/src/cider/nrepl/middleware/tap.clj
+++ b/src/cider/nrepl/middleware/tap.clj
@@ -54,6 +54,13 @@
   "Map of subscription id -> the `add-tap' handler registered for it."
   (atom {}))
 
+(defn- unsubscribe!
+  "Drop the tap subscription with the given id, if it still exists."
+  [id]
+  (when-let [tap-fn (get @subscriptions id)]
+    (remove-tap tap-fn)
+    (swap! subscriptions dissoc id)))
+
 (defn tap-subscribe
   "Stream a summary of every tapped value to the client until
   `cider/tap-unsubscribe'.  Registers an `add-tap' handler that forwards each
@@ -62,9 +69,15 @@
   (let [id     (str (UUID/randomUUID))
         tap-fn (fn [value]
                  (let [idx (retain! value)]
-                   (respond-to msg
-                               :cider/tap-value (assoc (summarize value) :idx idx)
-                               :status :cider/tap-value)))]
+                   (try
+                     (respond-to msg
+                                 :cider/tap-value (assoc (summarize value) :idx idx)
+                                 :status :cider/tap-value)
+                     (catch Exception _
+                       ;; The client vanished without unsubscribing (its
+                       ;; transport is closed), so this handler would fail on
+                       ;; every future `tap>`. Drop the dead subscription.
+                       (unsubscribe! id)))))]
     (swap! subscriptions assoc id tap-fn)
     (add-tap tap-fn)
     {:cider/tap-subscribe id}))
@@ -72,9 +85,7 @@
 (defn tap-unsubscribe
   "Stop streaming tapped values for the given subscription."
   [{:keys [subscription]}]
-  (when-let [tap-fn (get @subscriptions subscription)]
-    (remove-tap tap-fn)
-    (swap! subscriptions dissoc subscription))
+  (unsubscribe! subscription)
   {:cider/tap-unsubscribe subscription})
 
 (defn tap-inspect

--- a/src/cider/nrepl/middleware/trace.clj
+++ b/src/cider/nrepl/middleware/trace.clj
@@ -51,6 +51,16 @@
   [event]
   (update event :phase name))
 
+(defn- unsubscribe!
+  "Drop the trace subscription with the given id, if it still exists.
+  Restores REPL trace output once the last subscription is gone."
+  [id]
+  (when-let [listener (get @subscriptions id)]
+    (trace/remove-trace-listener listener)
+    (swap! subscriptions dissoc id))
+  (when (empty? @subscriptions)
+    (trace/set-output-mode! :repl)))
+
 (defn trace-subscribe
   "Stream trace events to the client until `cider/trace-unsubscribe`.
   Registers an orchard trace listener that forwards each event on this
@@ -58,9 +68,17 @@
   [msg]
   (let [id (str (UUID/randomUUID))
         listener (fn [event]
-                   (respond-to msg
-                               :cider/trace-event (serialize-event event)
-                               :status :cider/trace-event))]
+                   (try
+                     (respond-to msg
+                                 :cider/trace-event (serialize-event event)
+                                 :status :cider/trace-event)
+                     (catch Exception _
+                       ;; The listener runs inside the traced call, so a write
+                       ;; failure (e.g. the client vanished without
+                       ;; unsubscribing, leaving a closed transport) would
+                       ;; otherwise propagate into - and break - the user's
+                       ;; own evaluation. Drop the dead subscription instead.
+                       (unsubscribe! id))))]
     (swap! subscriptions assoc id listener)
     (trace/add-trace-listener listener)
     (trace/set-output-mode! :listeners)
@@ -70,11 +88,7 @@
   "Stop streaming trace events for the given subscription.
   Restores REPL trace output once the last subscription is gone."
   [{:keys [subscription]}]
-  (when-let [listener (get @subscriptions subscription)]
-    (trace/remove-trace-listener listener)
-    (swap! subscriptions dissoc subscription))
-  (when (empty? @subscriptions)
-    (trace/set-output-mode! :repl))
+  (unsubscribe! subscription)
   {:cider/trace-unsubscribe subscription})
 
 (defn handle-trace [handler msg]

--- a/test/clj/cider/nrepl/middleware/tap_test.clj
+++ b/test/clj/cider/nrepl/middleware/tap_test.clj
@@ -53,3 +53,19 @@
         (reset! sent [])
         (tap> {:ignored true})
         (is (nil? (wait-for #(seq (keep :cider/tap-value @sent)))))))))
+
+(deftest tap-subscribe-dead-transport-test
+  (testing "a subscription whose transport fails is pruned"
+    (let [transport (reify transport/Transport
+                      (send [_this _msg]
+                        (throw (java.net.SocketException. "Socket closed")))
+                      (recv [_this] nil)
+                      (recv [_this _timeout] nil))
+          {id :cider/tap-subscribe} (tap-subscribe {:transport transport
+                                                    :id "1" :session "s"})]
+      (try
+        (tap> :doomed)
+        (is (wait-for #(not (contains? @@#'cider.nrepl.middleware.tap/subscriptions id)))
+            "the dead subscription was pruned")
+        (finally
+          (tap-unsubscribe {:subscription id}))))))

--- a/test/clj/cider/nrepl/middleware/trace_test.clj
+++ b/test/clj/cider/nrepl/middleware/trace_test.clj
@@ -146,6 +146,30 @@
       (is (empty? (keep :cider/trace-event @sent)))
       (toggle-trace-var {:ns "cider.nrepl.middleware.trace-test" :sym "traced-sample"}))))
 
+(deftest trace-subscribe-dead-transport-test
+  (testing "a subscription whose transport fails is pruned instead of breaking the traced call"
+    (let [transport (reify transport/Transport
+                      (send [_this _msg]
+                        (throw (java.net.SocketException. "Socket closed")))
+                      (recv [_this] nil)
+                      (recv [_this _timeout] nil))
+          {id :cider/trace-subscribe} (trace-subscribe {:transport transport
+                                                        :id "42" :session "s"})]
+      (try
+        (toggle-trace-var {:ns "cider.nrepl.middleware.trace-test" :sym "traced-sample"})
+        ;; The listener runs inside the traced call, so before the fix the
+        ;; write failure escaped into the user's own evaluation.
+        (let [result (volatile! nil)]
+          ;; Pruning the last subscription flips trace output back to the
+          ;; REPL, so the same call's return event prints; swallow it.
+          (with-out-str (vreset! result (traced-sample 1)))
+          (is (= 2 @result) "the traced call is unaffected by the dead subscriber"))
+        (is (not (contains? @@#'cider.nrepl.middleware.trace/subscriptions id))
+            "the dead subscription was pruned")
+        (finally
+          (toggle-trace-var {:ns "cider.nrepl.middleware.trace-test" :sym "traced-sample"})
+          (trace-unsubscribe {:subscription id}))))))
+
 (deftest deprecated-ops-test
   (testing "Deprecated 'toggle-trace-var' op still works"
     (let [on  (session/message {:op "toggle-trace-var"


### PR DESCRIPTION
When a client disconnects without unsubscribing (a crashed or killed editor session), its trace/tap subscription lingers with a closed transport. For tap that meant a handler failing (silently, thanks to `tap-loop`'s catch) on every `tap>` forever. For trace it was much worse: the listener runs *inside* the traced call, so the `SocketException` from the failed write escaped into the user's own evaluation - every traced call on the server failed until a restart.

This drops a subscription as soon as a write to its transport fails, restoring REPL trace output when the pruned subscription was the last one. Found while scripting throwaway Emacs sessions against a shared nREPL server, and verified end-to-end: subscribe from one connection, kill it, and a traced eval from a second connection now works on the first try.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the user manual (if adding/changing user-visible functionality)