### PR TITLE
Don't let the debugger shadow enlighten's eval function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## master (unreleased)
 
+* [#1038](https://github.com/clojure-emacs/cider-nrepl/pull/1038): Fix `enlighten` evaluations being silently ignored on nREPL 1.5+: the debug middleware's eval function shadowed the one the enlighten middleware installs, so code never lit up.
+
 * [#1037](https://github.com/clojure-emacs/cider-nrepl/pull/1037): Drop trace and tap subscriptions whose client connection has died; a stale trace subscription used to break every traced evaluation with a `SocketException` until the server was restarted.
 
 ## 0.62.1 (2026-07-15)

--- a/src/cider/nrepl/middleware/debug.clj
+++ b/src/cider/nrepl/middleware/debug.clj
@@ -790,10 +790,14 @@ this map (identified by a key), and will `dissoc` it afterwards."}
                                         :file (:file msg)
                                         :original-id (:id msg)})
                 form))))]
-    (assoc msg
-           ::ieval/read-fn read-fn
-           ::ieval/eval-fn (cider.nrepl.middleware.util.eval/eval-dispatcher
-                            instrument-and-eval ::form-info))))
+    (cond-> (assoc msg ::ieval/read-fn read-fn)
+      ;; Install the debugger's eval function only when the message doesn't
+      ;; carry one already. nREPL ignores the `:eval` slot (which the
+      ;; enlighten middleware uses) whenever `::ieval/eval-fn` is set, so
+      ;; setting ours unconditionally would disable the other middleware.
+      (not (or (::ieval/eval-fn msg) (:eval msg)))
+      (assoc ::ieval/eval-fn (cider.nrepl.middleware.util.eval/eval-dispatcher
+                              instrument-and-eval ::form-info)))))
 
 (defn- initialize
   "Initialize the channel used for debug-input requests."

--- a/test/clj/cider/nrepl/middleware/debug_integration_test.clj
+++ b/test/clj/cider/nrepl/middleware/debug_integration_test.clj
@@ -734,3 +734,43 @@
     (<-- {:debug-value "9" :coor [3]})
     (--> :next)
     (<-- {:value "9"})))
+
+;;; Enlighten routing through the full middleware stack
+
+(defn- with-enlighten-session*
+  "Run `f` against a server whose stack has both `wrap-debug` and `wrap-enlighten`."
+  [f]
+  (with-open [^nrepl.server.Server
+              server    (nrepl.server/start-server
+                         :handler (nrepl.server/default-handler
+                                   #'wrap-debug
+                                   #'cider.nrepl/wrap-enlighten))
+              ^nrepl.transport.FnTransport
+              transport (nrepl/connect :port (:port server))]
+    (transport/send transport {:op "clone" :id (next-id)})
+    (binding [*transport*  transport
+              *session-id* (:new-session (transport/recv transport 1000))]
+      (with-redefs [d/debugger-message (atom nil)]
+        (nrepl-send {:op "init-debugger"})
+        (f)))))
+
+(deftest enlighten-flag-reaches-the-evaluator-test
+  ;; wrap-debug used to shadow the eval fn that wrap-enlighten picks (its
+  ;; ::ieval/eval-fn takes precedence over the public `:eval` slot), which
+  ;; silently disabled `enlighten` evals on nREPL 1.5+.
+  (when @#'d/nrepl-1-5+?
+    (with-enlighten-session*
+      (fn []
+        (nrepl-send {:op "eval" :enlighten "true"
+                     :code "(defn enl-routing-check [x] (inc x))"})
+        (Thread/sleep 500)
+        (nrepl-send {:op "eval" :code "(enl-routing-check 41)"})
+        (is (loop [nils 0]
+              (if-let [m (nrepl-recv)]
+                (if (and (some #{"enlighten" :enlighten} (:status m))
+                         (:debug-value m))
+                  true
+                  (recur 0))
+                ;; several consecutive quiet reads => nothing more is coming
+                (if (< nils 6) (recur (inc nils)) false)))
+            "an enlighten event reaches the debug channel")))))


### PR DESCRIPTION
Since the nREPL 1.5 read-fn support landed, `maybe-debug-nrepl-1-5+` has assoc'ed `::ieval/eval-fn` onto every eval message. nREPL prefers that slot over the public `:eval` one that the enlighten middleware sets, so `enlighten` evaluations have been silently ignored for a good while - the code was never instrumented and nothing ever lit up. The enlighten unit tests call `eval-with-enlighten` directly, which is why CI never noticed.

The fix installs the debugger's eval fn only when no other middleware has picked one, and adds a regression test that drives the full `wrap-debug` + `wrap-enlighten` stack over a real connection (it fails on master). Found while scripting screenshots of enlighten for the docs, of all things.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/.github/CONTRIBUTING.md)
- [x] You've added tests to cover your change(s)
- [x] All tests are passing
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the user manual (if adding/changing user-visible functionality)